### PR TITLE
Cidr supports Sub

### DIFF
--- a/src/cfnlint/rules/functions/Cidr.py
+++ b/src/cfnlint/rules/functions/Cidr.py
@@ -92,6 +92,7 @@ class Cidr(CloudFormationLintRule):
             'Fn::Select',
             'Ref',
             'Fn::GetAtt',
+            'Fn::Sub',
             'Fn::ImportValue'
         ]
 
@@ -114,7 +115,7 @@ class Cidr(CloudFormationLintRule):
                         if len(ip_block_obj) == 1:
                             for index_key, _ in ip_block_obj.items():
                                 if index_key not in supported_functions:
-                                    message = 'Cidr ipBlock should be Cidr Range, Ref, GetAtt, or Select for {0}'
+                                    message = 'Cidr ipBlock should be Cidr Range, Ref, GetAtt, Sub or Select for {0}'
                                     matches.append(RuleMatch(
                                         tree[:] + [0], message.format('/'.join(map(str, tree[:] + [0])))))
                     elif isinstance(ip_block_obj, (six.text_type, six.string_types)):

--- a/test/fixtures/templates/good/functions_cidr.yaml
+++ b/test/fixtures/templates/good/functions_cidr.yaml
@@ -15,6 +15,10 @@ Parameters:
         Type: Number
         MinValue: 1
         MaxValue: 128
+    vpcSubnetPrefix:
+        Type: String
+        Default: '10.0'
+        AllowedPattern: ^(?:[0-9]{1,3}\\.){1}[0-9]{1,3}$
 Resources:
     Subnet1:
         Type: AWS::EC2::Subnet
@@ -35,6 +39,13 @@ Resources:
             CidrBlock: !Select [1, !Cidr [!Ref cidrBlock, !Ref count, !Ref maskSizeForIPv4]]
             #Test Ipv6 CidrBlock
             Ipv6CidrBlock: !Select [1, !Cidr [!Select [0, !GetAtt VPC.Ipv6CidrBlocks], !Ref count, !Ref maskSizeForIPv6]]
+        DependsOn: Ipv6VPCCidrBlock
+    Subnet3:
+        Type: AWS::EC2::Subnet
+        Properties:
+            AssignIpv6AddressOnCreation: true
+            VpcId: !Ref VPC
+            CidrBlock: !Select [1, !Cidr [!Sub "${VPCSubnetPrefix}.48.0/23", !Ref count, !Ref maskSizeForIPv4]]
         DependsOn: Ipv6VPCCidrBlock
     VPC:
         Type: AWS::EC2::VPC


### PR DESCRIPTION
`Fn::Sub` and `!Sub` are supported in `Fn::Cidr`:

Example:
```yml
  MySubnet:
    Type: AWS::EC2::Subnet
    Properties:
      CidrBlock:
        Fn::Select:
        - 1
        - Fn::Cidr:
          - !Sub ${VPCSubnetPrefix}.48.0/23
          - 2
          - 8
      VpcId: !Ref MainVPC
```
