### PR TITLE
Add explicit encoding

### DIFF
--- a/src/cfnlint/decode/cfn_yaml.py
+++ b/src/cfnlint/decode/cfn_yaml.py
@@ -233,7 +233,7 @@ def load(filename):
         for line in fileinput.input(files=filename):
             content = content + line
     else:
-        with open(filename) as fp:
+        with open(filename, encoding='utf-8') as fp:
             content = fp.read()
 
     return loads(content, filename)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Add explicit `encoding='utf-8'` argument when cfn-lint loads .yml file.

  Some languages' environment such as Windows in Japanese, default encodings is not UTF-8. UTF-8 encoded template file could not be read without implicit `encoding` argument. For example, when cfn-lint runs template with comment in Japanese in Japanese-Windows environment, it cannot work because system interprets that file is written in cp932 despite done in UTF-8. These users must set `encoding` option when use `read()` method in Python.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
