### PR TITLE
Add AWS::EKS::Cluster.ClusterSecurityGroupId to list of AWS::EC2::SecurityGroup.NameOrGroupId

### DIFF
--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_ec2.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_ec2.json
@@ -46,7 +46,8 @@
     "value": {
       "GetAtt": {
         "AWS::EC2::SecurityGroup": "GroupId",
-        "AWS::EC2::VPC": "DefaultSecurityGroup"
+        "AWS::EC2::VPC": "DefaultSecurityGroup",
+        "AWS::EKS::Cluster": "ClusterSecurityGroupId"
       },
       "Ref": {
         "Parameters": [


### PR DESCRIPTION
*Issue #, if available:*
fix #2162 
*Description of changes:*
Add AWS::EKS::Cluster.ClusterSecurityGroupId to list of AWS::EC2::SecurityGroup.NameOrGroupId

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
