### PR TITLE
Point to the general "Rules" documentation when a rule doesn't specify a `source_url`

### DIFF
--- a/src/cfnlint/formatters/__init__.py
+++ b/src/cfnlint/formatters/__init__.py
@@ -327,7 +327,7 @@ class SARIFFormatter(BaseFormatter):
                 full_description=sarif.MultiformatMessageString(
                     text=rules_map[rule_id].description
                 ),
-                help_uri=rules_map[rule_id].source_url if rules_map[rule_id] else "https://github.com/aws-cloudformation/cfn-lint/blob/main/docs/rules.md"
+                help_uri=rules_map[rule_id].source_url if rules_map[rule_id] else 'https://github.com/aws-cloudformation/cfn-lint/blob/main/docs/rules.md'
             )
             for rule_id in matched_rules
         ]

--- a/src/cfnlint/formatters/__init__.py
+++ b/src/cfnlint/formatters/__init__.py
@@ -327,7 +327,7 @@ class SARIFFormatter(BaseFormatter):
                 full_description=sarif.MultiformatMessageString(
                     text=rules_map[rule_id].description
                 ),
-                help_uri=rules_map[rule_id].source_url if rules_map[rule_id] else None
+                help_uri=rules_map[rule_id].source_url if rules_map[rule_id] else "https://github.com/aws-cloudformation/cfn-lint/blob/main/docs/rules.md"
             )
             for rule_id in matched_rules
         ]


### PR DESCRIPTION
The SARIF schema defines `help_uri` as a `uri`, and it cannot be empty -- if it is then Github's codeql-action
to upload the SARIF will fail with validation errors, for instance.

I'm a bit unsure who is exactly at fault here, maybe the problem is actually that the sarif-om library shouldn't write the `help_uri` if it is `None`?

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.