### PR TITLE
Add Replica key to ref/gettatt on AWS::KMS::Alias.TargetKeyId

### DIFF
--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
@@ -233,14 +233,16 @@
       },
       "AWS::KMS::Alias.TargetKeyId": {
         "GetAtt": {
-          "AWS::KMS::Key": "Arn"
+          "AWS::KMS::Key": "Arn",
+          "AWS::KMS::ReplicaKey": "Arn"
         },
         "Ref": {
           "Parameters": [
             "String"
           ],
           "Resources": [
-            "AWS::KMS::Key"
+            "AWS::KMS::Key",
+            "AWS::KMS::ReplicaKey"
           ]
         }
       },


### PR DESCRIPTION
*Issue #, if available:*
fix #2107
*Description of changes:*
- Add `AWS::KMS::ReplicaKey` to valid Ref/GetAtt on `AWS::KMS::Alias.TargetKeyId`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
