### PR TITLE
Fix E2532 to not fail when the step types are not known

### DIFF
--- a/src/cfnlint/rules/resources/stepfunctions/StateMachine.py
+++ b/src/cfnlint/rules/resources/stepfunctions/StateMachine.py
@@ -51,7 +51,7 @@ class StateMachine(CloudFormationLintRule):
         state_key_types = {
             'Pass': ['Result', 'ResultPath'],
             'Task': ['Resource', 'ResultPath', 'Retry', 'Catch', 'TimeoutSeconds', 'HeartbeatSeconds'],
-            'Choices': ['Choices', 'Default'],
+            'Choice': ['Choices', 'Default'],
             'Wait': ['Seconds', 'Timestamp', 'SecondsPath', 'TimestampPath'],
             'Succeed': [],
             'Fail': ['Cause', 'Error'],
@@ -60,7 +60,7 @@ class StateMachine(CloudFormationLintRule):
         state_required_types = {
             'Pass': [],
             'Task': ['Resource'],
-            'Choices': ['Choices'],
+            'Choice': ['Choices'],
             'Wait': [],
             'Succeed': [],
             'Fail': [],
@@ -75,15 +75,19 @@ class StateMachine(CloudFormationLintRule):
 
         state_type = def_json.get('Type')
 
-        for state_key, _ in def_json.items():
-            if state_key not in common_state_keys + state_key_types.get(state_type):
-                message = 'State Machine Definition key (%s) for State (%s) of Type (%s) is not valid' % (state_key, state_name, state_type)
-                matches.append(RuleMatch(path, message))
-        for req_key in common_state_required_keys + state_required_types.get(state_type):
-            if req_key not in def_json:
-                message = 'State Machine Definition required key (%s) for State (%s) of Type (%s) is missing' % (req_key, state_name, state_type)
-                matches.append(RuleMatch(path, message))
-                return matches
+        if state_type in state_key_types:
+            for state_key, _ in def_json.items():
+                if state_key not in common_state_keys + state_key_types.get(state_type, []):
+                    message = 'State Machine Definition key (%s) for State (%s) of Type (%s) is not valid' % (state_key, state_name, state_type)
+                    matches.append(RuleMatch(path, message))
+            for req_key in common_state_required_keys + state_required_types.get(state_type, []):
+                if req_key not in def_json:
+                    message = 'State Machine Definition required key (%s) for State (%s) of Type (%s) is missing' % (req_key, state_name, state_type)
+                    matches.append(RuleMatch(path, message))
+                    return matches
+        else:
+            message = 'State Machine Definition Type (%s) is not valid' % (state_type)
+            matches.append(RuleMatch(path, message))
 
         return matches
 

--- a/test/fixtures/templates/bad/resources/stepfunctions/state_machine.yaml
+++ b/test/fixtures/templates/bad/resources/stepfunctions/state_machine.yaml
@@ -25,13 +25,18 @@ Resources:
       # Missing StartsAt
       # ByeWorld is missing Resource
       # HelloWorld is missing Type
+      # Type doesn't exist
       DefinitionString:
         Fn::Sub: |-
           {
             "States": {
               "HelloWorld": {
                 "Resource": "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:HelloFunction",
-                "End": true
+                "Next": "GoodDay"
+              },
+              "GoodDay": {
+                "Type": "DNE",
+                "Next": "ByeWorld"
               },
               "ByeWorld": {
                 "Type": "Task",

--- a/test/rules/resources/stepfunctions/test_state_machine.py
+++ b/test/rules/resources/stepfunctions/test_state_machine.py
@@ -34,4 +34,4 @@ class TestStateMachine(BaseRuleTestCase):
 
     def test_file_negative_alias(self):
         """Test failure"""
-        self.helper_file_negative('fixtures/templates/bad/resources/stepfunctions/state_machine.yaml', 4)
+        self.helper_file_negative('fixtures/templates/bad/resources/stepfunctions/state_machine.yaml', 5)


### PR DESCRIPTION
*Issue #, if available:*
Fix #332
*Description of changes:*
- Fix rule E2532 so it doesn't fail if the type is not known and switch `choices` to `choice`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
