### PR TITLE
--update-specs even if official CloudFormation Resource Specification hasn't changed

### DIFF
--- a/src/cfnlint/maintenance.py
+++ b/src/cfnlint/maintenance.py
@@ -10,7 +10,7 @@ import os
 import jsonpointer
 import jsonpatch
 import cfnlint
-from cfnlint.helpers import get_url_content, url_has_newer_version
+from cfnlint.helpers import get_url_content
 from cfnlint.helpers import SPEC_REGIONS
 import cfnlint.data.ExtendedSpecs
 import cfnlint.data.AdditionalSpecs
@@ -44,8 +44,9 @@ def update_resource_spec(region, url):
     multiprocessing_logger.debug('Downloading template %s into %s', url, filename)
 
     # Check to see if we already have the latest version, and if so stop
-    if not url_has_newer_version(url):
-        return
+    # commented out for now due to https://github.com/aws-cloudformation/cfn-python-lint/pull/1383#issuecomment-629891506
+    # if not url_has_newer_version(url):
+    #     return
 
     spec_content = get_url_content(url, caching=True)
 


### PR DESCRIPTION
https://github.com/aws-cloudformation/cfn-python-lint/pull/1383#issuecomment-629891506

[`cfn-lint --update-specs`](https://github.com/aws-cloudformation/cfn-python-lint/blob/cc6ac28ff7deba86cb82813733cceec4bdff68a2/src/cfnlint/maintenance.py#L142-L150) patches [`ExtendedSpecs`](https://github.com/aws-cloudformation/cfn-python-lint/blob/master/src/cfnlint/data/ExtendedSpecs) and [`botocore` data](https://github.com/aws-cloudformation/cfn-python-lint/pull/1682) into [`CloudSpecs`](https://github.com/aws-cloudformation/cfn-python-lint/tree/master/src/cfnlint/data/CloudSpecs) in addition to newly downloaded [official CloudFormation Resource Specifications](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-resource-specification.html)

[`ExtendedSpecs/$REGION/05_pricing_property_values.json`](https://github.com/aws-cloudformation/cfn-python-lint/blob/master/src/cfnlint/data/ExtendedSpecs/all/05_pricing_property_values.json) written by [`scripts/update_specs_from_pricing.py`](https://github.com/aws-cloudformation/cfn-python-lint/blob/cc6ac28ff7deba86cb82813733cceec4bdff68a2/scripts/update_specs_from_pricing.py#L235)
[`ExtendedSpecs/$REGION/06_ssm_service_removal.json`](https://github.com/aws-cloudformation/cfn-python-lint/blob/master/src/cfnlint/data/ExtendedSpecs/us-gov-east-1/06_ssm_service_removal.json) written by [`scripts/update_specs_services_from_ssm.py`](https://github.com/aws-cloudformation/cfn-python-lint/blob/cc6ac28ff7deba86cb82813733cceec4bdff68a2/scripts/update_specs_services_from_ssm.py#L165)
[`ExtendedSpecs/$REGION/07_ssm_service_addition.json`](https://github.com/aws-cloudformation/cfn-python-lint/blob/master/src/cfnlint/data/ExtendedSpecs/us-gov-east-1/07_ssm_service_addition.json) written by [`scripts/update_specs_services_from_ssm.py`](https://github.com/aws-cloudformation/cfn-python-lint/blob/cc6ac28ff7deba86cb82813733cceec4bdff68a2/scripts/update_specs_services_from_ssm.py#L204)

the rest of [`ExtendedSpecs`](https://github.com/aws-cloudformation/cfn-python-lint/blob/master/src/cfnlint/data/ExtendedSpecs) is hand maintained