### PR TITLE
fix(rds) - Patch db.serverless into allowedValues of pricing script

### DIFF
--- a/scripts/update_specs_from_pricing.py
+++ b/scripts/update_specs_from_pricing.py
@@ -163,7 +163,7 @@ def get_rds_pricing():
                 if product.get('productFamily') in ['Database Instance']:
                     # Get overall instance types
                     if not results.get(region_map[product.get('attributes').get('location')]):
-                        results[region_map[product.get('attributes').get('location')]] = set()
+                        results[region_map[product.get('attributes').get('location')]] = set(['db.serverless'])
                     results[region_map[product.get('attributes').get('location')]].add(
                         product.get('attributes').get('instanceType')
                     )
@@ -178,7 +178,10 @@ def get_rds_pricing():
                         if not rds_specs.get(license_name).get(product_name):
                             rds_specs[license_name][product_name] = {}
                         if not rds_specs.get(license_name).get(product_name).get(product_region):
-                            rds_specs[license_name][product_name][product_region] = set(['db.serverless'])
+                            if license_name == 'general-public-license' and product_name in ['aurora-mysql', 'aurora-postgresql']:
+                                rds_specs[license_name][product_name][product_region] = set(['db.serverless'])
+                            else:
+                                rds_specs[license_name][product_name][product_region] = set()
 
                         rds_specs[license_name][product_name][product_region].add(instance_type)
 


### PR DESCRIPTION
*Issue #, if available:*
#2257 
*Description of changes:*
- patch in db.serverless to allowedValues of RDS DBInstance
- smarter patching of db.serverless into allowed values based on licensing

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
