### PR TITLE
Prevent error from showing when new LanguageExtensions intrinsic functions are included within certain intrinsic functions

### DIFF
--- a/src/cfnlint/helpers.py
+++ b/src/cfnlint/helpers.py
@@ -73,9 +73,22 @@ REGEX_DYN_REF_SSM_SECURE = re.compile(r'^.*{{resolve:ssm-secure:[a-zA-Z0-9_\.\-/
 
 
 FUNCTIONS = [
-    'Fn::Base64', 'Fn::GetAtt', 'Fn::GetAZs', 'Fn::ImportValue',
-    'Fn::Join', 'Fn::Split', 'Fn::FindInMap', 'Fn::Select', 'Ref',
-    'Fn::If', 'Fn::Contains', 'Fn::Sub', 'Fn::Cidr']
+    'Fn::Base64',
+    'Fn::GetAtt',
+    'Fn::GetAZs',
+    'Fn::ImportValue',
+    'Fn::Join',
+    'Fn::Split',
+    'Fn::FindInMap',
+    'Fn::Select',
+    'Ref',
+    'Fn::If',
+    'Fn::Contains',
+    'Fn::Sub',
+    'Fn::Cidr',
+    'Fn::Length',
+    'Fn::ToJsonString',
+]
 
 FUNCTIONS_MULTIPLE = ['Fn::GetAZs', 'Fn::Split']
 

--- a/src/cfnlint/languageExtensions.py
+++ b/src/cfnlint/languageExtensions.py
@@ -12,7 +12,7 @@ class LanguageExtensions(object):
 
     def validate_type(self, fn_object_val, matches, tree, intrinsic_function):
         if not isinstance(fn_object_val, dict) and not isinstance(fn_object_val, list):
-            message = intrinsic_function + ' needs a map at {0}'
+            message = intrinsic_function + ' needs a map or a list at {0}'
             matches.append(RuleMatch(tree[:], message.format('/'.join(map(str, tree)))))
         elif len(fn_object_val) == 0:
             message = 'Invalid value for '+intrinsic_function+' for {0}'

--- a/src/cfnlint/rules/conditions/Equals.py
+++ b/src/cfnlint/rules/conditions/Equals.py
@@ -15,8 +15,16 @@ class Equals(CloudFormationLintRule):
     source_url = 'https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-conditions.html#intrinsic-function-reference-conditions-equals'
     tags = ['functions', 'equals']
 
-    allowed_functions = ['Ref', 'Fn::FindInMap',
-                         'Fn::Sub', 'Fn::Join', 'Fn::Select', 'Fn::Split']
+    allowed_functions = [
+        'Ref',
+        'Fn::FindInMap',
+        'Fn::Sub',
+        'Fn::Join',
+        'Fn::Select',
+        'Fn::Split',
+        'Fn::Length',
+        'Fn::ToJsonString',
+    ]
     function = 'Fn::Equals'
 
     def _check_equal_values(self, element, path, valid_refs):

--- a/src/cfnlint/rules/functions/Split.py
+++ b/src/cfnlint/rules/functions/Split.py
@@ -30,6 +30,7 @@ class Split(CloudFormationLintRule):
             'Fn::Select',
             'Fn::Sub',
             'Ref',
+            'Fn::ToJsonString',
         ]
 
         for split_obj in split_objs:

--- a/src/cfnlint/rules/functions/Sub.py
+++ b/src/cfnlint/rules/functions/Sub.py
@@ -54,6 +54,7 @@ class Sub(CloudFormationLintRule):
             'Fn::Select',
             'Fn::Sub',
             'Ref',
+            'Fn::ToJsonString',
         ]
 
         matches = []


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- When the new `Fn::ToJsonString` intrinsic function is included within the `Fn::Equals`, `Fn::Split`, or `Fn::Sub` intrinsic function, within the Outputs section, etc., an exception is no longer displayed
- When the new `Fn::Length` intrinsic function is included within the `Fn::Equals` intrinsic function, within the Outputs section, etc., an exception is no longer displayed
- Message updated for `Fn::ToJsonString` if a non-map & non-list is included as a parameter of the function

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
