### PR TITLE
AWS::Kinesis::Stream.RetentionPeriodHours NumberMax update

### DIFF
--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_kinesis.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_kinesis.json
@@ -3,7 +3,7 @@
     "op": "add",
     "path": "/ValueTypes/AWS::Kinesis::Stream.RetentionPeriodHours",
     "value": {
-      "NumberMax": 168,
+      "NumberMax": 8760,
       "NumberMin": 1
     }
   },


### PR DESCRIPTION
*Issue #, if available:*

Kinesis supports retention of up to [365 days (8760 hours)](https://docs.aws.amazon.com/streams/latest/dev/kinesis-extended-retention.html) it is no longer 7 days (168 hours)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
