### PR TITLE
Lambda runtime deprecation updates (dotnetcore2.1)

### DIFF
--- a/src/cfnlint/data/AdditionalSpecs/LmbdRuntimeLifecycle.json
+++ b/src/cfnlint/data/AdditionalSpecs/LmbdRuntimeLifecycle.json
@@ -9,6 +9,11 @@
         "deprecated": "2019-05-30",
         "successor": "dotnetcore3.1"
     },
+    "dotnetcore2.1": {
+        "eol": "2021-08-23",
+        "deprecated": "2021-09-23",
+        "successor": "dotnetcore3.1"
+    },
     "nodejs": {
         "eol": "2016-10-31",
         "deprecated": "2016-10-31",


### PR DESCRIPTION
https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html
[`AWS::Lambda::Function.Runtime`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-runtime)