### PR TITLE
Add PredictiveScaling to AWS::AutoScaling::ScalingPolicy.PolicyType

### DIFF
--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_autoscaling.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_autoscaling.json
@@ -56,6 +56,7 @@
     "path": "/ValueTypes/AWS::AutoScaling::ScalingPolicy.PolicyType",
     "value": {
       "AllowedValues": [
+        "PredictiveScaling",
         "SimpleScaling",
         "StepScaling",
         "TargetTrackingScaling"


### PR DESCRIPTION
*Issue #, if available:*
fix #2378

*Description of changes:*
- Add `PredictiveScaling` to `AWS::AutoScaling::ScalingPolicy.PolicyType`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
