### PR TITLE
Fix networkx import

### DIFF
--- a/src/cfnlint/graph.py
+++ b/src/cfnlint/graph.py
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MIT-0
 import logging
 import re
 import six
-from networkx import networkx
+import networkx
 
 LOGGER = logging.getLogger('cfnlint.graph')
 


### PR DESCRIPTION
Package nesting is fixed in latest `networkx` release.  `setup.py` installs `networkx~=2.4` which grabs `2.6rc1` as of a few days ago.  In 2.6, the nested import issue is fixed.  Attempting to import the nested package now causes an `ImportError`.

*Issue #, if available:*

*Description of changes:*

Fix bad import of a nested package which was resolved by https://github.com/networkx/networkx/pull/4839

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
