### PR TITLE
Add ImageUri for serverless function in SAM Transform

### DIFF
--- a/src/cfnlint/transform.py
+++ b/src/cfnlint/transform.py
@@ -76,7 +76,10 @@ class Transform(object):
 
             if resource_type == 'AWS::Serverless::Function':
 
-                Transform._update_to_s3_uri('CodeUri', resource_dict)
+                if resource_dict.get('PackageType') == 'Image':
+                    Transform._update_to_s3_uri('ImageUri', resource_dict)
+                else:
+                    Transform._update_to_s3_uri('CodeUri', resource_dict)
                 auto_publish_alias = resource_dict.get('AutoPublishAlias')
                 if isinstance(auto_publish_alias, dict):
                     if len(auto_publish_alias) == 1:

--- a/test/fixtures/templates/good/transform/function_using_image.yaml
+++ b/test/fixtures/templates/good/transform/function_using_image.yaml
@@ -1,0 +1,11 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Resources:
+  HelloWorldFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      PackageType: Image
+    Metadata:
+      DockerTag: nodejs14.x-v1
+      DockerContext: ./hello-world
+      Dockerfile: Dockerfile

--- a/test/unit/module/transform/test_transform.py
+++ b/test/unit/module/transform/test_transform.py
@@ -51,3 +51,12 @@ class TestTransform(BaseTestCase):
         transformed_template = Transform(filename, template, region)
         transformed_template.transform_template()
         self.assertDictEqual(transformed_template._parameters, {})
+
+    def test_test_function_using_image_good(self):
+        """Test Parameter is created for autopublish version run"""
+        filename = 'test/fixtures/templates/good/transform/function_using_image.yaml'
+        region = 'us-east-1'
+        template = cfn_yaml.load(filename)
+        transformed_template = Transform(filename, template, region)
+        transformed_template.transform_template()
+        self.assertDictEqual(transformed_template._parameters, {})


### PR DESCRIPTION
*Issue #, if available:*
fixes #1828 

*Description of changes:*
- Update SAM Transform pre work to add `ImageUri` when using `Image` as `PackageType` in `AWS::Serverless::Function`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
