### PR TITLE
Lambda runtime deprecation updates

### DIFF
--- a/src/cfnlint/data/AdditionalSpecs/LmbdRuntimeLifecycle.json
+++ b/src/cfnlint/data/AdditionalSpecs/LmbdRuntimeLifecycle.json
@@ -2,52 +2,62 @@
     "dotnetcore1.0": {
         "eol": "2019-06-27",
         "deprecated": "2019-07-31",
-        "successor": "dotnetcore3.1"
+        "successor": "dotnet6"
     },
     "dotnetcore2.0": {
         "eol": "2019-04-30",
         "deprecated": "2019-05-30",
-        "successor": "dotnetcore3.1"
+        "successor": "dotnet6"
     },
     "dotnetcore2.1": {
         "eol": "2021-08-23",
         "deprecated": "2021-09-23",
-        "successor": "dotnetcore3.1"
+        "successor": "dotnet6"
+    },
+    "dotnetcore3.1": {
+        "eol": "2023-01-20",
+        "deprecated": "2023-02-20",
+        "successor": "dotnet6"
     },
     "nodejs": {
         "eol": "2016-10-31",
         "deprecated": "2016-10-31",
-        "successor": "nodejs14.x"
+        "successor": "nodejs16.x"
     },
     "nodejs4.3": {
         "eol": "2018-04-30",
         "deprecated": "2019-04-30",
-        "successor": "nodejs14.x"
+        "successor": "nodejs16.x"
     },
     "nodejs4.3-edge": {
         "eol": "2018-04-30",
         "deprecated": "2019-04-30",
-        "successor": "nodejs14.x"
+        "successor": "nodejs16.x"
     },
     "nodejs6.10": {
         "eol": "2019-04-30",
         "deprecated": "2019-08-12",
-        "successor": "nodejs14.x"
+        "successor": "nodejs16.x"
     },
     "nodejs8.10": {
         "eol": "2019-12-31",
         "deprecated": "2020-02-03",
-        "successor": "nodejs14.x"
+        "successor": "nodejs16.x"
     },
     "nodejs10.x": {
         "eol": "2021-07-30",
         "deprecated": "2021-08-30",
-        "successor": "nodejs14.x"
+        "successor": "nodejs16.x"
+    },
+    "nodejs12.x": {
+        "eol": "2022-11-14",
+        "deprecated": "2022-12-14",
+        "successor": "nodejs16.x"
     },
     "python2.7": {
         "eol": "2021-07-15",
         "deprecated": "2021-09-30",
-        "successor": "python3.8"
+        "successor": "python3.9"
     },
     "python3.6": {
         "eol": "2022-07-18",

--- a/test/fixtures/results/public/lambda-poller.json
+++ b/test/fixtures/results/public/lambda-poller.json
@@ -18,7 +18,7 @@
                 "LineNumber": 151
             }
         },
-        "Message": "Deprecated runtime (nodejs6.10) specified. Updating disabled since 2019-08-12. Please consider updating to nodejs14.x",
+        "Message": "Deprecated runtime (nodejs6.10) specified. Updating disabled since 2019-08-12. Please consider updating to nodejs16.x",
         "Rule": {
             "Description": "Check if an EOL Lambda Runtime is specified and give an error if used. ",
             "Id": "E2531",

--- a/test/fixtures/results/quickstart/nist_config_rules.json
+++ b/test/fixtures/results/quickstart/nist_config_rules.json
@@ -44,7 +44,7 @@
                 "LineNumber": 94
             }
         },
-        "Message": "Deprecated runtime (nodejs) specified. Updating disabled since 2016-10-31. Please consider updating to nodejs14.x",
+        "Message": "Deprecated runtime (nodejs) specified. Updating disabled since 2016-10-31. Please consider updating to nodejs16.x",
         "Rule": {
             "Description": "Check if an EOL Lambda Runtime is specified and give an error if used. ",
             "Id": "E2531",
@@ -124,7 +124,7 @@
                 "LineNumber": 159
             }
         },
-        "Message": "Deprecated runtime (nodejs) specified. Updating disabled since 2016-10-31. Please consider updating to nodejs14.x",
+        "Message": "Deprecated runtime (nodejs) specified. Updating disabled since 2016-10-31. Please consider updating to nodejs16.x",
         "Rule": {
             "Description": "Check if an EOL Lambda Runtime is specified and give an error if used. ",
             "Id": "E2531",

--- a/test/integration/test_good_templates.py
+++ b/test/integration/test_good_templates.py
@@ -139,7 +139,7 @@ class TestQuickStartTemplates(BaseCliTestCase):
                             "LineNumber": 10
                         }
                     },
-                    "Message": "Deprecated runtime (nodejs6.10) specified. Updating disabled since 2019-08-12. Please consider updating to nodejs14.x",
+                    "Message": "Deprecated runtime (nodejs6.10) specified. Updating disabled since 2019-08-12. Please consider updating to nodejs16.x",
                     "Rule": {
                         "Description": "Check if an EOL Lambda Runtime is specified and give an error if used. ",
                         "Id": "E2531",


### PR DESCRIPTION
https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html#runtime-support-policy
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-runtime

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

---

maybe we should also have an informational rule a bit before either of the deprecation phases 🤔 