### PR TITLE
Add rule E3043 to validate nested stack parameters

### DIFF
--- a/src/cfnlint/rules/resources/cloudformation/NestedStackParameters.py
+++ b/src/cfnlint/rules/resources/cloudformation/NestedStackParameters.py
@@ -1,0 +1,95 @@
+"""
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+"""
+import os
+import six
+from cfnlint.decode import decode
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
+
+
+class NestedStackParameters(CloudFormationLintRule):
+    """Check that nested stack parameters are specified as needed"""
+    id = 'E3043'
+    shortdesc = 'Validate parameters for in a nested stack'
+    description = 'Evalute if parameters for a nested stack are specified and ' \
+                  'if parameters are specified for a nested stack that aren\'t required.'
+    source_url = 'https://github.com/awslabs/cfn-python-lint'
+    tags = ['resources', 'cloudformation']
+
+    def __init__(self):
+        """Init"""
+        super(NestedStackParameters, self).__init__()
+        self.resource_property_types.append('AWS::CloudFormation::Stack')
+
+
+    def __get_template_parameters(self, filename):
+
+        try:
+            (tmp, matches) = decode(filename)
+        except:  #pylint: disable=bare-except
+            return None
+        if matches:
+            return None
+
+        return tmp.get('Parameters', {})
+
+
+    def __compare_objects(self, template_parameters, nested_parameters, scenario, path):
+        matches = []
+        for key in set(template_parameters.keys()) - set(nested_parameters.keys()):
+            if scenario is None:
+                message = 'Specified parameter "{0}" doesn\'t exist in nested stack template at {1}'
+                matches.append(
+                    RuleMatch(path + [key], message.format(key, '/'.join(map(str, path + [key])))))
+            else:
+                message = 'Specified parameter "{0}" doesn\'t exist in nested stack template {1}'
+                scenario_text = ' and '.join(
+                    ['when condition "%s" is %s' % (k, v) for (k, v) in scenario.items()])
+                matches.append(
+                    RuleMatch(path, message.format(key, scenario_text)))
+        for key in set(nested_parameters.keys())- set(template_parameters.keys()):
+            if nested_parameters.get(key).get('Default') is None:
+                if scenario is None:
+                    message = 'Nested stack template parameter "{0}" is not specified at {1}'
+                    matches.append(
+                        RuleMatch(path, message.format(key, '/'.join(map(str, path)))))
+                else:
+                    message = 'Nested stack template parameter "{0}" is not specified {1}'
+                    scenario_text = ' and '.join(
+                        ['when condition "%s" is %s' % (k, v) for (k, v) in scenario.items()])
+                    matches.append(
+                        RuleMatch(path, message.format(key, scenario_text)))
+
+        return matches
+
+
+    def match_resource_properties(self, properties, _, path, cfn):
+        """Check CloudFormation Properties"""
+        matches = []
+
+        # when template is passed via cat (or equivalent filename is none)
+        if cfn.filename:
+            base_dir = os.path.dirname(os.path.abspath(cfn.filename))
+
+            parameter_groups = cfn.get_object_without_conditions(obj=properties, property_names=['TemplateURL', 'Parameters'])
+            for parameter_group in parameter_groups:
+                obj = parameter_group.get('Object')
+                template_url = obj.get('TemplateURL')
+                if isinstance(template_url, six.string_types):
+                    if not (template_url.startswith('http://') or template_url.startswith('https://') or template_url.startswith('s3://')):
+                        template_path = os.path.normpath(os.path.join(base_dir, template_url))
+                        nested_parameters = self.__get_template_parameters(template_path)
+                        template_parameters = obj.get('Parameters')
+                        if isinstance(nested_parameters, dict) and isinstance(template_parameters, dict):
+                            matches.extend(
+                                self.__compare_objects(
+                                    template_parameters=template_parameters,
+                                    nested_parameters=nested_parameters,
+                                    path=path + ['Parameters'],
+                                    scenario=parameter_group.get('Scenario'),
+                                )
+                            )
+
+        return matches

--- a/src/cfnlint/rules/resources/cloudformation/__init__.py
+++ b/src/cfnlint/rules/resources/cloudformation/__init__.py
@@ -1,0 +1,4 @@
+"""
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+"""

--- a/test/fixtures/templates/bad/resources/cloudformation/stack_nested.yaml
+++ b/test/fixtures/templates/bad/resources/cloudformation/stack_nested.yaml
@@ -1,0 +1,6 @@
+Parameters:
+  One:
+    Type: String
+  Two:
+    Type: String
+Resources: {}

--- a/test/fixtures/templates/bad/resources/cloudformation/stacks.yaml
+++ b/test/fixtures/templates/bad/resources/cloudformation/stacks.yaml
@@ -1,0 +1,28 @@
+Conditions:
+  IsUsEast1: !Equals [!Ref 'AWS::Region', 'us-east-1']
+  IsUsWest2: !Equals [!Ref 'AWS::Region', 'us-west-2']
+Resources:
+  # Doesn't fail on normal process
+  StackNormal:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: ./stack_nested.yaml
+      Parameters:
+        One: a
+        Three: b
+  # Doesn't fail on scenarios
+  Stack3:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: ./stack_nested.yaml
+      Parameters:
+        Fn::If:
+        - IsUsEast1
+        - Zero: a
+          One: b
+        - Fn::If:
+          - IsUsWest2
+          - Two: c
+            Three: d
+          - One: e
+            Three: f

--- a/test/fixtures/templates/good/resources/cloudformation/stack_nested.yaml
+++ b/test/fixtures/templates/good/resources/cloudformation/stack_nested.yaml
@@ -1,0 +1,6 @@
+Parameters:
+  One:
+    Type: String
+  Two:
+    Type: String
+Resources: {}

--- a/test/fixtures/templates/good/resources/cloudformation/stacks.yaml
+++ b/test/fixtures/templates/good/resources/cloudformation/stacks.yaml
@@ -1,0 +1,51 @@
+Conditions:
+  IsUsEast1: !Equals [!Ref 'AWS::Region', 'us-east-1']
+Resources:
+  # Doesn't fail on normal process
+  StackNormal:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: ./stack_nested.yaml
+      Parameters:
+        One: a
+        Two: b
+  # Doesn't fail on TemplateURL for web url
+  StackIsWebUrl:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: https://someurl.com
+      Parameters:
+        One: a
+        Two: b
+  # Doesn't fail on TemplateURL for web url
+  StackUrlIsObject:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: !Sub "${AWS::Region}/template.yaml"
+      Parameters:
+        One: a
+        Two: b
+  # Don't fail when template not found
+  StackInvalidPath:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: ./invalid_stack.yaml
+      Parameters:
+        One: a
+        Two: b
+  # Doesn't fail on scenarios
+  Stack3:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: ./stack_nested.yaml
+      Parameters:
+        Fn::If:
+        - IsUsEast1
+        - One: a
+          Two: b
+        - Fn::If:
+          - IsUsEast1
+          - One: c
+            Two: d
+          - One: e
+            Two: f

--- a/test/unit/rules/resources/cloudformation/__init__.py
+++ b/test/unit/rules/resources/cloudformation/__init__.py
@@ -1,0 +1,4 @@
+"""
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+"""

--- a/test/unit/rules/resources/cloudformation/test_nested_stack_parameters.py
+++ b/test/unit/rules/resources/cloudformation/test_nested_stack_parameters.py
@@ -1,0 +1,28 @@
+"""
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+"""
+from test.unit.rules import BaseRuleTestCase
+from cfnlint.rules.resources.cloudformation.NestedStackParameters import NestedStackParameters  # pylint: disable=E0401
+
+
+class TestNestedStackParameters(BaseRuleTestCase):
+    """Test CloudFormation Nested stack parameters """
+
+    def setUp(self):
+        """Setup"""
+        super(TestNestedStackParameters, self).setUp()
+        self.collection.register(NestedStackParameters())
+        self.success_templates = [
+            'test/fixtures/templates/good/resources/cloudformation/stacks.yaml'
+        ]
+
+    def test_file_positive(self):
+        """Test Positive"""
+        self.helper_file_positive()
+
+    def test_file_negative(self):
+        """Test failure"""
+        err_count = 8
+        self.helper_file_negative(
+            'test/fixtures/templates/bad/resources/cloudformation/stacks.yaml', err_count)


### PR DESCRIPTION
*Issue #, if available:*
#1963

*Description of changes:*
- Add rule E3043 to validate nested stack parameters

This rule will not do the following.  It could be possible to add these capabilities on a future release. As a result I'm not closing the issue.
1. Fail if the template isn't found
2. Not validate parameters if the TemplateURL is not a string
3. Not validate parameters if the TemplateURL is pointed at a s3 bucket
4. Does not validate nested stack parameter outputs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
