### PR TITLE
Add option to filter for Cloudformation templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ Optional parameters:
 | -l, --list-rules | | | List all the rules |
 | -r, --regions | regions | [REGIONS [REGIONS ...]], ALL_REGIONS  | Test the template against many regions.  [Supported regions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-resource-specification.html) |
 | -b, --ignore-bad-template | ignore_bad_template | | Ignores bad template errors |
+| --detect-cfn-files | detect_cfn_files | | Only lint files that contain the string `AWSTemplateFormatVersion`. This is useful for ignoring non-Cloudformation yaml files |
 | --ignore-templates | | IGNORE_TEMPLATES [IGNORE_TEMPLATES ...] | Ignore templates from being scanned
 | -a, --append-rules | append_rules | [RULESPATH [RULESPATH ...]] | Specify one or more rules paths using one or more --append-rules arguments.  Each path can be either a directory containing python files, or an import path to a module. |
 | -i, --ignore-checks | ignore_checks | [IGNORE_CHECKS [IGNORE_CHECKS ...]] | Only check rules whose ID do not match or prefix these values.  Examples: <br />- A value of `W` will disable all warnings<br />- `W2` disables all Warnings for Parameter rules.<br />- `W2001` will disable rule `W2001` |


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adding support for the `--detect-cfn-lint` argument.  This only lints files which contain the string `AWSTemplateFormatVersion`.

After some internal tests, this check neither excludes any files that should be checked nor does it usually check any file that are intended to be left out.  But if requested I can implement a more specific detection mechanism.

I didn't add any tests for this code since I'm not sure what tests would be expected.  I can add some tests if needed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
