### PR TITLE
AWS::ElasticLoadBalancingV2::LoadBalancer.LoadBalancerAttribute AllowedValues expansion

### DIFF
--- a/src/cfnlint/rules/resources/elb/Elb.py
+++ b/src/cfnlint/rules/resources/elb/Elb.py
@@ -91,6 +91,8 @@ HTTPS has certificate HTTP has no certificate'
                 'idle_timeout.timeout_seconds',
                 'routing.http.desync_mitigation_mode',
                 'routing.http.drop_invalid_header_fields.enabled',
+                'routing.http.x_amzn_tls_version_and_cipher_suite.enabled',
+                'routing.http.xff_client_port.enabled',
                 'routing.http2.enabled',
                 'waf.fail_open.enabled'
             ],


### PR DESCRIPTION
fix https://github.com/aws-cloudformation/cfn-lint/issues/2100
[`AWS::ElasticLoadBalancingV2::LoadBalancer.LoadBalancerAttribute`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticloadbalancingv2-loadbalancer-loadbalancerattributes.html#cfn-elasticloadbalancingv2-loadbalancer-loadbalancerattributes-key)

---

previously: https://github.com/aws-cloudformation/cfn-lint/pull/1220, https://github.com/aws-cloudformation/cfn-lint/pull/1660, https://github.com/aws-cloudformation/cfn-lint/pull/1783

[Highest churn for a service-specific rule](https://github.com/aws-cloudformation/cfn-python-lint/pull/1646#issuecomment-727257299), wonder if we need to re-think this?