### PR TITLE
Drop PyPI mock test dependency

### DIFF
--- a/test/unit/module/cfn_json/test_cfn_json.py
+++ b/test/unit/module/cfn_json/test_cfn_json.py
@@ -4,7 +4,7 @@ SPDX-License-Identifier: MIT-0
 """
 from test.testlib.testcase import BaseTestCase
 from six import StringIO
-from mock import patch
+from unittest.mock import patch
 from cfnlint.template import Template  # pylint: disable=E0401
 from cfnlint.rules import RulesCollection
 from cfnlint.core import DEFAULT_RULESDIR  # pylint: disable=E0401

--- a/test/unit/module/cfn_yaml/test_yaml.py
+++ b/test/unit/module/cfn_yaml/test_yaml.py
@@ -4,7 +4,7 @@ SPDX-License-Identifier: MIT-0
 """
 from test.testlib.testcase import BaseTestCase
 from six import StringIO
-from mock import patch
+from unittest.mock import patch
 from cfnlint.template import Template  # pylint: disable=E0401
 from cfnlint.rules import RulesCollection
 from cfnlint.core import DEFAULT_RULESDIR  # pylint: disable=E0401

--- a/test/unit/module/config/test_config_file_args.py
+++ b/test/unit/module/config/test_config_file_args.py
@@ -5,7 +5,7 @@ SPDX-License-Identifier: MIT-0
 import logging
 from test.testlib.testcase import BaseTestCase
 import jsonschema
-from mock import patch
+from unittest.mock import patch
 import cfnlint.config  # pylint: disable=E0401
 try:  # pragma: no cover
     from pathlib import Path

--- a/test/unit/module/config/test_config_mixin.py
+++ b/test/unit/module/config/test_config_mixin.py
@@ -5,7 +5,7 @@ SPDX-License-Identifier: MIT-0
 import logging
 import os
 from test.testlib.testcase import BaseTestCase
-from mock import patch
+from unittest.mock import patch
 import cfnlint.config  # pylint: disable=E0401
 from cfnlint.helpers import REGIONS
 

--- a/test/unit/module/core/test_run_cli.py
+++ b/test/unit/module/core/test_run_cli.py
@@ -7,7 +7,7 @@ from test.testlib.testcase import BaseTestCase
 from six import StringIO
 import cfnlint.core  # pylint: disable=E0401
 import cfnlint.config  # pylint: disable=E0401
-from mock import patch
+from unittest.mock import patch
 
 
 LOGGER = logging.getLogger('cfnlint')

--- a/test/unit/module/custom_rules/test_custom_rules.py
+++ b/test/unit/module/custom_rules/test_custom_rules.py
@@ -4,7 +4,7 @@ SPDX-License-Identifier: MIT-0
 """
 from test.testlib.testcase import BaseTestCase
 from six import StringIO
-from mock import patch
+from unittest.mock import patch
 from cfnlint.template import Template  # pylint: disable=E0401
 from cfnlint.rules import RulesCollection
 from cfnlint.core import DEFAULT_RULESDIR  # pylint: disable=E0401

--- a/test/unit/module/helpers/test_downloads_metadata.py
+++ b/test/unit/module/helpers/test_downloads_metadata.py
@@ -5,7 +5,7 @@ SPDX-License-Identifier: MIT-0
 import sys
 import os
 from test.testlib.testcase import BaseTestCase
-from mock import patch, MagicMock, mock_open
+from unittest.mock import patch, MagicMock, mock_open
 import cfnlint.helpers
 import json
 

--- a/test/unit/module/helpers/test_get_url_content.py
+++ b/test/unit/module/helpers/test_get_url_content.py
@@ -9,7 +9,7 @@ try:
 except:
     pass
 from test.testlib.testcase import BaseTestCase
-from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 import cfnlint.helpers
 
 

--- a/test/unit/module/maintenance/test_update_documentation.py
+++ b/test/unit/module/maintenance/test_update_documentation.py
@@ -5,7 +5,7 @@ SPDX-License-Identifier: MIT-0
 import sys
 import logging
 from test.testlib.testcase import BaseTestCase
-from mock import patch, mock_open, call
+from unittest.mock import patch, mock_open, call
 import cfnlint.maintenance
 from cfnlint.rules import CloudFormationLintRule, RulesCollection
 

--- a/test/unit/module/maintenance/test_update_iam_policies.py
+++ b/test/unit/module/maintenance/test_update_iam_policies.py
@@ -5,7 +5,7 @@ SPDX-License-Identifier: MIT-0
 import sys
 import logging
 from test.testlib.testcase import BaseTestCase
-from mock import patch
+from unittest.mock import patch
 import cfnlint.maintenance
 
 LOGGER = logging.getLogger('cfnlint.maintenance')

--- a/test/unit/module/maintenance/test_update_resource_specs.py
+++ b/test/unit/module/maintenance/test_update_resource_specs.py
@@ -6,7 +6,7 @@ import sys
 import logging
 import zipfile
 from test.testlib.testcase import BaseTestCase
-from mock import patch, MagicMock, Mock, ANY
+from unittest.mock import patch, MagicMock, Mock, ANY
 import cfnlint.maintenance
 try:
     from urllib.request import urlopen, Request

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,6 @@ commands =
   coverage xml
 skip_install = True
 deps =
-  mock
   coverage
   pydot
 setenv =


### PR DESCRIPTION
The functionality is in the standard library as `unittest.mock` beginning with Python 3.3.

*Issue #, if available:* (none)

*Description of changes:*

In any tests, prefer to import from `unittest.mock` in the Python 3.3+ standard library, falling back to the PyPI `mock` backport package only where required (Python 2.7). Drop the `mock` dependency from `tox.ini` for Python 3.3+, too.

See https://fedoraproject.org/wiki/Changes/DeprecatePythonMock for further context.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
