### PR TITLE
add AWS::OpenSearchService::Domain.AccessPolicies to IAM rules

### DIFF
--- a/src/cfnlint/rules/resources/iam/Permissions.py
+++ b/src/cfnlint/rules/resources/iam/Permissions.py
@@ -20,6 +20,7 @@ class Permissions(CloudFormationLintRule):
 
     IAM_PERMISSION_RESOURCE_TYPES = {
         'AWS::Elasticsearch::Domain': 'AccessPolicies',
+        'AWS::OpenSearchService::Domain': 'AccessPolicies',
         'AWS::IAM::Group': 'Policies',
         'AWS::IAM::ManagedPolicy': 'PolicyDocument',
         'AWS::IAM::Policy': 'PolicyDocument',

--- a/src/cfnlint/rules/resources/iam/Policy.py
+++ b/src/cfnlint/rules/resources/iam/Policy.py
@@ -26,6 +26,7 @@ class Policy(CloudFormationLintRule):
         self.resources_and_keys = {
             'AWS::ECR::Repository': 'RepositoryPolicyText',
             'AWS::Elasticsearch::Domain': 'AccessPolicies',
+            'AWS::OpenSearchService::Domain': 'AccessPolicies',
             'AWS::KMS::Key': 'KeyPolicy',
             'AWS::S3::BucketPolicy': 'PolicyDocument',
             'AWS::SNS::TopicPolicy': 'PolicyDocument',

--- a/src/cfnlint/rules/resources/iam/PolicyVersion.py
+++ b/src/cfnlint/rules/resources/iam/PolicyVersion.py
@@ -21,6 +21,7 @@ class PolicyVersion(CloudFormationLintRule):
         self.resources_and_keys = {
             'AWS::ECR::Repository': 'RepositoryPolicyText',
             'AWS::Elasticsearch::Domain': 'AccessPolicies',
+            'AWS::OpenSearchService::Domain': 'AccessPolicies',
             'AWS::KMS::Key': 'KeyPolicy',
             'AWS::S3::BucketPolicy': 'PolicyDocument',
             'AWS::SNS::TopicPolicy': 'PolicyDocument',


### PR DESCRIPTION
duplicating [`AWS::Elasticsearch::Domain.AccessPolicies`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticsearch-domain.html#cfn-elasticsearch-domain-accesspolicies) logic for [`AWS::OpenSearchService::Domain.AccessPolicies`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-opensearchservice-domain.html#cfn-opensearchservice-domain-accesspolicies)

related:
https://github.com/aws-cloudformation/cfn-lint/pull/2174, https://github.com/aws-cloudformation/cfn-lint/pull/2179

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
