### PR TITLE
removing AWS::DMS::Endpoint.EngineName AllowedValues

### DIFF
--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
@@ -82,29 +82,6 @@
       "DLMPolicyResourceType": {
         "botocore": "dlm/2018-01-12/ResourceTypeValues"
       },
-      "DmsEndpointEngineName": {
-        "AllowedValues": [
-          "aurora-postgresql",
-          "aurora",
-          "azuredb",
-          "db2",
-          "docdb",
-          "dynamodb",
-          "elasticsearch",
-          "kafka",
-          "kinesis",
-          "mariadb",
-          "mongodb",
-          "mysql",
-          "neptune",
-          "oracle",
-          "postgres",
-          "redshift",
-          "s3",
-          "sqlserver",
-          "sybase"
-        ]
-      },
       "DmsEndpointSslMode": {
         "botocore": "dms/2016-01-01/DmsSslModeValue"
       },

--- a/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
@@ -530,13 +530,6 @@
   },
   {
     "op": "add",
-    "path": "/ResourceTypes/AWS::DMS::Endpoint/Properties/EngineName/Value",
-    "value": {
-      "ValueType": "DmsEndpointEngineName"
-    }
-  },
-  {
-    "op": "add",
     "path": "/ResourceTypes/AWS::DMS::Endpoint/Properties/EndpointType/Value",
     "value": {
       "ValueType": "DmsEndpointType"


### PR DESCRIPTION
similar to https://github.com/aws-cloudformation/cfn-lint/pull/1975

---

https://github.com/aws-cloudformation/cfn-lint/issues/50, https://github.com/aws-cloudformation/cfn-lint/pull/1682

https://github.com/aws-cloudformation/cfn-lint/pull/1472, https://github.com/aws-cloudformation/cfn-lint/pull/1473, https://github.com/aws-cloudformation/cfn-lint/pull/1725, https://github.com/aws-cloudformation/cfn-lint/pull/1920, `opensearch` just added to [`AWS::DMS::Endpoint.EngineName`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dms-endpoint.html#cfn-dms-endpoint-enginename)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
