### PR TITLE
globbing doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,8 @@ Lint all `yaml` files in `path` and all subdirectories (recursive):
 
 - `cfn-lint path/**/*.yaml`
 
-*Note*: Glob in Python 3.5 supports recursive searching `**/*.yaml`.  If you are using an earlier version of Python you will have to handle this manually (`folder1/*.yaml`, `folder2/*.yaml`, etc).
+*Note*: If using sh/bash/zsh, you must enable globbing.
+(`setopt -s globstar` for sh/bash, `setopt extended_glob` for zsh).
 
 ##### Specifying the template as an input stream
 


### PR DESCRIPTION
*Description of changes:*

Python globing does not seem to work as expected. `**` was not evaluated when passed as a direct argument to `cfn-lint`, as in `os.Command("/usr/bin/cfn-lint", "**/*.template");` using Python 3.8. 

The current documentation stumped me for longer than I would care to admit, making me believe there was an issue in my invocation of the script or argument passing.

As mentioned in this issue, it seems that `cfn-python-lint` relies on shell globing: https://github.com/aws-cloudformation/cfn-python-lint/issues/546

This change makes that clear in the documentation.

If the Python globing is indeed working without shell globing, I would be happy to amend this PR to include the previous Python note. However, as this was not working as expected, I removed the note entirely to prevent future user confusion.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
