### PR TITLE
Wrap creating a map into try/except with appropriate error

### DIFF
--- a/src/cfnlint/decode/cfn_yaml.py
+++ b/src/cfnlint/decode/cfn_yaml.py
@@ -103,7 +103,21 @@ class NodeConstructor(SafeConstructor):
                             ),
                         ]
                     )
-            mapping[key] = value
+            try:
+                mapping[key] = value
+            except:
+                raise CfnParseError(
+                        self.filename,
+                        [
+                            build_match(
+                                filename=self.filename,
+                                message=f'Unhashable type "{key}" (line {key.start_mark.line + 1})',
+                                line_number=key.start_mark.line,
+                                column_number=key.start_mark.column,
+                                key=key
+                            ),
+                        ]
+                    )
 
         obj, = SafeConstructor.construct_yaml_map(self, node)
 

--- a/test/fixtures/templates/bad/core/parse_invalid_map.yaml
+++ b/test/fixtures/templates/bad/core/parse_invalid_map.yaml
@@ -1,0 +1,23 @@
+Resources:
+  NodeGroup:
+    Type: "AWS::AutoScaling::AutoScalingGroup"
+    Properties:
+      DesiredCapacity: !Ref NodeAutoScalingGroupDesiredCapacity
+      LaunchTemplate:
+        LaunchTemplateId: !Ref NodeLaunchTemplate
+        Version: !GetAtt NodeLaunchTemplate.LatestVersionNumber
+      MaxSize: !Ref NodeAutoScalingGroupMaxSize
+      MinSize: !Ref NodeAutoScalingGroupMinSize
+      Tags:
+        - Key: Name
+          PropagateAtLaunch: true
+          Value: !Sub Cluster-Group-Node
+        - Key: !Sub kubernetes.io/cluster/Cluster
+          PropagateAtLaunch: true
+          Value: owned
+      VPCZoneIdentifier: !Join [ ',', [ !ImportValue Fn::Sub: "${NetworkStackName}-SubnetsPrivate01", !ImportValue Fn::Sub: "${NetworkStackName}-SubnetsPrivate02" ] ]
+    UpdatePolicy:
+      AutoScalingRollingUpdate:
+        MaxBatchSize: 1
+        MinInstancesInService: !Ref NodeAutoScalingGroupDesiredCapacity
+        PauseTime: PT5M

--- a/test/unit/module/cfn_yaml/test_yaml.py
+++ b/test/unit/module/cfn_yaml/test_yaml.py
@@ -61,3 +61,10 @@ class TestYamlParse(BaseTestCase):
                 matches.extend(self.rules.run(filename, cfn))
                 assert len(matches) == failures, 'Expected {} failures, got {} on {}'.format(
                     failures, len(matches), values.get('filename'))
+
+
+    def test_map_failure(self):
+        """Test a failure is passed on unhashable map"""
+        filename = 'test/fixtures/templates/bad/core/parse_invalid_map.yaml'
+
+        self.assertRaises(cfnlint.decode.cfn_yaml.CfnParseError, cfnlint.decode.cfn_yaml.load, filename)


### PR DESCRIPTION
*Issue #, if available:*
Fix #2224 

*Description of changes:*
- Wrap creating a map in yaml parser with try/except and create appropriate error

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
