### PR TITLE
Fix merge-config cross-template config leakage

### DIFF
--- a/src/cfnlint/config.py
+++ b/src/cfnlint/config.py
@@ -615,7 +615,9 @@ class ConfigMixIn(TemplateArgs, CliArgs, ConfigFileArgs):
                 # the CLI will always have an empty list when the item is a list
                 # we will use that to evaluate if we need to merge the lists
                 if isinstance(cli_value, list):
-                    result = cli_value
+                    # Use a copy here, otherwise we will accumulate template level config
+                    # into the cli_value which will  persist between template files
+                    result = cli_value.copy()
                     if isinstance(template_value, list):
                         result.extend(template_value)
                     if isinstance(file_value, list):


### PR DESCRIPTION
*Issue #, if available:*
2535 

*Description of changes:*
Fix leakage of config-merges between individual template files when merge-config is enabled

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
