### PR TITLE
Lambda runtime deprecation updates

### DIFF
--- a/src/cfnlint/data/AdditionalSpecs/LmbdRuntimeLifecycle.json
+++ b/src/cfnlint/data/AdditionalSpecs/LmbdRuntimeLifecycle.json
@@ -40,8 +40,8 @@
         "successor": "nodejs14.x"
     },
     "nodejs10.x": {
-        "eol": "2021-05-31",
-        "deprecated": "2021-06-30",
+        "eol": "2021-07-30",
+        "deprecated": "2021-08-30",
         "successor": "nodejs14.x"
     },
     "python2.7": {
@@ -50,8 +50,8 @@
         "successor": "python3.8"
     },
     "ruby2.5": {
-        "eol": "2021-05-31",
-        "deprecated": "2021-06-30",
+        "eol": "2021-07-30",
+        "deprecated": "2021-08-30",
         "successor": "ruby2.7"
     }
 }


### PR DESCRIPTION
https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html
[`AWS::Lambda::Function.Runtime`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-runtime)