### PR TITLE
Support Python 3.10

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,7 @@ Tox test suites available:
 * **py37**: Unit tests (Python 3.7)
 * **py38**: Unit tests (Python 3.8)
 * **py39**: Unit tests (Python 3.9)
+* **py310**: Unit tests (Python 3.10)
 * **pylint**: Python syntax check
 
 ## Contributing via Pull Requests

--- a/setup.py
+++ b/setup.py
@@ -70,5 +70,6 @@ that could potentially be improved'),
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{37,38,39},pylint
+envlist = py{37,38,39,310},pylint
 
 [testenv]
 commands =


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

I updated the same config files as affected by #2347 to run the tests on Python 3.10 and reflect support. I ran the test suite locally and saw no warnings from Python 3.10.

It looks like #2328 added Python 3.10 to the test matrix on GitHub Actions but didn't do the other updates.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
