### PR TITLE
Ignore Mapping key issues when using Fn::Transform

### DIFF
--- a/src/cfnlint/rules/mappings/KeyName.py
+++ b/src/cfnlint/rules/mappings/KeyName.py
@@ -35,7 +35,7 @@ class KeyName(CloudFormationLintRule):
         if not isinstance(key, six.string_types):
             message = 'Mapping key ({0}) has to be a string.'
             matches.append(RuleMatch(path[:], message.format(key)))
-        elif not re.match('^[a-zA-Z0-9.-]{1,255}$', key):
+        elif not re.match('^[a-zA-Z0-9.-]{1,255}$', key) and key != 'Fn::Transform':
             message = 'Mapping key ({0}) has invalid name. Name has to be alphanumeric, \'-\' or \'.\''
             matches.append(RuleMatch(path[:], message.format(key)))
 

--- a/test/fixtures/templates/good/mappings/key_name.yaml
+++ b/test/fixtures/templates/good/mappings/key_name.yaml
@@ -1,5 +1,10 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Mappings:
+  AwsAgentPlatformMap:
+    Fn::Transform:
+      Name: AWS::Include
+      Parameters:
+        Location: s3://my-bucket-name/version/3.0.1/amazonlinux2/a-json-file.json
   myMap:
     '123456789012':
       AMI: "ami-7f418316"


### PR DESCRIPTION
*Issue #, if available:*
fix #2016
*Description of changes:*
- Ignore Fn::Transform when evaluating the mapping key in a mapping rule `E7003`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
