### PR TITLE
Blank out all functions in json size check

### DIFF
--- a/src/cfnlint/rules/resources/properties/JsonSize.py
+++ b/src/cfnlint/rules/resources/properties/JsonSize.py
@@ -36,6 +36,7 @@ class JsonSize(CloudFormationLintRule):
         """Check Role.AssumeRolePolicyDocument is within limits"""
         matches = []
 
+        #pylint: disable=too-many-return-statements
         def remove_functions(obj):
             """ Replaces intrinsic functions with string """
             if isinstance(obj, dict):
@@ -48,6 +49,8 @@ class JsonSize(CloudFormationLintRule):
                                     return re.sub(r'\${.*}', '', v)
                                 if isinstance(v, list):
                                     return re.sub(r'\${.*}', '', v[0])
+                            else:
+                                return ''
                         else:
                             new_obj[k] = remove_functions(v)
                             return new_obj


### PR DESCRIPTION
*Issue #, if available:*
fix #2221 

*Description of changes:*
- Blank out all functions in rule `E3502` when validating json document size

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
