### PR TITLE
Remove AWS::RDS::DBCluster MasterUsername and MasterUserPassword from Inclusive

### DIFF
--- a/src/cfnlint/data/AdditionalSpecs/Inclusive.json
+++ b/src/cfnlint/data/AdditionalSpecs/Inclusive.json
@@ -29,22 +29,6 @@
         "ScalableDimension"
       ]
     },
-    "AWS::RDS::DBCluster": {
-      "MasterUsername": [
-        "MasterUserPassword"
-      ],
-      "MasterUserPassword": [
-        "MasterUsername"
-      ]
-    },
-    "AWS::RDS::DBInstance": {
-      "MasterUsername": [
-        "MasterUserPassword"
-      ],
-      "MasterUserPassword": [
-        "MasterUsername"
-      ]
-    },
     "AWS::OpsWorks::Stack": {
       "VpcId": [
         "DefaultSubnetId"

--- a/test/fixtures/templates/bad/resources/properties/inclusive.yaml
+++ b/test/fixtures/templates/bad/resources/properties/inclusive.yaml
@@ -20,7 +20,21 @@ Resources:
       - MasterUsername: admin
         MasterUserPassword: test
         Engine: test
-  LoadBalancer:
+  LoadBalancer1:
+    Type: AWS::ApplicationAutoScaling::ScalingPolicy
+    Properties:
+      Fn::If:
+      - cPrimaryRegion
+      - PolicyName: Test
+        ScalableDimension: Test
+        ResourceId: Id
+        PolicyType: StepScaling
+      - PolicyName: Test
+        ScalableDimension: Test
+        ResourceId: Id
+        PolicyType: StepScaling
+        ServiceNamespace: !Ref "AWS::NoValue"
+  LoadBalancer2:
     Type: AWS::ApplicationAutoScaling::ScalingPolicy
     Properties:
       PolicyName: Test

--- a/test/unit/rules/resources/properties/test_inclusive.py
+++ b/test/unit/rules/resources/properties/test_inclusive.py
@@ -27,5 +27,5 @@ class TestPropertyInclusive(BaseRuleTestCase):
     def test_file_negative(self):
         """Test failure"""
         self.helper_file_negative(
-            "test/fixtures/templates/bad/resources/properties/inclusive.yaml", 4
+            "test/fixtures/templates/bad/resources/properties/inclusive.yaml", 6
         )


### PR DESCRIPTION
*Issue #, if available:*
fix #2562 
*Description of changes:*
- Remove `AWS::RDS::DBCluster` `MasterUsername` and `MasterUserPassword` from Inclusive

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
