### PR TITLE
Fix setuptools warning wrt description-file key

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-description-file = README.md
+description_file = README.md
 
 [flake8]
 max-line-length = 100


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fix the following warning:

    /usr/lib/python3.10/site-packages/setuptools/dist.py:691: UserWarning: Usage of dash-separated 'description-file' will not be supported in future versions. Please use the underscore name 'description_file' instead


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
