### PR TITLE
Add support to nest rules

### DIFF
--- a/src/cfnlint/exceptions.py
+++ b/src/cfnlint/exceptions.py
@@ -1,0 +1,23 @@
+
+
+class CfnLintError(Exception):
+    """
+    The base exception class for cfn-lint exceptions.
+    :ivar msg: The descriptive message associated with the error.
+    """
+
+    fmt = 'An unspecified error occurred'
+
+    def __init__(self, **kwargs):
+        msg = self.fmt.format(**kwargs)
+        Exception.__init__(self, msg)
+        self.kwargs = kwargs
+
+
+class DuplicateRuleError(CfnLintError):
+    """
+    The data associated with a particular path could not be loaded.
+    :ivar data_path: The data path that the user attempted to load.
+    """
+
+    fmt = 'Rule already included: {rule_id}'

--- a/src/cfnlint/formatters/__init__.py
+++ b/src/cfnlint/formatters/__init__.py
@@ -97,7 +97,7 @@ class JUnitFormatter(BaseFormatter):
             return None
 
         test_cases = []
-        for rule in rules.all_rules:
+        for rule in rules.all_rules.values():
             if not rule.id in rules.used_rules:
                 if not rule.id:
                     continue

--- a/src/cfnlint/rules/__init__.py
+++ b/src/cfnlint/rules/__init__.py
@@ -7,7 +7,7 @@ import logging
 from datetime import datetime
 import importlib
 import traceback
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 import cfnlint.helpers
 import cfnlint.rules.custom
 from cfnlint.decode.node import TemplateAttributeError
@@ -45,17 +45,20 @@ def matching(match_type):
 
             if results:
                 for result in results:
+                    error_rule = self
+                    if hasattr(result, 'rule'):
+                        error_rule = result.rule
                     linenumbers = cfn.get_location_yaml(cfn.template, result.path)
                     if linenumbers:
                         matches.append(Match(
                             linenumbers[0] + 1, linenumbers[1] + 1,
                             linenumbers[2] + 1, linenumbers[3] + 1,
-                            filename, self, result.message, result))
+                            filename, error_rule, result.message, result))
                     else:
                         matches.append(Match(
                             1, 1,
                             1, 1,
-                            filename, self, result.message, result))
+                            filename, error_rule, result.message, result))
 
             return matches
         return wrapper
@@ -63,12 +66,13 @@ def matching(match_type):
 
 class CloudFormationLintRule(object):
     """CloudFormation linter rules"""
-    id = ''
-    shortdesc = ''
-    description = ''
-    source_url = ''
+    id: str = ''
+    shortdesc: str = ''
+    description: str = ''
+    source_url: str = ''
     tags: List[str] = []
-    experimental = False
+    experimental: bool = False
+    child_rules: Dict[str, Any] = {}
 
     logger = logging.getLogger(__name__)
 
@@ -184,8 +188,8 @@ class RulesCollection(object):
     """Collection of rules"""
 
     def __init__(self, ignore_rules=None, include_rules=None, configure_rules=None, include_experimental=False, mandatory_rules=None):
-        self.rules = []
-        self.all_rules = []
+        self.rules: Dict[str, CloudFormationLintRule] = {}
+        self.all_rules: Dict[str, CloudFormationLintRule] = {}
         self.used_rules = set()
 
         self.configure(
@@ -197,7 +201,7 @@ class RulesCollection(object):
             )
 
     def configure(self, ignore_rules=None, include_rules=None, configure_rules=None, include_experimental=False, mandatory_rules=None):
-        self.rules = []
+        self.rules: Dict[str, CloudFormationLintRule] = {}
         # Whether "experimental" rules should be added
         self.include_experimental = include_experimental
 
@@ -213,26 +217,26 @@ class RulesCollection(object):
             if default_rule not in self.include_rules:
                 self.include_rules.extend([default_rule])
 
-        for rule in self.all_rules:
+        for rule in self.all_rules.values():
             self.__register(rule)
 
-    def __register(self, rule):
+    def __register(self, rule: CloudFormationLintRule):
         """ Register and configure the rule """
         if self.is_rule_enabled(rule):
             self.used_rules.add(rule.id)
-            self.rules.append(rule)
+            self.rules[rule.id] = rule
             rule.configure(self.configure_rules.get(rule.id, None))
 
-    def register(self, rule):
+    def register(self, rule: CloudFormationLintRule):
         """Register rules"""
-        self.all_rules.append(rule)
+        self.all_rules[rule.id] = rule
         self.__register(rule)
 
     def __iter__(self):
-        return iter(self.rules)
+        return iter(self.rules.values())
 
     def __len__(self):
-        return len(self.rules)
+        return len(self.rules.keys())
 
     def extend(self, more):
         """Extend rules"""
@@ -243,7 +247,7 @@ class RulesCollection(object):
         return '\n'.join([rule.verbose()
                           for rule in sorted(self.rules, key=lambda x: x.id)])
 
-    def is_rule_enabled(self, rule):
+    def is_rule_enabled(self, rule: CloudFormationLintRule):
         """ Checks if an individual rule is valid """
         return rule.is_enabled(self.include_experimental, self.ignore_rules,
                                self.include_rules, self.mandatory_rules)
@@ -279,7 +283,7 @@ class RulesCollection(object):
             property_spec_name = '%s.%s' % (resource_type, property_type)
 
         if property_spec_name in property_spec:
-            for rule in self.rules:
+            for rule in self.rules.values():
                 if isinstance(properties, dict):
                     if len(properties) == 1:
                         for k, _ in properties.items():
@@ -391,10 +395,14 @@ class RulesCollection(object):
     def run(self, filename: Optional[str], cfn: Template):
         """Run rules"""
         matches = []
-        for rule in self.rules:
+        for rule in self.rules.values():
             rule.initialize(cfn)
 
-        for rule in self.rules:
+        for rule in self.rules.values():
+            for key in rule.child_rules.keys():
+                rule.child_rules[key] = self.rules.get(key)
+
+        for rule in self.rules.values():
             matches.extend(
                 self.run_check(
                     rule.matchall, filename, rule.id, filename, cfn
@@ -406,7 +414,7 @@ class RulesCollection(object):
             resource_properties = resource_attributes.get('Properties')
             if isinstance(resource_type, str) and isinstance(resource_properties, dict):
                 path = ['Resources', resource_name, 'Properties']
-                for rule in self.rules:
+                for rule in self.rules.values():
                     matches.extend(
                         self.run_check(
                             rule.matchall_resource_properties, filename, rule.id,

--- a/src/cfnlint/rules/__init__.py
+++ b/src/cfnlint/rules/__init__.py
@@ -8,6 +8,7 @@ from datetime import datetime
 import importlib
 import traceback
 from typing import Any, Dict, List, Optional
+from cfnlint.exceptions import DuplicateRuleError
 import cfnlint.helpers
 import cfnlint.rules.custom
 from cfnlint.decode.node import TemplateAttributeError
@@ -229,8 +230,13 @@ class RulesCollection(object):
 
     def register(self, rule: CloudFormationLintRule):
         """Register rules"""
-        self.all_rules[rule.id] = rule
-        self.__register(rule)
+        # Some rules are inheritited to limit code re-use.
+        # These rules have no rule ID so we filter this out
+        if rule.id != '':
+            if rule.id in self.all_rules:
+                raise DuplicateRuleError(rule_id=rule.id)
+            self.all_rules[rule.id] = rule
+            self.__register(rule)
 
     def __iter__(self):
         return iter(self.rules.values())

--- a/test/unit/module/rule/test_rule_child.py
+++ b/test/unit/module/rule/test_rule_child.py
@@ -1,0 +1,141 @@
+"""
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+"""
+from typing import Dict, Any
+from cfnlint.decode import decode_str
+from cfnlint.runner import Runner
+from test.testlib.testcase import BaseTestCase
+from cfnlint.rules import Match, RuleMatch, RulesCollection
+from cfnlint.rules import CloudFormationLintRule  # pylint: disable=E0401
+
+
+class TestCloudFormationRuleChild(BaseTestCase):
+    """Test CloudFormation Rule"""
+
+    def test_child_rules(self):
+        class TestRuleParent(CloudFormationLintRule):
+            """Def Rule"""
+
+            id = "E1000"
+            shortdesc = "Test Rule"
+            description = "Test Rule Description"
+            source_url = "https://github.com/aws-cloudformation/cfn-python-lint/"
+            tags = ["resources"]
+            child_rules: Dict[str, Any] = {"E1001": None}
+
+            def match(self, _):
+                return self.child_rules["E1001"].failure()
+
+        class TestRuleChild(CloudFormationLintRule):
+            """Def Rule"""
+
+            id = "E1001"
+            shortdesc = "Test Rule"
+            description = "Test Rule Description"
+            source_url = "https://github.com/aws-cloudformation/cfn-python-lint/"
+            tags = ["resources"]
+
+            def failure(self):
+                return [RuleMatch(["key"], "failure", rule=self)]
+
+        rule_collection = RulesCollection()
+        test_rule_parent = TestRuleParent()
+        test_rule_child = TestRuleChild()
+        rule_collection.register(test_rule_parent)
+        rule_collection.register(test_rule_child)
+
+        template, _ = decode_str('{"key": "value"}')
+        runner = Runner(rule_collection, None, template, ["us-east-1"], [])
+        failures = runner.run()
+
+        self.assertListEqual(
+            failures, [Match(1, 2, 1, 7, None, test_rule_child, "failure")]
+        )
+
+    def test_child_rules_suppressed(self):
+        class TestRuleParent(CloudFormationLintRule):
+            """Def Rule"""
+
+            id = "E1000"
+            shortdesc = "Test Rule"
+            description = "Test Rule Description"
+            source_url = "https://github.com/aws-cloudformation/cfn-python-lint/"
+            tags = ["resources"]
+            child_rules: Dict[str, Any] = {"E1001": None}
+
+            def match(self, _):
+                if self.child_rules.get("E1001"):
+                    return self.child_rules["E1001"].failure()
+                return []
+
+        class TestRuleChild(CloudFormationLintRule):
+            """Def Rule"""
+
+            id = "E1001"
+            shortdesc = "Test Rule"
+            description = "Test Rule Description"
+            source_url = "https://github.com/aws-cloudformation/cfn-python-lint/"
+            tags = ["resources"]
+
+            def failure(self):
+                return [RuleMatch(["key"], "failure", rule=self)]
+
+        rule_collection = RulesCollection(ignore_rules=["E1001"])
+        test_rule_parent = TestRuleParent()
+        test_rule_child = TestRuleChild()
+        rule_collection.register(test_rule_parent)
+        rule_collection.register(test_rule_child)
+
+        template, _ = decode_str('{"key": "value"}')
+        runner = Runner(rule_collection, None, template, ["us-east-1"], [])
+        failures = runner.run()
+
+        self.assertListEqual(failures, [])
+
+    def test_child_rules_configured(self):
+        class TestRuleParent(CloudFormationLintRule):
+            """Def Rule"""
+
+            id = "E1000"
+            shortdesc = "Test Rule"
+            description = "Test Rule Description"
+            source_url = "https://github.com/aws-cloudformation/cfn-python-lint/"
+            tags = ["resources"]
+            child_rules: Dict[str, Any] = {"E1001": None}
+
+            def match(self, _):
+                return self.child_rules["E1001"].failure()
+
+        class TestRuleChild(CloudFormationLintRule):
+            """Def Rule"""
+
+            id = "E1001"
+            shortdesc = "Test Rule"
+            description = "Test Rule Description"
+            source_url = "https://github.com/aws-cloudformation/cfn-python-lint/"
+            tags = ["resources"]
+
+            def __init__(self):
+                """Init"""
+                super(TestRuleChild, self).__init__()
+                self.config_definition = {"pass": {"default": True, "type": "boolean"}}
+                self.configure()
+
+            def failure(self):
+                if self.config["pass"]:
+                    return [RuleMatch(["key"], "failure", rule=self)]
+                return []
+
+        rule_collection = RulesCollection()
+        test_rule_parent = TestRuleParent()
+        test_rule_child = TestRuleChild()
+        rule_collection.register(test_rule_parent)
+        rule_collection.register(test_rule_child)
+        rule_collection.configure(configure_rules={"E1001": {"pass": False}})
+
+        template, _ = decode_str('{"key": "value"}')
+        runner = Runner(rule_collection, None, template, ["us-east-1"], [])
+        failures = runner.run()
+
+        self.assertListEqual(failures, [])

--- a/test/unit/module/test_rules_collections.py
+++ b/test/unit/module/test_rules_collections.py
@@ -2,6 +2,7 @@
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
+from cfnlint.exceptions import DuplicateRuleError
 from test.testlib.testcase import BaseTestCase
 from cfnlint.template import Template
 from cfnlint.rules import CloudFormationLintRule, RulesCollection
@@ -216,6 +217,19 @@ class TestRulesCollection(BaseTestCase):
         for rule in rules:
             self.assertIn(rule.id, ['E0000', 'E0002', 'W0000'])
 
+    def test_duplicate_rules(self):
+        """Test extend function"""
+        class rule0_e0000(CloudFormationLintRule):
+            """Error Rule"""
+            id = 'E0000'
+
+        class rule1_e0000(CloudFormationLintRule):
+            """Error Rule"""
+            id = 'E0000'
+
+        rules_to_add = [rule0_e0000(), rule1_e0000()]
+        rules = RulesCollection()
+        self.assertRaises(DuplicateRuleError, rules.extend, rules_to_add)
 
 class TestCreateFromModule(BaseTestCase):
     """Test loading a rules collection from a module"""

--- a/test/unit/rules/__init__.py
+++ b/test/unit/rules/__init__.py
@@ -29,13 +29,14 @@ class BaseRuleTestCase(BaseTestCase):
     def helper_file_rule_config(self, filename, config, err_count):
         """Success test with rule config included"""
         template = self.load_template(filename)
-        self.collection.rules[0].configure(config)
+        rule_id = list(self.collection.rules.keys())[0]
+        self.collection.rules[rule_id].configure(config)
         good_runner = Runner(self.collection, filename, template, ['us-east-1'], [])
         good_runner.transform()
         failures = good_runner.run()
         self.assertEqual(err_count, len(failures), 'Expected {} failures but got {} on {}'.format(
             err_count, failures, filename))
-        self.collection.rules[0].configure(config)
+        self.collection.rules[rule_id].configure(config)
 
     def helper_file_positive_template(self, filename):
         """Success test with template parameter"""

--- a/test/unit/rules/resources/lmbd/test_deprecated_runtime_end.py
+++ b/test/unit/rules/resources/lmbd/test_deprecated_runtime_end.py
@@ -13,8 +13,9 @@ class TestDeprecatedRuntimeEnd(BaseRuleTestCase):
     def setUp(self):
         """Setup"""
         super(TestDeprecatedRuntimeEnd, self).setUp()
-        self.collection.register(DeprecatedRuntimeEnd())
-        self.collection.rules[0].current_date = datetime(2019, 6, 29)
+        rule = DeprecatedRuntimeEnd()
+        self.collection.register(rule)
+        self.collection.rules[rule.id].current_date = datetime(2019, 6, 29)
 
     def test_file_positive(self):
         """Test Positive"""

--- a/test/unit/rules/resources/lmbd/test_deprecated_runtime_eol.py
+++ b/test/unit/rules/resources/lmbd/test_deprecated_runtime_eol.py
@@ -13,8 +13,9 @@ class TestDeprecatedRuntimeEol(BaseRuleTestCase):
     def setUp(self):
         """Setup"""
         super(TestDeprecatedRuntimeEol, self).setUp()
-        self.collection.register(DeprecatedRuntimeEol())
-        self.collection.rules[0].current_date = datetime(2019, 6, 29)
+        rule = DeprecatedRuntimeEol()
+        self.collection.register(rule)
+        self.collection.rules[rule.id].current_date = datetime(2019, 6, 29)
 
     def test_file_positive(self):
         """Test Positive"""


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Add support to create child rules.  Child rules will be called from their parent but still need to be configured and filtered
- This is pre-work to support the new CloudFormation schema for json schema validation.  By doing this we can do json schema validation but keep the rule numbers, and handle unique scenarios more accurately. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
