### PR TITLE
Add AWS::DynamoDB::Table to AllowedValues on AWS::CloudTrail::Trail.DataResourceType

### DIFF
--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_cloudtrail.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_cloudtrail.json
@@ -5,7 +5,14 @@
     "value": {
       "AllowedValues": [
         "AWS::Lambda::Function",
-        "AWS::S3::Object"
+        "AWS::S3::Object",
+        "AWS::DynamoDB::Table",
+        "AWS::S3Outposts::Object",
+        "AWS::ManagedBlockchain::Node",
+        "AWS::S3ObjectLambda::AccessPoint",
+        "AWS::EC2::Snapshot",
+        "AWS::S3::AccessPoint",
+        "AWS::DynamoDB::Stream"
       ]
     }
   }


### PR DESCRIPTION
*Issue #, if available:*
fix #2133 

*Description of changes:*
-Add `AWS::DynamoDB::Table` to `AllowedValues` on `AWS::CloudTrail::Trail.DataResourceType`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
