### PR TITLE
Fix an issues with me-central-1 not being a module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### v0.64.1
+###### Fixes
+- Make `me-central-1` `ExtendedSpecs` a module (pull #[2350](https://github.com/aws-cloudformation/cfn-lint/pull/2350))
+
 ### v0.64.0
 ###### Features
 - Update `jsonschema` to be able to use version 3.0 and 4.0 (pull #[2336](https://github.com/aws-cloudformation/cfn-lint/pull/2336))

--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ If you'd like cfn-lint to be run automatically when making changes to files in y
 ```yaml
 repos:
 - repo: https://github.com/aws-cloudformation/cfn-python-lint
-  rev: v0.64.0  # The version of cfn-lint to use
+  rev: v0.64.1  # The version of cfn-lint to use
   hooks:
     - id: cfn-python-lint
       files: path/to/cfn/dir/.*\.(json|yml|yaml)$

--- a/src/cfnlint/version.py
+++ b/src/cfnlint/version.py
@@ -3,4 +3,4 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 
-__version__ = '0.64.0'
+__version__ = '0.64.1'


### PR DESCRIPTION
*Issue #, if available:*
fix #2358

*Description of changes:*
- Fix an issue with `me-central-1` in ExtendedSpecs isn't a module
- Release v0.64.1

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
