### PR TITLE
Fix an issue when checking for boolean values that are false

### DIFF
--- a/src/cfnlint/rules/custom/Operators.py
+++ b/src/cfnlint/rules/custom/Operators.py
@@ -49,7 +49,7 @@ def CreateCustomRule(rule_id, resourceType, prop, value, error_message, descript
                         cfn=cfn,
                     ))
                 return matches
-            if value:
+            if value is not None:
                 matches.extend(self.rule_func(value, self.property_value, path))
             return matches
 

--- a/test/fixtures/custom_rules/bad/custom_rule_invalid_boolean.txt
+++ b/test/fixtures/custom_rules/bad/custom_rule_invalid_boolean.txt
@@ -1,0 +1,1 @@
+AWS::EC2::Instance BlockDeviceMappings.Ebs.DeleteOnTermination == True ERROR

--- a/test/fixtures/custom_rules/good/custom_rule_boolean.txt
+++ b/test/fixtures/custom_rules/good/custom_rule_boolean.txt
@@ -1,0 +1,1 @@
+AWS::EC2::Instance BlockDeviceMappings.Ebs.DeleteOnTermination == False ERROR

--- a/test/unit/module/custom_rules/test_custom_rules.py
+++ b/test/unit/module/custom_rules/test_custom_rules.py
@@ -28,6 +28,8 @@ class TestCustomRuleParsing(BaseTestCase):
         }
 
         self.perfect_rule = 'test/fixtures/custom_rules/good/custom_rule_perfect.txt'
+        self.valid_boolean = 'test/fixtures/custom_rules/good/custom_rule_boolean.txt'
+        self.invalid_boolean = 'test/fixtures/custom_rules/bad/custom_rule_invalid_boolean.txt'
         self.invalid_op = 'test/fixtures/custom_rules/bad/custom_rule_invalid_op.txt'
         self.invalid_prop = 'test/fixtures/custom_rules/bad/custom_rule_invalid_prop.txt'
         self.invalid_propkey = 'test/fixtures/custom_rules/bad/custom_rule_invalid_propkey.txt'
@@ -71,6 +73,14 @@ class TestCustomRuleParsing(BaseTestCase):
         """Test Successful Custom_Rule Parsing"""
         assert (self.run_tests(self.invalid_less_than)[0].message.find('Lesser than check') > -1)
 
+    def test_valid_boolean_value(self):
+        """Test Boolean values"""
+        assert (self.run_tests(self.valid_boolean) == [])
+
+    def test_invalid_boolean_value(self):
+        """Test Boolean values"""
+        assert (self.run_tests(self.invalid_boolean)[0].message.find('Must equal check failed') > -1)
+
     def test_invalid_prop(self):
         """Test Successful Custom_Rule Parsing"""
         assert (self.run_tests(self.invalid_prop) == [])
@@ -92,4 +102,3 @@ class TestCustomRuleParsing(BaseTestCase):
             rules.create_from_custom_rules_file(rulename)
             runner = cfnlint.runner.Runner(rules, filename, template, None, None)
             return runner.run()
-


### PR DESCRIPTION
*Issue #, if available:*
fix #2189 

*Description of changes:*
- Fix an issue when custom rules wouldn't check values that are false

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
