### PR TITLE
patch in DBClusterResourceId for AWS::RDS::DBCluster

### DIFF
--- a/src/cfnlint/data/ExtendedSpecs/all/01_spec_patch.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/01_spec_patch.json
@@ -571,5 +571,12 @@
         }
       }
     }
+  },
+  {
+    "op": "add",
+    "path": "/ResourceTypes/AWS::RDS::DBCluster/Attributes/DBClusterResourceId",
+    "value": {
+      "PrimitiveType": "String"
+    }
   }
 ]


### PR DESCRIPTION
*Issue #, if available:*
fix #2400
*Description of changes:*
- patch in `DBClusterResourceId` for `AWS::RDS::DBCluster`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
