### PR TITLE
Reduce scenarios used when conditions match

### DIFF
--- a/test/unit/module/conditions/test_conditions.py
+++ b/test/unit/module/conditions/test_conditions.py
@@ -27,6 +27,7 @@ class TestConditions(BaseTestCase):
                 'isProduction': {'Fn::Equals': [{'Ref': 'myEnvironment'}, 'Prod']},
                 'isPrimary': {'Fn::Equals': ['True', {'Fn::FindInMap': ['location', {'Ref': 'AWS::Region'}, 'primary']}]},
                 'isPrimaryAndProduction': {'Fn::And': [{'Condition': 'isProduction'}, {'Condition': 'isPrimary'}]},
+                'isPrimaryOrProduction': {'Fn::Or': [{'Condition': 'isProduction'}, {'Condition': 'isPrimary'}]},
                 'isProductionOrStaging': {'Fn::Or': [{'Condition': 'isProduction'}, {'Fn::Equals': [{'Ref': 'myEnvironment'}, 'Stage']}]},
                 'isNotProduction': {'Fn::Not': [{'Condition': 'isProduction'}]},
                 'isDevelopment': {'Fn::Equals': ['Dev', {'Ref': 'myEnvironment'}]},
@@ -46,7 +47,7 @@ class TestConditions(BaseTestCase):
 
     def test_success_size_of_conditions(self):
         """Test success run"""
-        self.assertEqual(len(self.conditions.Conditions), 9)
+        self.assertEqual(len(self.conditions.Conditions), 10)
         self.assertEqual(len(self.conditions.Parameters), 2)
         self.assertListEqual(self.conditions.Parameters['55caa18684cddafa866bdb947fb31ea563b2ea73'], [
                              'None', 'Single NAT', 'High Availability'])
@@ -242,6 +243,16 @@ class TestConditions(BaseTestCase):
                 {'isProduction': False, 'isProductionOrStaging': False},
             ]
         )
+        # Nested OR Logic
+        self.assertEqualListOfDicts(
+            self.conditions.get_scenarios(['isProduction', 'isPrimaryOrProduction']),
+            [
+                {'isProduction': True, 'isPrimaryOrProduction': True},
+                {'isProduction': False, 'isPrimaryOrProduction': True},
+                {'isProduction': False, 'isPrimaryOrProduction': False},
+            ]
+        )
+
         # We cover all the possible scenarios in this case
         self.assertEqualListOfDicts(
             self.conditions.get_scenarios(['isProduction', 'isPrimaryAndProdOrStage']),


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Before this change, when conditions are evaluated to determine scenarios we will pull all the equals that are under each condition.  In very complex scenarios this list can get long even though most of the equals don't overlap.  This change reduces the scenarios to where the equals overlap.  We add in one outside scenario to help create a complete list when a parent has an `and` or `or`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
