### PR TITLE
test formatters and create used rules

### DIFF
--- a/src/cfnlint/__main__.py
+++ b/src/cfnlint/__main__.py
@@ -25,7 +25,7 @@ def main():
     try:
         (args, filenames, formatter) = cfnlint.core.get_args_filenames(sys.argv[1:])
         matches = list(cfnlint.core.get_matches(filenames, args))
-        (_, rules, _) = cfnlint.core.get_template_rules(filenames[-1], args)
+        rules = cfnlint.core.get_used_rules()
         matches_output = formatter.print_matches(matches, rules, filenames)
 
         if matches_output:

--- a/src/cfnlint/core.py
+++ b/src/cfnlint/core.py
@@ -188,7 +188,8 @@ def get_used_rules():
     return __CACHED_RULES
 
 def _reset_rule_cache():
-    global __CACHED_RULES
+    """ Reset the rule cache. Used mostly for testing"""
+    global __CACHED_RULES #pylint: disable=global-statement
     __CACHED_RULES = None
 
 def get_template_rules(filename, args):

--- a/src/cfnlint/core.py
+++ b/src/cfnlint/core.py
@@ -184,6 +184,13 @@ def get_args_filenames(cli_args):
     return(config, config.templates, formatter)
 
 
+def get_used_rules():
+    return __CACHED_RULES
+
+def _reset_rule_cache():
+    global __CACHED_RULES
+    __CACHED_RULES = None
+
 def get_template_rules(filename, args):
     """ Get Template Configuration items and set them as default values"""
     global __CACHED_RULES  #pylint: disable=global-statement

--- a/src/cfnlint/formatters/__init__.py
+++ b/src/cfnlint/formatters/__init__.py
@@ -95,7 +95,7 @@ class JUnitFormatter(BaseFormatter):
 
         test_cases = []
         for rule in rules.all_rules:
-            if not rules.is_rule_enabled(rule):
+            if not rule.id in rules.used_rules:
                 if not rule.id:
                     continue
                 test_case = TestCase(name='{0} {1}'.format(rule.id, rule.shortdesc))
@@ -215,7 +215,7 @@ class PrettyFormatter(BaseFormatter):
 
         results.append('Cfn-lint scanned {} templates against {} rules and found {} errors, {} warnings, and {} informational violations'.format(
             colored(len(filenames), color.bold_reset),
-            colored(len(rules), color.bold_reset),
+            colored(len(rules.used_rules), color.bold_reset),
             colored(len([i for i in matches if i.rule.severity.lower() == 'error']), color.error),
             colored(len([i for i in matches if i.rule.severity.lower() == 'warning']), color.warning),
             colored(len([i for i in matches if i.rule.severity.lower()

--- a/src/cfnlint/rules/__init__.py
+++ b/src/cfnlint/rules/__init__.py
@@ -185,6 +185,7 @@ class RulesCollection(object):
     def __init__(self, ignore_rules=None, include_rules=None, configure_rules=None, include_experimental=False, mandatory_rules=None):
         self.rules = []
         self.all_rules = []
+        self.used_rules = set()
 
         self.configure(
             ignore_rules=ignore_rules,
@@ -217,6 +218,7 @@ class RulesCollection(object):
     def __register(self, rule):
         """ Register and configure the rule """
         if self.is_rule_enabled(rule):
+            self.used_rules.add(rule.id)
             self.rules.append(rule)
             if rule.id in self.configure_rules:
                 rule.configure(self.configure_rules[rule.id])

--- a/src/cfnlint/rules/__init__.py
+++ b/src/cfnlint/rules/__init__.py
@@ -179,6 +179,7 @@ class CloudFormationLintRule(object):
         return self.match_resource_sub_properties(resource_properties, property_type, path, cfn)  # pylint: disable=E1102
 
 
+#pylint: disable=too-many-instance-attributes
 class RulesCollection(object):
     """Collection of rules"""
 

--- a/test/fixtures/templates/good/core/config_only_i1002.yaml
+++ b/test/fixtures/templates/good/core/config_only_i1002.yaml
@@ -1,0 +1,8 @@
+---
+AWSTemplateFormatVersion: "2010-09-09"
+Metadata:
+  cfn-lint:
+    config:
+      ignore_checks: ['W', 'E']
+      include_checks: ['I1002']
+Resources: {}

--- a/test/fixtures/templates/good/core/config_only_i1003.yaml
+++ b/test/fixtures/templates/good/core/config_only_i1003.yaml
@@ -1,0 +1,8 @@
+---
+AWSTemplateFormatVersion: "2010-09-09"
+Metadata:
+  cfn-lint:
+    config:
+      ignore_checks: ['W', 'E']
+      include_checks: ['I1003']
+Resources: {}

--- a/test/integration/test_formatters.py
+++ b/test/integration/test_formatters.py
@@ -1,0 +1,29 @@
+"""
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+"""
+import subprocess
+from test.integration import BaseCliTestCase
+
+
+class TestFormatters(BaseCliTestCase):
+    '''Test Formatters '''
+
+    def test_junit(self):
+        '''Test JUnit formatting'''
+        result = subprocess.check_output(['cfn-lint', '--format', 'junit', '--', 'test/fixtures/templates/good/core/config_only_*.yaml'])
+
+        if isinstance(result, bytes):
+            result = result.decode('utf8')
+        
+        self.assertIn('<testcase name="I1002 Template size limit" url="https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-limits.html"/>', result)
+        self.assertIn('<testcase name="I1003 Template description limit" url="https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-limits.html"/>', result)
+
+    def test_pretty(self):
+        '''Test pretty formatting'''
+        result = subprocess.check_output(['cfn-lint', '--format', 'pretty', '--', 'test/fixtures/templates/good/core/config_only_*.yaml'])
+
+        if isinstance(result, bytes):
+            result = result.decode('utf8')
+        
+        self.assertEqual("Cfn-lint scanned 2 templates against 2 rules and found 0 errors, 0 warnings, and 0 informational violations\n", result)

--- a/test/integration/test_formatters.py
+++ b/test/integration/test_formatters.py
@@ -11,19 +11,23 @@ class TestFormatters(BaseCliTestCase):
 
     def test_junit(self):
         '''Test JUnit formatting'''
-        result = subprocess.check_output(['cfn-lint', '--format', 'junit', '--', 'test/fixtures/templates/good/core/config_only_*.yaml'])
+        result = subprocess.check_output(
+            ['cfn-lint', '--format', 'junit', '--', 'test/fixtures/templates/good/core/config_only_*.yaml'])
 
         if isinstance(result, bytes):
             result = result.decode('utf8')
-        
-        self.assertIn('<testcase name="I1002 Template size limit" url="https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-limits.html"/>', result)
+
+        self.assertIn(
+            '<testcase name="I1002 Template size limit" url="https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-limits.html"/>', result)
         self.assertIn('<testcase name="I1003 Template description limit" url="https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-limits.html"/>', result)
 
     def test_pretty(self):
         '''Test pretty formatting'''
-        result = subprocess.check_output(['cfn-lint', '--format', 'pretty', '--', 'test/fixtures/templates/good/core/config_only_*.yaml'])
+        result = subprocess.check_output(
+            ['cfn-lint', '--format', 'pretty', '--', 'test/fixtures/templates/good/core/config_only_*.yaml'])
 
         if isinstance(result, bytes):
             result = result.decode('utf8')
-        
-        self.assertEqual("Cfn-lint scanned 2 templates against 2 rules and found 0 errors, 0 warnings, and 0 informational violations\n", result)
+
+        self.assertEqual(
+            "Cfn-lint scanned 2 templates against 2 rules and found 0 errors, 0 warnings, and 0 informational violations\n", result)

--- a/test/integration/test_formatters.py
+++ b/test/integration/test_formatters.py
@@ -30,4 +30,4 @@ class TestFormatters(BaseCliTestCase):
             result = result.decode('utf8')
 
         self.assertEqual(
-            "Cfn-lint scanned 2 templates against 2 rules and found 0 errors, 0 warnings, and 0 informational violations\n", result)
+            "Cfn-lint scanned 2 templates against 2 rules and found 0 errors, 0 warnings, and 0 informational violations", result.strip())

--- a/test/unit/module/formatters/test_formatters.py
+++ b/test/unit/module/formatters/test_formatters.py
@@ -11,6 +11,7 @@ import jsonschema
 import cfnlint.formatters
 import cfnlint.helpers
 
+
 class TestFormatters(BaseTestCase):
     """Test Formatters """
 
@@ -76,7 +77,6 @@ class TestFormatters(BaseTestCase):
         # The actual test
         self.assertIsNone(formatter.print_matches([], []))
 
-
     def test_junit_formatter(self):
         """Test JUnit Formatter"""
 
@@ -103,7 +103,8 @@ class TestFormatters(BaseTestCase):
         self.assertEqual(results[1].rule.id, 'W1020')
         self.assertEqual(results[2].rule.id, 'E3012')
 
-        root = ET.fromstring(formatter.print_matches(results, cfnlint.core.get_used_rules()))
+        root = ET.fromstring(formatter.print_matches(
+            results, cfnlint.core.get_used_rules()))
 
         self.assertEqual(root.tag, 'testsuites')
         self.assertEqual(root[0].tag, 'testsuite')
@@ -111,9 +112,12 @@ class TestFormatters(BaseTestCase):
         found_i3011 = False
         found_w1020 = False
         found_e3012 = False
-        name_i3011 = '{0} {1}'.format(results[0].rule.id, results[0].rule.shortdesc)
-        name_w1020 = '{0} {1}'.format(results[1].rule.id, results[1].rule.shortdesc)
-        name_e3012 = '{0} {1}'.format(results[2].rule.id, results[2].rule.shortdesc)
+        name_i3011 = '{0} {1}'.format(
+            results[0].rule.id, results[0].rule.shortdesc)
+        name_w1020 = '{0} {1}'.format(
+            results[1].rule.id, results[1].rule.shortdesc)
+        name_e3012 = '{0} {1}'.format(
+            results[2].rule.id, results[2].rule.shortdesc)
         name_e1029 = 'E1029 Sub is required if a variable is used in a string'
         for child in root[0]:
             self.assertEqual(child.tag, 'testcase')
@@ -129,8 +133,6 @@ class TestFormatters(BaseTestCase):
                     found_e3012 = True
 
             if child.attrib['name'] == name_e1029:
-                print(len(child))
-                print(type(child[0]))
                 self.assertEqual(child[0].tag, 'skipped')
                 self.assertEqual(child[0].attrib['type'], 'skipped')
 
@@ -144,7 +146,7 @@ class TestFormatters(BaseTestCase):
         # Run a broken template
         filename = 'test/fixtures/templates/bad/formatters.yaml'
         (args, filenames, formatter) = cfnlint.core.get_args_filenames([
-            '--template', filename, '--format', 'sarif', '--include-checks', 'I', '--ignore-checks', 'E1029'])
+            '--template', filename, '--format', 'sarif', '--include-checks', 'I', '--ignore-checks', 'E1029', '--configure-rule', 'E3012:strict=true'])
 
         results = []
         rules = None
@@ -168,7 +170,8 @@ class TestFormatters(BaseTestCase):
         sarif = json.loads(formatter.print_matches(results, rules))
 
         # Fetch the SARIF schema
-        schema = json.loads(cfnlint.helpers.get_url_content(sarif['$schema'], False))
+        schema = json.loads(
+            cfnlint.helpers.get_url_content(sarif['$schema'], False))
         jsonschema.validate(sarif, schema)
 
         sarif_results = sarif['runs'][0]['results']

--- a/test/unit/module/formatters/test_formatters.py
+++ b/test/unit/module/formatters/test_formatters.py
@@ -11,9 +11,12 @@ import jsonschema
 import cfnlint.formatters
 import cfnlint.helpers
 
-
 class TestFormatters(BaseTestCase):
     """Test Formatters """
+
+    def setUp(self) -> None:
+        super().setUp()
+        cfnlint.core._reset_rule_cache()
 
     def test_json_formatter(self):
         """Test JSON formatter"""
@@ -57,7 +60,7 @@ class TestFormatters(BaseTestCase):
         # Test setup
         filename = 'test/fixtures/templates/bad/formatters.yaml'
         (args, filenames, formatter) = cfnlint.core.get_args_filenames([
-            '--template', filename, '--format', 'junit', '--include-checks', 'I', '--ignore-checks', 'E1029'])
+            '--template', filename, '--format', 'junit', '--include-checks', 'I', '--ignore-checks', 'E1029', '--configure-rule', 'E3012:strict=true'])
 
         results = []
         rules = None
@@ -80,7 +83,7 @@ class TestFormatters(BaseTestCase):
         # Run a broken template
         filename = 'test/fixtures/templates/bad/formatters.yaml'
         (args, filenames, formatter) = cfnlint.core.get_args_filenames([
-            '--template', filename, '--format', 'junit', '--include-checks', 'I', '--ignore-checks', 'E1029'])
+            '--template', filename, '--format', 'junit', '--include-checks', 'I', '--ignore-checks', 'E1029', '--configure-rule', 'E3012:strict=true'])
 
         results = []
         rules = None
@@ -100,7 +103,7 @@ class TestFormatters(BaseTestCase):
         self.assertEqual(results[1].rule.id, 'W1020')
         self.assertEqual(results[2].rule.id, 'E3012')
 
-        root = ET.fromstring(formatter.print_matches(results, rules))
+        root = ET.fromstring(formatter.print_matches(results, cfnlint.core.get_used_rules()))
 
         self.assertEqual(root.tag, 'testsuites')
         self.assertEqual(root[0].tag, 'testsuite')
@@ -126,6 +129,8 @@ class TestFormatters(BaseTestCase):
                     found_e3012 = True
 
             if child.attrib['name'] == name_e1029:
+                print(len(child))
+                print(type(child[0]))
                 self.assertEqual(child[0].tag, 'skipped')
                 self.assertEqual(child[0].attrib['type'], 'skipped')
 


### PR DESCRIPTION
*Issue #, if available:*
#1930 

*Description of changes:* This adds some tests for formatters that make use of the `rules` argument.

They are currently failing because I believe the current code to be incorrect. It only uses the rules from the last template that is checked.

Replacing PR #1929

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
