### PR TITLE
Create force flag to be used with update-specs

### DIFF
--- a/src/cfnlint/config.py
+++ b/src/cfnlint/config.py
@@ -427,6 +427,10 @@ class CliArgs(object):
             '--merge-configs', default=False, action='store_true',
             help='Merges lists between configuration layers'
         )
+        advanced.add_argument(
+            '--force', help=argparse.SUPPRESS,
+            action='store_true'
+        )
 
         return parser
 
@@ -667,3 +671,7 @@ class ConfigMixIn(TemplateArgs, CliArgs, ConfigFileArgs, object):
     @property
     def merge_configs(self):
         return self._get_argument_value('merge_configs', True, True)
+
+    @property
+    def force(self):
+        return self._get_argument_value('force', False, False)

--- a/src/cfnlint/core.py
+++ b/src/cfnlint/core.py
@@ -149,7 +149,7 @@ def get_args_filenames(cli_args):
     formatter = get_formatter(fmt)
 
     if config.update_specs:
-        cfnlint.maintenance.update_resource_specs()
+        cfnlint.maintenance.update_resource_specs(config.force)
         sys.exit(0)
 
     if config.update_documentation:

--- a/test/unit/module/config/test_cli_args.py
+++ b/test/unit/module/config/test_cli_args.py
@@ -50,6 +50,13 @@ class TestArgsParser(BaseTestCase):
         config = cfnlint.config.CliArgs(['-t', 'template1.yaml', '--output-file', 'test_output.txt'])
         self.assertEqual(config.cli_args.output_file, 'test_output.txt')
 
+    def test_force_update_specs(self):
+        """Test success run"""
+
+        config = cfnlint.config.CliArgs(['--update-specs', '--force'])
+        self.assertEqual(config.cli_args.force, True)
+        self.assertEqual(config.cli_args.update_specs, True)
+
     def test_create_parser_exend(self):
         """Test success run"""
 
@@ -57,7 +64,7 @@ class TestArgsParser(BaseTestCase):
         self.assertEqual(config.cli_args.templates, [])
         self.assertEqual(config.cli_args.template_alt, ['template1.yaml', 'template2.yaml'])
 
-    def test_create_parser_config_file(self):
+    def test_create_parser_config_file_regions(self):
         """Test success run"""
 
         config = cfnlint.config.CliArgs(

--- a/test/unit/module/config/test_config_mixin.py
+++ b/test/unit/module/config/test_config_mixin.py
@@ -116,6 +116,20 @@ class TestConfigMixIn(BaseTestCase):
         self.assertEqual(config.regions, REGIONS)
 
     @patch('cfnlint.config.ConfigFileArgs._read_config', create=True)
+    def test_config_force_with_update_specs(self, yaml_mock):
+        """ Test precedence in  """
+
+        yaml_mock.side_effect = [
+            {},
+            {}
+        ]
+        config = cfnlint.config.ConfigMixIn(['--update-specs', '--force'])
+
+        # test defaults
+        self.assertEqual(config.force, True)
+        self.assertEqual(config.update_specs, True)
+
+    @patch('cfnlint.config.ConfigFileArgs._read_config', create=True)
     def test_config_expand_paths(self, yaml_mock):
         """ Test precedence in  """
 

--- a/test/unit/module/maintenance/test_update_resource_specs.py
+++ b/test/unit/module/maintenance/test_update_resource_specs.py
@@ -19,6 +19,77 @@ LOGGER.addHandler(logging.NullHandler())
 
 class TestUpdateResourceSpecs(BaseTestCase):
     """Used for Testing Resource Specs"""
+
+    side_effect = [
+        {
+            'PropertyTypes': {
+                'AWS::Lambda::CodeSigningConfig.AllowedPublishers': {
+                    'Properties': {
+                        'SigningProfileVersionArns': {},
+                    }
+                },
+                'AWS::Lambda::CodeSigningConfig.CodeSigningPolicies': {
+                    'Properties': {
+                        'UntrustedArtifactOnDeployment': {},
+                    }
+                },
+            },
+            'ResourceTypes': {
+                'AWS::Lambda::CodeSigningConfig': {
+                    'Attributes': {
+                        'CodeSigningConfigArn': {
+                            'PrimitiveType': 'String',
+                        },
+                        'CodeSigningConfigId': {
+                            'PrimitiveType': 'String',
+                        }
+                    },
+                    'Properties': {
+                        'AllowedPublishers': {},
+                        'CodeSigningPolicies': {},
+                        'Description': {},
+                    }
+                }
+            },
+            'ValueTypes': {}
+        },
+        {
+            'PropertyTypes': {
+                'AWS::Lambda::CodeSigningConfig.AllowedPublishers': {
+                    'Properties': {
+                        'SigningProfileVersionArns': {},
+                    }
+                },
+                'AWS::Lambda::CodeSigningConfig.CodeSigningPolicies': {
+                    'Properties': {
+                        'UntrustedArtifactOnDeployment': {},
+                    }
+                },
+            },
+            'ResourceTypes': {
+                'AWS::Lambda::CodeSigningConfig': {
+                    'Attributes': {
+                        'CodeSigningConfigArn': {
+                            'PrimitiveType': 'String',
+                        },
+                        'CodeSigningConfigId': {
+                            'PrimitiveType': 'String',
+                        }
+                    },
+                    'Properties': {
+                        'AllowedPublishers': {},
+                        'CodeSigningPolicies': {},
+                        'Description': {},
+                    }
+                }
+            },
+            'ValueTypes': {
+                'AWS::EC2::Instance.Types': [
+                    'm2.medium'],
+            }
+        },
+    ]
+
     @patch('cfnlint.maintenance.url_has_newer_version')
     @patch('cfnlint.maintenance.get_url_content')
     @patch('cfnlint.maintenance.json.dump')
@@ -30,75 +101,7 @@ class TestUpdateResourceSpecs(BaseTestCase):
 
         mock_url_newer_version.return_value = True
         mock_content.return_value = '{"PropertyTypes": {}, "ResourceTypes": {}}'
-        mock_patch_spec.side_effect = [
-            {
-                'PropertyTypes': {
-                    'AWS::Lambda::CodeSigningConfig.AllowedPublishers': {
-                        'Properties': {
-                            'SigningProfileVersionArns': {},
-                        }
-                    },
-                    'AWS::Lambda::CodeSigningConfig.CodeSigningPolicies': {
-                        'Properties': {
-                            'UntrustedArtifactOnDeployment': {},
-                        }
-                    },
-                },
-                'ResourceTypes': {
-                    'AWS::Lambda::CodeSigningConfig': {
-                        'Attributes': {
-                            'CodeSigningConfigArn': {
-                                'PrimitiveType': 'String',
-                            },
-                            'CodeSigningConfigId': {
-                                'PrimitiveType': 'String',
-                            }
-                        },
-                        'Properties': {
-                            'AllowedPublishers': {},
-                            'CodeSigningPolicies': {},
-                            'Description': {},
-                        }
-                    }
-                },
-                'ValueTypes': {}
-            },
-            {
-                'PropertyTypes': {
-                    'AWS::Lambda::CodeSigningConfig.AllowedPublishers': {
-                        'Properties': {
-                            'SigningProfileVersionArns': {},
-                        }
-                    },
-                    'AWS::Lambda::CodeSigningConfig.CodeSigningPolicies': {
-                        'Properties': {
-                            'UntrustedArtifactOnDeployment': {},
-                        }
-                    },
-                },
-                'ResourceTypes': {
-                    'AWS::Lambda::CodeSigningConfig': {
-                        'Attributes': {
-                            'CodeSigningConfigArn': {
-                                'PrimitiveType': 'String',
-                            },
-                            'CodeSigningConfigId': {
-                                'PrimitiveType': 'String',
-                            }
-                        },
-                        'Properties': {
-                            'AllowedPublishers': {},
-                            'CodeSigningPolicies': {},
-                            'Description': {},
-                        }
-                    }
-                },
-                'ValueTypes': {
-                    'AWS::EC2::Instance.Types': [
-                        'm2.medium'],
-                }
-            },
-        ]
+        mock_patch_spec.side_effect = self.side_effect
 
         mock_urlresponse = Mock()
         with open("test/fixtures/registry/schema.zip", 'rb') as f:
@@ -114,7 +117,8 @@ class TestUpdateResourceSpecs(BaseTestCase):
             builtin_module_name = '__builtin__'
 
         with patch('{}.open'.format(builtin_module_name)) as mock_builtin_open:
-            cfnlint.maintenance.update_resource_spec('us-east-1', 'http://foo.badurl', schema_cache)
+            cfnlint.maintenance.update_resource_spec(
+                'us-east-1', 'http://foo.badurl', schema_cache)
             mock_json_dump.assert_called_with(
                 {
                     'PropertyTypes': {
@@ -131,7 +135,7 @@ class TestUpdateResourceSpecs(BaseTestCase):
                             'Properties': {
                                 'UntrustedArtifactOnDeployment': {
                                     'Value': {
-                                         'ValueType': 'AWS::Lambda::CodeSigningConfig.CodeSigningPolicies.UntrustedArtifactOnDeployment',
+                                        'ValueType': 'AWS::Lambda::CodeSigningConfig.CodeSigningPolicies.UntrustedArtifactOnDeployment',
                                     }
                                 },
                             }
@@ -184,11 +188,45 @@ class TestUpdateResourceSpecs(BaseTestCase):
 
         mock_url_newer_version.return_value = False
 
-        result = cfnlint.maintenance.update_resource_spec('us-east-1', 'http://foo.badurl', ANY)
+        result = cfnlint.maintenance.update_resource_spec(
+            'us-east-1', 'http://foo.badurl', ANY)
         self.assertIsNone(result)
         mock_content.assert_not_called()
         mock_patch_spec.assert_not_called()
         mock_json_dump.assert_not_called()
+
+    @patch('cfnlint.maintenance.url_has_newer_version')
+    @patch('cfnlint.maintenance.get_url_content')
+    @patch('cfnlint.maintenance.json.dump')
+    @patch('cfnlint.maintenance.patch_spec')
+    @patch('cfnlint.maintenance.SPEC_REGIONS', {'us-east-1': 'http://foo.badurl'})
+    @patch('cfnlint.maintenance.urlopen')
+    def test_update_resource_spec_force(self, mock_urlopen, mock_patch_spec, mock_json_dump, mock_content, mock_url_newer_version):
+        """Success update resource spec"""
+
+        mock_url_newer_version.return_value = False
+        mock_content.return_value = '{"PropertyTypes": {}, "ResourceTypes": {}}'
+        mock_patch_spec.side_effect = self.side_effect
+
+        mock_urlresponse = Mock()
+        with open("test/fixtures/registry/schema.zip", 'rb') as f:
+            byte = f.read()
+            mock_urlresponse.read.side_effect = [byte]
+            mock_urlopen.return_value = mock_urlresponse
+
+        schema_cache = cfnlint.maintenance.get_schema_value_types()
+
+        if sys.version_info.major == 3:
+            builtin_module_name = 'builtins'
+        else:
+            builtin_module_name = '__builtin__'
+
+        with patch('{}.open'.format(builtin_module_name)) as mock_builtin_open:
+            cfnlint.maintenance.update_resource_spec(
+                'us-east-1', 'http://foo.badurl', schema_cache, True)
+            mock_content.assert_called_once()
+            mock_patch_spec.assert_called()
+            mock_json_dump.assert_called_once()
 
     @patch('cfnlint.maintenance.multiprocessing.Pool')
     @patch('cfnlint.maintenance.update_resource_spec')
@@ -208,8 +246,10 @@ class TestUpdateResourceSpecs(BaseTestCase):
     def test_update_resource_specs_python_2(self, mock_update_resource_spec, mock_pool):
 
         fake_pool = MagicMock()
-        mock_pool.return_value.__enter__.return_value = AttributeError('foobar')
+        mock_pool.return_value.__enter__.return_value = AttributeError(
+            'foobar')
 
         cfnlint.maintenance.update_resource_specs()
 
-        mock_update_resource_spec.assert_called_once_with('us-east-1', 'http://foo.badurl', ANY)
+        mock_update_resource_spec.assert_called_once_with(
+            'us-east-1', 'http://foo.badurl', ANY, False)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Add `--force` flag for `--update-specs` to force update even if specs haven't updated

replace #1554 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
