### PR TITLE
expanding likely_stateful_resource_types (AWS::Organizations::Account)

### DIFF
--- a/src/cfnlint/data/AdditionalSpecs/StatefulResources.json
+++ b/src/cfnlint/data/AdditionalSpecs/StatefulResources.json
@@ -18,6 +18,7 @@
     "AWS::Neptune::DBCluster" : {},
     "AWS::Neptune::DBInstance" : {},
     "AWS::OpenSearchService::Domain" : {},
+    "AWS::Organizations::Account" : {},
     "AWS::QLDB::Ledger" : {},
     "AWS::RDS::DBCluster" : {},
     "AWS::RDS::DBInstance" : {},


### PR DESCRIPTION
[`AWS::Organizations::Account`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-organizations-account.html)

*Issue #, if available:* https://github.com/aws-cloudformation/cfn-lint/issues/2516

As mentioned in https://github.com/aws/aws-cdk/issues/12563#issuecomment-771222642, inconsistent defaults are confusing, so encouraging explicit policies for this resource type rather than relying on a default that's different than almost all the other default policies