### PR TITLE
Add support for AWS SSO PermissionSet - CustomerManagedPolicyReferences

### DIFF
--- a/src/cfnlint/rules/resources/iam/Policy.py
+++ b/src/cfnlint/rules/resources/iam/Policy.py
@@ -39,6 +39,7 @@ class Policy(CloudFormationLintRule):
             'AWS::IAM::Role': 'Policies',
             'AWS::IAM::User': 'Policies',
             'AWS::SSO::PermissionSet': 'InlinePolicy',
+            'AWS::SSO::PermissionSet': 'CustomerManagedPolicyReferences',
         }
         for resource_type in self.resources_and_keys:
             self.resource_property_types.append(resource_type)
@@ -215,7 +216,7 @@ class Policy(CloudFormationLintRule):
                             resource_exceptions=resource_exceptions,
                             start_mark=key.start_mark, end_mark=key.end_mark,
                         ))
-            elif key in ['KeyPolicy', 'PolicyDocument', 'RepositoryPolicyText', 'AccessPolicies', 'InlinePolicy']:
+            elif key in ['KeyPolicy', 'PolicyDocument', 'RepositoryPolicyText', 'AccessPolicies', 'InlinePolicy', 'CustomerManagedPolicyReferences']:
                 matches.extend(
                     cfn.check_value(
                         obj=properties, key=key,


### PR DESCRIPTION
*Issue # N/A

*Description of changes:
This PR fixes following error message from cfn-lint:

> E3002 Invalid Property Resources/ReadOnlyPermissionSet/Properties/CustomerManagedPolicyReferences

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
