### PR TITLE
Move logic for multiple templates from __main__ into core.py

### DIFF
--- a/src/cfnlint/__main__.py
+++ b/src/cfnlint/__main__.py
@@ -21,22 +21,8 @@ def main():
 
     try:
         (args, filenames, formatter) = cfnlint.core.get_args_filenames(sys.argv[1:])
-        matches = []
-        rules = None
-        for filename in filenames:
-            LOGGER.debug('Begin linting of file: %s', str(filename))
-            (template, rules, errors) = cfnlint.core.get_template_rules(filename, args)
-            # template matches may be empty but the template is still None
-            # this happens when ignoring bad templates
-            if not errors and template:
-                matches.extend(
-                    cfnlint.core.run_cli(
-                        filename, template, rules,
-                        args.regions, args.override_spec, args.build_graph, args.registry_schemas, args.mandatory_checks))
-            else:
-                matches.extend(errors)
-            LOGGER.debug('Completed linting of file: %s', str(filename))
-
+        matches = list(cfnlint.core.get_matches(filenames, args))
+        (_, rules, _) = cfnlint.core.get_template_rules(filenames[-1], args)
         matches_output = formatter.print_matches(matches, rules, filenames)
 
         if matches_output:

--- a/src/cfnlint/core.py
+++ b/src/cfnlint/core.py
@@ -120,9 +120,12 @@ def get_matches(filenames, args):
         # template matches may be empty but the template is still None
         # this happens when ignoring bad templates
         if not errors and template:
-            yield from run_cli(filename, template, rules, args.regions, args.override_spec, args.build_graph, args.registry_schemas, args.mandatory_checks)
+            matches = run_cli(filename, template, rules, args.regions, args.override_spec, args.build_graph, args.registry_schemas, args.mandatory_checks)
+            for match in matches:
+                yield match
         else:
-            yield from errors
+            for match in matches:
+                yield match
         LOGGER.debug('Completed linting of file: %s', str(filename))
 
 

--- a/src/cfnlint/core.py
+++ b/src/cfnlint/core.py
@@ -113,6 +113,19 @@ def get_rules(append_rules, ignore_rules, include_rules, configure_rules=None, i
     return rules
 
 
+def get_matches(filenames, args):
+    for filename in filenames:
+        LOGGER.debug('Begin linting of file: %s', str(filename))
+        (template, rules, errors) = get_template_rules(filename, args)
+        # template matches may be empty but the template is still None
+        # this happens when ignoring bad templates
+        if not errors and template:
+            yield from run_cli(filename, template, rules, args.regions, args.override_spec, args.build_graph, args.registry_schemas, args.mandatory_checks)
+        else:
+            yield from errors
+        LOGGER.debug('Completed linting of file: %s', str(filename))
+
+
 def configure_logging(debug_logging):
     """ Backwards compatibility for integrators """
     LOGGER.info('Update your integrations to use "cfnlint.config.configure_logging" instead')

--- a/test/unit/module/core/test_get_matches.py
+++ b/test/unit/module/core/test_get_matches.py
@@ -1,0 +1,25 @@
+"""
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+"""
+import os
+
+from test.testlib.testcase import BaseTestCase
+import cfnlint.core
+import cfnlint.helpers  # pylint: disable=E0401
+
+
+class TestGetMatches(BaseTestCase):
+    """Test Get Matches """
+
+    def test_multiple_templates(self):
+        """test multiple templates"""
+
+        filenames = [
+            'test/fixtures/templates/bad/noecho.yaml',
+            'test/fixtures/templates/bad/issues.yaml'
+        ]
+
+        (args, filenames, _) = cfnlint.core.get_args_filenames(filenames)
+        matches = cfnlint.core.get_matches(filenames, args)
+        self.assertEqual(['E1012', 'W4002', 'W4002'], [match.rule.id for match in matches]) 


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-cloudformation/cfn-lint/pull/1933

*Description of changes:*
Move logic for multiple templates from __main__ into core.py

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
