### PR TITLE
Add InstanceRefresh to allowed values for SuspendProcesses

### DIFF
--- a/src/cfnlint/rules/resources/updatepolicy/Configuration.py
+++ b/src/cfnlint/rules/resources/updatepolicy/Configuration.py
@@ -39,7 +39,7 @@ class Configuration(CloudFormationLintRule):
                     'ValidValues': [
                         'Launch', 'Terminate', 'HealthCheck',
                         'ReplaceUnhealthy', 'AZRebalance', 'AlarmNotification',
-                        'ScheduledActions', 'AddToLoadBalancer'
+                        'ScheduledActions', 'AddToLoadBalancer', 'InstanceRefresh',
                     ]
                 },
                 'WaitOnResourceSignals': {


### PR DESCRIPTION
*Issue #, if available:*
fix #2159 

*Description of changes:*
- Add `InstanceRefresh` to allowed values for `SuspendProcesses` in rule `E3016`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
