### PR TITLE
fix(transform) - Don't replace location in SAM transform when its a string

### DIFF
--- a/src/cfnlint/transform.py
+++ b/src/cfnlint/transform.py
@@ -105,8 +105,9 @@ class Transform:
                     Transform._update_to_s3_uri('ContentUri', resource_dict)
             if resource_type == 'AWS::Serverless::Application':
                 if resource_dict.get('Location'):
-                    resource_dict['Location'] = ''
-                    Transform._update_to_s3_uri('Location', resource_dict)
+                    if isinstance(resource_dict.get('Location'), dict):
+                        resource_dict['Location'] = ''
+                        Transform._update_to_s3_uri('Location', resource_dict)
             if resource_type == 'AWS::Serverless::Api':
                 if (
                     'DefinitionBody' not in resource_dict

--- a/test/fixtures/templates/good/transform/applications_location.yaml
+++ b/test/fixtures/templates/good/transform/applications_location.yaml
@@ -1,0 +1,11 @@
+Transform: AWS::Serverless-2016-10-31
+Resources:
+  App1:
+    Type: AWS::Serverless::Application
+    Properties:
+      Location: ./step_function_local_definition.yaml
+  App2:
+    Type: AWS::Serverless::Application
+    Properties:
+      Location:
+        ApplicationId: '1'

--- a/test/unit/module/transform/test_transform.py
+++ b/test/unit/module/transform/test_transform.py
@@ -43,6 +43,37 @@ class TestTransform(BaseTestCase):
                 'Key': 'value'
             })
 
+    def test_conversion_of_application_location(self):
+        """ Tests if serverless application converts location to string when dict """
+        filename = 'test/fixtures/templates/good/transform/applications_location.yaml'
+        region = 'us-east-1'
+        template = cfn_yaml.load(filename)
+        transformed_template = Transform(filename, template, region)
+        transformed_template.transform_template()
+        self.assertEqual(
+            transformed_template._template.get('Resources').get(
+                'App1').get('Properties').get('TemplateURL'),
+            './step_function_local_definition.yaml')
+        self.assertEqual(
+            transformed_template._template.get('Resources').get(
+                'App2').get('Properties').get('TemplateURL'),
+            's3://bucket/value')
+    
+    def test_conversion_of_step_function_definition_uri(self):
+        """ Tests that the a serverless step function can convert a local path to a s3 path """
+        filename = 'test/fixtures/templates/good/transform/step_function_local_definition.yaml'
+        region = 'us-east-1'
+        template = cfn_yaml.load(filename)
+        transformed_template = Transform(filename, template, region)
+        transformed_template.transform_template()
+        self.assertDictEqual(
+            transformed_template._template.get('Resources').get(
+                'StateMachine').get('Properties').get('DefinitionS3Location'),
+            {
+                'Bucket': 'bucket',
+                'Key': 'value'
+            })
+
     def test_parameter_for_autopublish_version_bad(self):
         """Test Parameter is created for autopublish version run"""
         filename = 'test/fixtures/templates/bad/transform/auto_publish_alias.yaml'


### PR DESCRIPTION
*Issue #, if available:*
fix #1194

*Description of changes:*
- With resource `AWS::Serverless::Application` `Location` don't replace if a string during Transform

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
