### PR TITLE
chore(test) - pip-audit updates ignore vulnerability for setuptools

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -66,3 +66,6 @@ jobs:
         run: |
           pip3 install -e .
       - uses: pypa/gh-action-pip-audit@v1.0.2
+        with:
+          ignore-vulns: |
+            GHSA-r9hx-vwmv-q579

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ commands =
   coverage xml
 skip_install = True
 deps =
-  coverage
+  coverage<7.0.0
   pydot
 setenv =
   LANG=en_US.UTF-8


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- `pip-audit` updates ignore vulnerability for `setuptools` `GHSA-r9hx-vwmv-q579`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
