### PR TITLE
fix(rule) - Update rule E3031 to use ASCII when using regex keywords

### DIFF
--- a/src/cfnlint/rules/resources/properties/AllowedPattern.py
+++ b/src/cfnlint/rules/resources/properties/AllowedPattern.py
@@ -60,7 +60,7 @@ class AllowedPattern(CloudFormationLintRule):
 
         if isinstance(value, str):
             if value_pattern_regex:
-                regex = re.compile(value_pattern_regex)
+                regex = re.compile(value_pattern_regex, re.ASCII)
 
                 # Ignore values with dynamic references. Simple check to prevent false-positives
                 # See: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/dynamic-references.html


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Update rule E3031 to use ASCII when using regex keywords like `\w`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
