### PR TITLE
expanding likely_stateful_resource_types (AWS::OpenSearchService::Domain)

### DIFF
--- a/src/cfnlint/data/AdditionalSpecs/StatefulResources.json
+++ b/src/cfnlint/data/AdditionalSpecs/StatefulResources.json
@@ -17,6 +17,7 @@
     "AWS::Logs::LogGroup" : {},
     "AWS::Neptune::DBCluster" : {},
     "AWS::Neptune::DBInstance" : {},
+    "AWS::OpenSearchService::Domain" : {},
     "AWS::QLDB::Ledger" : {},
     "AWS::RDS::DBCluster" : {},
     "AWS::RDS::DBInstance" : {},


### PR DESCRIPTION
inspired by https://github.com/aws-cloudformation/cfn-lint/pull/2174

[some more possible additions as well](https://sourcegraph.com/search?q=context:global+r:aws-cloudformation/cfn-lint+AWS::Elasticsearch::Domain+-file:test/&patternType=literal)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
