### PR TITLE
Added transform parameter which outputs transformed template to a jso…

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Optional parameters:
 | -u, --update-specs | | | Update the [CloudFormation Resource Specifications](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-resource-specification.html).  You may need sudo to run this.  You will need internet access when running this command |
 | -o, --override-spec | | filename | Spec-style file containing custom definitions. Can be used to override CloudFormation specifications. More info [here](#customize-specifications) |
 | -g, --build-graph | |  | Creates a file in the same directory as the template that models the template's resources in [DOT format](https://en.wikipedia.org/wiki/DOT_(graph_description_language)) |
+| --transform | |  | Creates a JSON file in the same directory as the template that contains the transformed template. This file has extension .transform.json |
 | -s, --registry-schemas | | | one or more directories of [CloudFormation Registry](https://aws.amazon.com/blogs/aws/cloudformation-update-cli-third-party-resource-support-registry/) [Resource Schemas](https://github.com/aws-cloudformation/aws-cloudformation-resource-schema/)
 | -v, --version | | | Version of cfn-lint |
 

--- a/src/cfnlint/config.py
+++ b/src/cfnlint/config.py
@@ -427,6 +427,10 @@ class CliArgs(object):
             '--merge-configs', default=False, action='store_true',
             help='Merges lists between configuration layers'
         )
+        standard.add_argument(
+            '--transform', default=False, action='store_true',
+            help='Creates a file in the same directory as the template that outputs the Transformed Template as JSON'
+        )
 
         return parser
 
@@ -667,3 +671,7 @@ class ConfigMixIn(TemplateArgs, CliArgs, ConfigFileArgs, object):
     @property
     def merge_configs(self):
         return self._get_argument_value('merge_configs', True, True)
+
+    @property
+    def transform(self):
+        return self._get_argument_value('transform', False, False)

--- a/src/cfnlint/core.py
+++ b/src/cfnlint/core.py
@@ -40,7 +40,7 @@ class UnexpectedRuleException(CfnLintExitException):
     """When processing a rule fails in an unexpected way"""
 
 
-def run_cli(filename, template, rules, regions, override_spec, build_graph, registry_schemas, mandatory_rules=None):
+def run_cli(filename, template, rules, regions, override_spec, build_graph, registry_schemas, output_transform, mandatory_rules=None):
     """Process args and run"""
 
 
@@ -50,6 +50,10 @@ def run_cli(filename, template, rules, regions, override_spec, build_graph, regi
     if build_graph:
         template_obj = Template(filename, template, regions)
         template_obj.build_graph()
+
+    if output_transform:
+        template_obj = Template(filename, template, regions)
+        template_obj.transform_template()
 
     if registry_schemas:
         for path in registry_schemas:
@@ -122,7 +126,7 @@ def get_matches(filenames, args):
         # template matches may be empty but the template is still None
         # this happens when ignoring bad templates
         if not errors and template:
-            matches = run_cli(filename, template, rules, args.regions, args.override_spec, args.build_graph, args.registry_schemas, args.mandatory_checks)
+            matches = run_cli(filename, template, rules, args.regions, args.override_spec, args.build_graph, args.registry_schemas, args.transform, args.mandatory_checks)
             for match in matches:
                 yield match
         else:

--- a/src/cfnlint/template.py
+++ b/src/cfnlint/template.py
@@ -9,6 +9,7 @@ from copy import deepcopy, copy
 import cfnlint.conditions
 import cfnlint.helpers
 from cfnlint.graph import Graph
+from cfnlint.transform import Transform
 
 LOGGER = logging.getLogger(__name__)
 
@@ -59,6 +60,13 @@ class Template(object):  # pylint: disable=R0904,too-many-lines
         except ImportError:
             LOGGER.error(
                 'Could not write the graph in DOT format. Please install either `pygraphviz` or `pydot` modules.')
+
+    def transform_template(self):
+        t = Transform(self.filename, self.template, self.regions[0])
+        t.transform_template()
+        path = self.filename + '.transform.json'
+        with open(path, 'w') as output_file:
+            output_file.write(cfnlint.helpers.format_json_string(t.template()))
 
     def get_resources(self, resource_type=[]):
         """


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

A new parameter was added --transform which causes cfn-lint to output the transformed template to a .json file in the same directory as the original template.

Created a new method in the Template class which creates a new file containing the transformed template.

The run_cli method was  updated to call the above mentioned method.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
