### PR TITLE
AWS::CloudWatch::Alarm.MetricDataQuery.Id AllowedPatternRegex

### DIFF
--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_cloudwatch.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_cloudwatch.json
@@ -52,7 +52,7 @@
     "op": "add",
     "path": "/ValueTypes/AWS::CloudWatch::Alarm.MetricDataQuery.Id",
     "value": {
-      "AllowedPatternRegex": "^([a-z])([A-Za-z0-9\\_]+)$"
+      "AllowedPatternRegex": "^([a-z])([A-Za-z0-9\\_]*)$"
     }
   }
 ]


### PR DESCRIPTION
fix https://github.com/aws-cloudformation/cfn-lint/issues/2413

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
