### PR TITLE
fix(rule) - Make type checks in E3016 not be type restrictive

### DIFF
--- a/src/cfnlint/rules/resources/updatepolicy/Configuration.py
+++ b/src/cfnlint/rules/resources/updatepolicy/Configuration.py
@@ -78,9 +78,9 @@ class Configuration(CloudFormationLintRule):
             },
         },
         'primitive_types': {
-            'String': str,
-            'Integer': int,
-            'Boolean': bool,
+            'String': (str, int, bool, float),
+            'Integer': (int, str),
+            'Boolean': (bool, str),
             'List': list,
         },
     }

--- a/src/cfnlint/rules/resources/updatepolicy/Configuration.py
+++ b/src/cfnlint/rules/resources/updatepolicy/Configuration.py
@@ -117,22 +117,14 @@ class Configuration(CloudFormationLintRule):
                     elif prim_type in ['Boolean']:
                         if value not in ['True', 'true', 'False', 'false']:
                             matches.append(RuleMatch(path, default_message))
-                    elif prim_type in ['Integer', 'Long', 'Double']:
+                    else:  # has to be integer
                         if isinstance(value, bool):
                             matches.append(RuleMatch(path, default_message))
-                        elif prim_type in ['Integer']:
-                            if isinstance(value, float):
-                                if not value.is_integer():
-                                    matches.append(RuleMatch(path, default_message))
-                            else:
-                                int(value)
-                        elif prim_type in ['Long']:
-                            # Some times python will strip the decimals when doing a conversion
-                            if isinstance(value, float):
+                        if isinstance(value, float):
+                            if not value.is_integer():
                                 matches.append(RuleMatch(path, default_message))
+                        else:
                             int(value)
-                        else:  # has to be a Double
-                            float(value)
                 except Exception:  # pylint: disable=W0703
                     matches.append(RuleMatch(path, default_message))
 

--- a/test/fixtures/templates/bad/resources/updatepolicy/config.yaml
+++ b/test/fixtures/templates/bad/resources/updatepolicy/config.yaml
@@ -25,11 +25,11 @@ Resources:
       MinSize: '1'
     UpdatePolicy:
       AutoScalingScheduledAction:
-        IgnoreUnmodifiedGroupSizeProperties: 'true' # invalid type
+        IgnoreUnmodifiedGroupSizeProperties: 4 # invalid type
       AutoScalingRollingUpdate:
-        MinInstancesInService: '1' # invalide type
-        MaxBatchSize: '2' # invalide type
-        WaitOnResourceSignals: 'true' # invalide type
+        MinInstancesInService: 1.4 # invalide type
+        MaxBatchSize: 'a' # invalide type
+        WaitOnResourceSignals: 'value' # invalide type
         PauseTime: PT10M
         SuspendProcesses:
         - ScheduledAction # missing a s
@@ -137,4 +137,4 @@ Resources:
   ESD2:
     Type: AWS::Elasticsearch::Domain
     UpdatePolicy:
-      EnableVersionUpgrade: 'true' # invalid type
+      EnableVersionUpgrade: 'true'

--- a/test/unit/rules/resources/updatepolicy/test_configuration.py
+++ b/test/unit/rules/resources/updatepolicy/test_configuration.py
@@ -24,4 +24,4 @@ class TestConfiguration(BaseRuleTestCase):
     def test_file_negative_alias(self):
         """Test failure"""
         self.helper_file_negative(
-            'test/fixtures/templates/bad/resources/updatepolicy/config.yaml', 14)
+            'test/fixtures/templates/bad/resources/updatepolicy/config.yaml', 13)


### PR DESCRIPTION
*Issue #, if available:*
#362 

*Description of changes:*
- Update rule E3016 so that isn't as restrictive on types.  Similar change to making our type changes for properties not being restrictive. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
