### PR TITLE
chore(spec) - Limit Lambda::Function.Code/Properties/Zipfile to 4MBs characters

### DIFF
--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_lambda.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_lambda.json
@@ -123,7 +123,7 @@
     "op": "add",
     "path": "/ValueTypes/AWS::Lambda::Function.Code.ZipFile",
     "value": {
-      "StringMax": 4096,
+      "StringMax": 4194304,
       "StringMin": 1
     }
   }


### PR DESCRIPTION
*Issue #, if available:*
#2431 

*Description of changes:*
- Update Lambda size to 4MBs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
