### PR TITLE
Lambda runtime deprecation updates (python3.6)

### DIFF
--- a/src/cfnlint/data/AdditionalSpecs/LmbdRuntimeLifecycle.json
+++ b/src/cfnlint/data/AdditionalSpecs/LmbdRuntimeLifecycle.json
@@ -49,6 +49,11 @@
         "deprecated": "2021-09-30",
         "successor": "python3.8"
     },
+    "python3.6": {
+        "eol": "2022-07-18",
+        "deprecated": "2022-08-17",
+        "successor": "python3.9"
+    },
     "ruby2.5": {
         "eol": "2021-07-30",
         "deprecated": "2021-08-30",


### PR DESCRIPTION
https://github.com/terraform-linters/tflint-ruleset-aws/pull/335
https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html
[`AWS::Lambda::Function.Runtime`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-runtime)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
