### PR TITLE
Fix rule message string formatting for cloudfront aliases rule (E3013)

### DIFF
--- a/src/cfnlint/rules/resources/cloudfront/Aliases.py
+++ b/src/cfnlint/rules/resources/cloudfront/Aliases.py
@@ -33,14 +33,12 @@ class Aliases(CloudFormationLintRule):
                     if isinstance(alias, str) and alias not in FUNCTIONS:
                         wildcard = alias.split('.')
                         if '*' in wildcard[1:]:
-                            message = 'Invalid use of wildcards: {}'.format(alias)
                             path = result['Path'] + ['Aliases']
-                            matches.append(
-                                RuleMatch(path, message.format(('/'.join(result['Path'])))))
+                            message = 'Invalid use of wildcards: {} at {}'.format(alias, '/'.join(result['Path']))
+                            matches.append(RuleMatch(path, message))
                         if not re.match(valid_domain, alias):
-                            message = 'Invalid alias found: {}'.format(alias)
                             path = result['Path'] + ['Aliases']
-                            matches.append(
-                                RuleMatch(path, message.format(('/'.join(result['Path'])))))
+                            message = 'Invalid alias found: {} at {}'.format(alias, '/'.join(result['Path']))
+                            matches.append(RuleMatch(path, message))
 
         return matches


### PR DESCRIPTION
Hi, there is an error on rule 3013 when using serverless variables. Here's a simple example reproducing it:
`test.yml`
```yaml
Resources:
  CloudFront:
    Type: AWS::CloudFront::Distribution
    Properties:
      DistributionConfig:
          Aliases:
            - ${env:DOMAIN_NAME}
```
Running cfn-lint produces the following results:
```console
$ cfn-lint test.yml
E0002 Unknown exception while processing rule E3013: 'env'
test.yml:1:1

E3003 Property DefaultCacheBehavior missing at Resources/CloudFront/Properties/DistributionConfig
test.yml:5:7

E3003 Property Enabled missing at Resources/CloudFront/Properties/DistributionConfig
test.yml:5:7

E3003 Property Origins missing at Resources/CloudFront/Properties/DistributionConfig
test.yml:5:7
```
The first line is the error.

I looked at the code before submitting an issue and was able to spot the error. It is caused by [incorrect string formatting](https://github.com/aws-cloudformation/cfn-lint/blob/36cb46192ad1be8c88715c16b4854048f49b18a2/src/cfnlint/rules/resources/cloudfront/Aliases.py#L41-L44)
Basically the last call to `message.format()` does nothing, and in my case since serverless variables contain {} they are considered as placeholders for `str.format` causing the error. The same error would appear for the wildcard rule violation as well if something like this was used `${env:SUBDOMAIN}.*.domain.com`, so I fixed that as well.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
