### PR TITLE
fix (rule) - Allow a GetAtt for objects in rule E3002

### DIFF
--- a/src/cfnlint/rules/resources/properties/Properties.py
+++ b/src/cfnlint/rules/resources/properties/Properties.py
@@ -380,6 +380,21 @@ class Properties(CloudFormationLintRule):
                     and text.get(prop) == "AWS::NoValue"
                 ):
                     pass
+                elif len(text) == 1 and prop in "Fn::GetAtt":
+                    getatt = text.get(prop)
+                    getatt_type = (
+                        self.cfn.template.get("Resources", {})
+                        .get(getatt[0], {})
+                        .get("Type", "")
+                    )
+                    if (
+                        getatt_type == "AWS::CloudFormation::CustomResource"
+                        or getatt_type.startswith("Custom::")
+                    ):
+                        pass
+                    else:
+                        message = f'GetAtt must refer to a custom resource {"/".join(map(str, proppath))}'
+                        matches.append(RuleMatch(proppath, message))
                 elif not supports_additional_properties:
                     close_match = False
                     for key in resourcespec.keys():

--- a/test/fixtures/templates/bad/resource_properties.yaml
+++ b/test/fixtures/templates/bad/resource_properties.yaml
@@ -48,3 +48,13 @@ Resources:
       VpcConfig:
         SubnetIds: !ImportValue foobar1
         SecurityGroupIds: !ImportValue foobar2
+  Custom:
+    Type: AWS::CloudFormation::CustomResource
+    Properties:
+      ServiceToken: arn.example
+  Helper:
+    Type: 'AWS::Lambda::Function'
+    Properties:
+      Handler: 'helper.lambda_handler'
+      Role: arn:aws:iam::123456789012:role/role-name-with-path
+      Code: !GetAtt myInstance.AvailabilityZone  # returns a string not an object

--- a/test/fixtures/templates/good/resource_properties.yaml
+++ b/test/fixtures/templates/good/resource_properties.yaml
@@ -641,7 +641,12 @@ Resources:
     Type: AWS::CloudFormation::CustomResource
     Properties:
       ServiceToken: arn.example
-
+  Helper:
+    Type: 'AWS::Lambda::Function'
+    Properties:
+      Handler: 'helper.lambda_handler'
+      Role: arn:aws:iam::123456789012:role/role-name-with-path
+      Code: !GetAtt Custom.Code
   LB1:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
     Properties:

--- a/test/unit/rules/resources/properties/test_properties.py
+++ b/test/unit/rules/resources/properties/test_properties.py
@@ -42,7 +42,7 @@ class TestResourceProperties(BaseRuleTestCase):
     def test_file_negative_3(self):
         """Failure test"""
         self.helper_file_negative(
-            "test/fixtures/templates/bad/resource_properties.yaml", 7
+            "test/fixtures/templates/bad/resource_properties.yaml", 8
         )
 
     def test_E3012_in_bad_template(self):


### PR DESCRIPTION
*Issue #, if available:*
fix #2537 

*Description of changes:*
- Fix rule E3002 to allow GetAtt for an object/dict

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
