### PR TITLE
Adds RecordSet Alias TTL match

### DIFF
--- a/src/cfnlint/rules/resources/route53/RecordSet.py
+++ b/src/cfnlint/rules/resources/route53/RecordSet.py
@@ -58,7 +58,7 @@ class RecordSet(CloudFormationLintRule):
 
     def check_aaaa_record(self, value, path):
         return self.check_record(value, path, 'AAAA', REGEX_IPV6, 'IPv6 address')
-
+    
     def check_caa_record(self, value, path):
         """Check CAA record Configuration"""
         matches = []
@@ -234,6 +234,9 @@ class RecordSet(CloudFormationLintRule):
                             check_value=self.check_txt_record,
                         )
                     )
+            else:
+                if recordset.get('TTL'):
+                    matches.append(RuleMatch(path + ['TTL'], 'TTL is not allowed for Alias records'))
 
         return matches
 

--- a/src/cfnlint/rules/resources/route53/RecordSet.py
+++ b/src/cfnlint/rules/resources/route53/RecordSet.py
@@ -58,7 +58,7 @@ class RecordSet(CloudFormationLintRule):
 
     def check_aaaa_record(self, value, path):
         return self.check_record(value, path, 'AAAA', REGEX_IPV6, 'IPv6 address')
-    
+
     def check_caa_record(self, value, path):
         """Check CAA record Configuration"""
         matches = []

--- a/test/fixtures/templates/bad/route53.yaml
+++ b/test/fixtures/templates/bad/route53.yaml
@@ -4,6 +4,12 @@ Parameters:
   DomainName:
     Type: String
     Default: "www.example.com"
+  AliasTarget:
+    Type: String
+    Default: "a1bcde2f3ghij4.cloudfront.net"
+  CloudFrontStaticZoneId:
+    Type: String
+    Default: "Z2FDTNDATAQYW2" # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-aliastarget-1.html#cfn-route53-aliastarget-hostedzoneid
 Conditions:
   isPrimaryRegion: !Equals [!Ref 'AWS::Region', 'us-east-1']
 Resources:
@@ -97,6 +103,18 @@ Resources:
       ResourceRecords:
         - "127.0.0.1"
         - "10 my domain"
+  MyAliasRecordSet:
+    Type: "AWS::Route53::RecordSet"
+    Properties:
+      Comment: "Invalid Alias A Record"
+      HostedZoneId: !Ref "MyHostedZone"
+      Name: "alias.example.com"
+      Type: "A"
+      TTL: "300" # TTL not allowed on Alias
+      AliasTarget:
+        DNSName: !Ref "AliasTarget"
+        EvaluateTargetHealth: false
+        HostedZoneId: !Ref "CloudFrontStaticZoneId"
   MyRecordSetGroup:
     Type: "AWS::Route53::RecordSetGroup"
     Properties:

--- a/test/fixtures/templates/good/route53.yaml
+++ b/test/fixtures/templates/good/route53.yaml
@@ -6,6 +6,12 @@ Parameters:
     Default: "example.com"
   RecordType:
     Type: String
+  AliasTarget:
+    Type: String
+    Default: "a1bcde2f3ghij4.cloudfront.net"
+  CloudFrontStaticZoneId:
+    Type: String
+    Default: "Z2FDTNDATAQYW2" # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-aliastarget-1.html#cfn-route53-aliastarget-hostedzoneid
 Resources:
   MyHostedZone:
     Type: "AWS::Route53::HostedZone"
@@ -134,6 +140,17 @@ Resources:
       TTL: "300"
       ResourceRecords:
         - "hostname.example.com"
+  MyAliasRecordSet:
+    Type: "AWS::Route53::RecordSet"
+    Properties:
+      Comment: "A valid Alias A Record"
+      HostedZoneId: !Ref "MyHostedZone"
+      Name: "alias.example.com"
+      Type: "A"
+      AliasTarget:
+        DNSName: !Ref "AliasTarget"
+        EvaluateTargetHealth: false
+        HostedZoneId: !Ref "CloudFrontStaticZoneId"
   MyRecordSetGroup:
     Type: "AWS::Route53::RecordSetGroup"
     Properties:

--- a/test/unit/rules/resources/route53/test_recordsets.py
+++ b/test/unit/rules/resources/route53/test_recordsets.py
@@ -23,4 +23,4 @@ class TestRoute53RecordSets(BaseRuleTestCase):
 
     def test_file_negative(self):
         """Test failure"""
-        self.helper_file_negative('test/fixtures/templates/bad/route53.yaml', 30)
+        self.helper_file_negative('test/fixtures/templates/bad/route53.yaml', 31)


### PR DESCRIPTION
*Description of changes:*
Adds an additional match to the R53 RecordSet rule to catch Alias records with a specified TTL, and updates the tests for this new match. If a template with one were to be deployed, the deployment would fail with an invalid request API error.

From the docs:
> If an alias record points to an AWS resource, you can’t set the time to live (TTL); Route 53 uses the default TTL for the resource. If an alias record points to another record in the same hosted zone, Route 53 uses the TTL of the record that the alias record points to.

https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resource-record-sets-choosing-alias-non-alias.html

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
