### PR TITLE
Fix an issue where tests were adding to download metadata

### DIFF
--- a/test/unit/module/formatters/test_formatters.py
+++ b/test/unit/module/formatters/test_formatters.py
@@ -163,7 +163,7 @@ class TestFormatters(BaseTestCase):
         sarif = json.loads(formatter.print_matches(results, rules))
 
         # Fetch the SARIF schema
-        schema = json.loads(cfnlint.helpers.get_url_content(sarif['$schema'], True))
+        schema = json.loads(cfnlint.helpers.get_url_content(sarif['$schema'], False))
         jsonschema.validate(sarif, schema)
 
         sarif_results = sarif['runs'][0]['results']


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- There is an issue where the sarif tests were causing an additional metadata file to be created

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
