### PR TITLE
Add GetAtt to AWS::KMS::ReplicaKey.Arn for KmsKey.Arn

### DIFF
--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
@@ -157,7 +157,8 @@
       },
       "KmsKey.Arn": {
         "GetAtt": {
-          "AWS::KMS::Key": "Arn"
+          "AWS::KMS::Key": "Arn",
+          "AWS::KMS::ReplicaKey": "Arn"
         },
         "Ref": {
           "Parameters": ["String"]


### PR DESCRIPTION
*Issue #, if available:*
fix #2415 

*Description of changes:*
- Add GetAtt to `AWS::KMS::ReplicaKey.Arn` for `KmsKey.Arn`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
