### PR TITLE
Add validate-registry-types and update-registry-type-specs parameters

### DIFF
--- a/src/cfnlint/__main__.py
+++ b/src/cfnlint/__main__.py
@@ -32,7 +32,8 @@ def main():
                 matches.extend(
                     cfnlint.core.run_cli(
                         filename, template, rules,
-                        args.regions, args.override_spec, args.build_graph, args.registry_schemas, args.mandatory_checks))
+                        args.regions, args.override_spec, args.build_graph, args.registry_schemas,
+                        args.mandatory_checks, args.validate_registry_types))
             else:
                 matches.extend(errors)
             LOGGER.debug('Completed linting of file: %s', str(filename))

--- a/src/cfnlint/config.py
+++ b/src/cfnlint/config.py
@@ -434,6 +434,15 @@ class CliArgs(object):
             '--merge-configs', default=False, action='store_true',
             help='Merges lists between configuration layers'
         )
+        standard.add_argument(
+            '--validate-registry-types', help='Validate private registry type',
+            dest='validate_registry_types', nargs='+', default=[],
+            type=comma_separated_arg, action='extend',
+        )
+        standard.add_argument(
+            '--update-registry-type-specs', help='Update the CloudFormation Module Information',
+            action='store_true'
+        )
 
         return parser
 
@@ -680,3 +689,11 @@ class ConfigMixIn(TemplateArgs, CliArgs, ConfigFileArgs, object):
     @property
     def merge_configs(self):
         return self._get_argument_value('merge_configs', True, True)
+
+    @property
+    def update_registry_type_specs(self):
+        return self._get_argument_value('update_registry_type_specs', False, False)
+
+    @property
+    def validate_registry_types(self):
+        return self._get_argument_value('validate_registry_types', False, True)

--- a/src/cfnlint/data/CfnLintCli/config/schema.json
+++ b/src/cfnlint/data/CfnLintCli/config/schema.json
@@ -103,6 +103,13 @@
         "type": "string"
       },
       "type": "array"
+    },
+    "validate_registry_types": {
+      "description": "Validate private registry type",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
     }
   },
   "title": "CFNLINTRC JSON Schema",

--- a/src/cfnlint/helpers.py
+++ b/src/cfnlint/helpers.py
@@ -66,6 +66,10 @@ UNCONVERTED_SUFFIXES = ['Ref', 'Condition']
 FN_PREFIX = 'Fn::'
 CONDITION_FUNCTIONS = ['Fn::If']
 REGIONS = list(SPEC_REGIONS.keys())
+REGISTRY_TYPES = [
+    'MODULE'
+    #     'RESOURCE' #new supported type in the future
+]
 
 REGEX_ALPHANUMERIC = re.compile('^[a-zA-Z0-9]*$')
 REGEX_CIDR = re.compile(

--- a/test/integration/__init__.py
+++ b/test/integration/__init__.py
@@ -83,7 +83,7 @@ class BaseCliTestCase(BaseTestCase):
                 filename,
                 template,
                 rules,
-                regions
+                regions,
             )
 
             # Only check that the error count matches as the formats are different

--- a/test/unit/module/config/test_cli_args.py
+++ b/test/unit/module/config/test_cli_args.py
@@ -81,3 +81,12 @@ class TestArgsParser(BaseTestCase):
             ['-x', 'E3012:strict=true', '-x', 'E3012:key=value,E3001:key=value'])
         self.assertEqual(config.cli_args.configure_rules, {
                          'E3012': {'key': 'value', 'strict': 'true'}, 'E3001': {'key': 'value'}})
+
+    def test_create_parser_registry_types(self):
+        """Test success run"""
+
+        config = cfnlint.config.CliArgs(
+            ['--validate-registry-types', 'MODULE', '--update-registry-type-specs', '--', 'template1.yaml']
+        )
+        self.assertEqual(config.cli_args.validate_registry_types, ['MODULE'])
+        self.assertEqual(config.cli_args.update_registry_type_specs, True)

--- a/test/unit/module/core/test_run_checks.py
+++ b/test/unit/module/core/test_run_checks.py
@@ -5,6 +5,7 @@ SPDX-License-Identifier: MIT-0
 from test.testlib.testcase import BaseTestCase
 import cfnlint.core
 import cfnlint.helpers  # pylint: disable=E0401
+from mock import patch
 
 
 class TestRunChecks(BaseTestCase):
@@ -53,3 +54,18 @@ class TestRunChecks(BaseTestCase):
         except cfnlint.core.InvalidRegionException as e:
             err = e
         assert(type(err) == cfnlint.core.InvalidRegionException)
+
+    def test_bad_registry_type(self):
+        """Test bad registry type"""
+        filename = 'test/fixtures/templates/good/generic.yaml'
+        (args, filenames, _) = cfnlint.core.get_args_filenames(['--template', filename])
+        (template, rules, _) = cfnlint.core.get_template_rules(filename, args)
+        err = None
+        try:
+            cfnlint.core.run_checks(filename, template, rules, ['us-east-1'], None, ['not-a-registry-type'])
+        except cfnlint.core.InvalidRegistryTypesException as e:
+            err = e
+        assert(type(err) == cfnlint.core.InvalidRegistryTypesException)
+
+
+

--- a/test/unit/module/core/test_run_cli.py
+++ b/test/unit/module/core/test_run_cli.py
@@ -141,7 +141,9 @@ class TestCli(BaseTestCase):
                          'test/fixtures/templates/good/core/config_parameters.yaml'])
         self.assertEqual(args.update_documentation, False)
         self.assertEqual(args.update_specs, False)
+        self.assertEqual(args.update_registry_type_specs, False)
         self.assertEqual(args.output_file, None)
+        self.assertEqual(args.validate_registry_types, [])
 
     def test_output_file(self):
         filename = 'test/fixtures/templates/good/core/config_parameters.yaml'
@@ -177,6 +179,8 @@ class TestCli(BaseTestCase):
                          'test/fixtures/templates/good/core/config_parameters.yaml'])
         self.assertEqual(args.update_documentation, False)
         self.assertEqual(args.update_specs, False)
+        self.assertEqual(args.update_registry_type_specs, False)
+        self.assertEqual(args.validate_registry_types, [])
 
     @patch('cfnlint.config.ConfigFileArgs._read_config', create=True)
     def test_override_parameters(self, yaml_mock):
@@ -205,6 +209,8 @@ class TestCli(BaseTestCase):
                          'test/fixtures/templates/good/core/config_parameters.yaml'])
         self.assertEqual(args.update_documentation, False)
         self.assertEqual(args.update_specs, False)
+        self.assertEqual(args.update_registry_type_specs, False)
+        self.assertEqual(args.validate_registry_types, [])
 
     @patch('cfnlint.config.ConfigFileArgs._read_config', create=True)
     def test_bad_config(self, yaml_mock):
@@ -231,3 +237,5 @@ class TestCli(BaseTestCase):
         self.assertEqual(args.templates, [filename])
         self.assertEqual(args.update_documentation, False)
         self.assertEqual(args.update_specs, False)
+        self.assertEqual(args.update_registry_type_specs, False)
+        self.assertEqual(args.validate_registry_types, [])


### PR DESCRIPTION
Added the 2 parameters --validate-registry-types and --update-registry-type-specs to the list of optional arguments for the client. Validation added to only accept the module type. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
