### PR TITLE
Add AWS::EC2::KeyPair as a Ref for the value type KeyPair

### DIFF
--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
@@ -192,6 +192,9 @@
           "Parameters": [
             "String",
             "KeyPair"
+          ],
+          "Resources": [
+            "AWS::EC2::KeyPair"
           ]
         }
       },


### PR DESCRIPTION
*Issue #, if available:*
fix #2303 

*Description of changes:*
- Update `KeyPair` value type to include a `Ref` to `AWS::EC2::KeyPair`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
