### PR TITLE
Add support for AllowedValues/AllowedPattern for CommaDelimitedLists

### DIFF
--- a/test/fixtures/templates/bad/parameters/default.yaml
+++ b/test/fixtures/templates/bad/parameters/default.yaml
@@ -34,4 +34,28 @@ Parameters:
   MyRefDefault:
     Type: !Ref "myMaxLength"
     Default: !Ref "myMinLength"
+  CDLAllowedPattern:
+    AllowedPattern: "[a-z]*$"
+    ConstraintDescription: Alphanumeric string of any length.
+    Description: test value using comma delimited list.
+    Type: CommaDelimitedList
+    Default: 1,2
+  CDLAllowedValues:
+    ConstraintDescription: Alphanumeric string of any length.
+    Description: test value using comma delimited list.
+    Type: CommaDelimitedList
+    Default: three
+    AllowedValues:
+      - one
+      - two
+      - three,four
+  CDLAllowedValuesWithSpaces:
+    ConstraintDescription: Alphanumeric string of any length.
+    Description: test value using comma delimited list.
+    Type: CommaDelimitedList
+    Default: three,four
+    AllowedValues:
+      - one
+      - two
+      - three, four
 Resources: {}

--- a/test/fixtures/templates/good/parameters/default.yaml
+++ b/test/fixtures/templates/good/parameters/default.yaml
@@ -39,4 +39,41 @@ Parameters:
     MaxLength: 12
     MinLength: 12
     Type: String
+  CDLAllowedPattern:
+    AllowedPattern: "[a-z]*$"
+    ConstraintDescription: Alphanumeric string of any length.
+    Description: test value using comma delimited list.
+    Type: CommaDelimitedList
+    Default: three,four
+  CDLAllowedPatternWithSpaceInDefault:
+    AllowedPattern: "[a-z]*$"
+    AllowedValues:
+      - one
+      - two
+      - three,four
+    ConstraintDescription: Alphanumeric string of any length.
+    Description: test value using comma delimited list.
+    Type: CommaDelimitedList
+    Default: one, two
+  CDLAllowedValues:
+    ConstraintDescription: Alphanumeric string of any length.
+    Description: test value using comma delimited list.
+    Type: CommaDelimitedList
+    Default: three,four
+    AllowedValues:
+      - one
+      - two
+      - three,four
+  CDLAllowedValuesWithSpaceInDefault:
+    ConstraintDescription: Alphanumeric string of any length.
+    Description: test value using comma delimited list.
+    Type: CommaDelimitedList
+    Default: one, two
+    AllowedValues:
+      - one
+      - two
+      - three,four
+  CDLWithoutDefault:
+    Type: CommaDelimitedList
+
 Resources: {}

--- a/test/unit/rules/parameters/test_default.py
+++ b/test/unit/rules/parameters/test_default.py
@@ -27,5 +27,5 @@ class TestDefault(BaseRuleTestCase):
     def test_file_negative(self):
         """Test failure"""
         self.helper_file_negative(
-            "test/fixtures/templates/bad/parameters/default.yaml", 6
+            "test/fixtures/templates/bad/parameters/default.yaml", 9
         )


### PR DESCRIPTION
This change adds support for AllowedValues and AllowedPattern for CommaDelimitedLists by warning the user when the default value is invalid according to the same rules enforced on the server-side. Both these contraints are now applied to every item of a CommaDelimitedList parameter.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
