### PR TITLE
Patch back in TargetRole for AWS::RDS::DBProxyEndpoint.TargetRole

### DIFF
--- a/src/cfnlint/data/CloudSpecs/af-south-1.json
+++ b/src/cfnlint/data/CloudSpecs/af-south-1.json
@@ -5941,6 +5941,7 @@
   "AWS::RDS::DBProxyEndpoint.DBProxyName": "CACHED",
   "AWS::RDS::DBProxyEndpoint.TagFormat.Key": "CACHED",
   "AWS::RDS::DBProxyEndpoint.TagFormat.Value": "CACHED",
+  "AWS::RDS::DBProxyEndpoint.TargetRole": "CACHED",
   "AWS::RDS::DBProxyTargetGroup.DBProxyName": "CACHED",
   "AWS::RDS::DBProxyTargetGroup.TargetGroupName": "CACHED",
   "AWS::RDS::DBSubnetGroup.DBSubnetGroupName": "CACHED",

--- a/src/cfnlint/data/CloudSpecs/ap-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-east-1.json
@@ -7123,6 +7123,7 @@
   "AWS::RDS::DBProxyEndpoint.DBProxyName": "CACHED",
   "AWS::RDS::DBProxyEndpoint.TagFormat.Key": "CACHED",
   "AWS::RDS::DBProxyEndpoint.TagFormat.Value": "CACHED",
+  "AWS::RDS::DBProxyEndpoint.TargetRole": "CACHED",
   "AWS::RDS::DBProxyTargetGroup.DBProxyName": "CACHED",
   "AWS::RDS::DBProxyTargetGroup.TargetGroupName": "CACHED",
   "AWS::RDS::DBSubnetGroup.DBSubnetGroupName": "CACHED",

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
@@ -8311,6 +8311,7 @@
   "AWS::RDS::DBProxyEndpoint.DBProxyName": "CACHED",
   "AWS::RDS::DBProxyEndpoint.TagFormat.Key": "CACHED",
   "AWS::RDS::DBProxyEndpoint.TagFormat.Value": "CACHED",
+  "AWS::RDS::DBProxyEndpoint.TargetRole": "CACHED",
   "AWS::RDS::DBProxyTargetGroup.DBProxyName": "CACHED",
   "AWS::RDS::DBProxyTargetGroup.TargetGroupName": "CACHED",
   "AWS::RDS::DBSubnetGroup.DBSubnetGroupName": "CACHED",

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
@@ -7748,6 +7748,7 @@
   "AWS::RDS::DBProxyEndpoint.DBProxyName": "CACHED",
   "AWS::RDS::DBProxyEndpoint.TagFormat.Key": "CACHED",
   "AWS::RDS::DBProxyEndpoint.TagFormat.Value": "CACHED",
+  "AWS::RDS::DBProxyEndpoint.TargetRole": "CACHED",
   "AWS::RDS::DBProxyTargetGroup.DBProxyName": "CACHED",
   "AWS::RDS::DBProxyTargetGroup.TargetGroupName": "CACHED",
   "AWS::RDS::DBSubnetGroup.DBSubnetGroupName": "CACHED",

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
@@ -5570,6 +5570,7 @@
   "AWS::RDS::DBProxyEndpoint.DBProxyName": "CACHED",
   "AWS::RDS::DBProxyEndpoint.TagFormat.Key": "CACHED",
   "AWS::RDS::DBProxyEndpoint.TagFormat.Value": "CACHED",
+  "AWS::RDS::DBProxyEndpoint.TargetRole": "CACHED",
   "AWS::RDS::DBProxyTargetGroup.DBProxyName": "CACHED",
   "AWS::RDS::DBProxyTargetGroup.TargetGroupName": "CACHED",
   "AWS::RDS::DBSubnetGroup.DBSubnetGroupName": "CACHED",

--- a/src/cfnlint/data/CloudSpecs/ap-south-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-south-1.json
@@ -7780,6 +7780,7 @@
   "AWS::RDS::DBProxyEndpoint.DBProxyName": "CACHED",
   "AWS::RDS::DBProxyEndpoint.TagFormat.Key": "CACHED",
   "AWS::RDS::DBProxyEndpoint.TagFormat.Value": "CACHED",
+  "AWS::RDS::DBProxyEndpoint.TargetRole": "CACHED",
   "AWS::RDS::DBProxyTargetGroup.DBProxyName": "CACHED",
   "AWS::RDS::DBProxyTargetGroup.TargetGroupName": "CACHED",
   "AWS::RDS::DBSubnetGroup.DBSubnetGroupName": "CACHED",

--- a/src/cfnlint/data/CloudSpecs/ap-south-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-south-2.json
@@ -6078,6 +6078,7 @@
   "AWS::RDS::DBInstance.ProcessorFeature.Name": "CACHED",
   "AWS::RDS::DBInstance.PromotionTier": "CACHED",
   "AWS::RDS::DBParameterGroup.DBParameterGroupName": "CACHED",
+  "AWS::RDS::DBProxyEndpoint.TargetRole": "CACHED",
   "AWS::RDS::DBSubnetGroup.DBSubnetGroupName": "CACHED",
   "AWS::Redshift::Cluster.NumberOfNodes": "CACHED",
   "AWS::ResourceGroups::Group.ResourceQuery.Type": "CACHED",

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
@@ -7783,6 +7783,7 @@
   "AWS::RDS::DBProxyEndpoint.DBProxyName": "CACHED",
   "AWS::RDS::DBProxyEndpoint.TagFormat.Key": "CACHED",
   "AWS::RDS::DBProxyEndpoint.TagFormat.Value": "CACHED",
+  "AWS::RDS::DBProxyEndpoint.TargetRole": "CACHED",
   "AWS::RDS::DBProxyTargetGroup.DBProxyName": "CACHED",
   "AWS::RDS::DBProxyTargetGroup.TargetGroupName": "CACHED",
   "AWS::RDS::DBSubnetGroup.DBSubnetGroupName": "CACHED",

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
@@ -7840,6 +7840,7 @@
   "AWS::RDS::DBProxyEndpoint.DBProxyName": "CACHED",
   "AWS::RDS::DBProxyEndpoint.TagFormat.Key": "CACHED",
   "AWS::RDS::DBProxyEndpoint.TagFormat.Value": "CACHED",
+  "AWS::RDS::DBProxyEndpoint.TargetRole": "CACHED",
   "AWS::RDS::DBProxyTargetGroup.DBProxyName": "CACHED",
   "AWS::RDS::DBProxyTargetGroup.TargetGroupName": "CACHED",
   "AWS::RDS::DBSubnetGroup.DBSubnetGroupName": "CACHED",

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-3.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-3.json
@@ -8290,6 +8290,7 @@
   "AWS::RDS::DBInstance.ProcessorFeature.Name": "CACHED",
   "AWS::RDS::DBInstance.PromotionTier": "CACHED",
   "AWS::RDS::DBParameterGroup.DBParameterGroupName": "CACHED",
+  "AWS::RDS::DBProxyEndpoint.TargetRole": "CACHED",
   "AWS::RDS::DBSubnetGroup.DBSubnetGroupName": "CACHED",
   "AWS::Redshift::Cluster.NumberOfNodes": "CACHED",
   "AWS::ResourceGroups::Group.ResourceQuery.Type": "CACHED",

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-4.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-4.json
@@ -7424,6 +7424,7 @@
   "AWS::RDS::DBInstance.Port": "CACHED",
   "AWS::RDS::DBInstance.ProcessorFeature.Name": "CACHED",
   "AWS::RDS::DBInstance.PromotionTier": "CACHED",
+  "AWS::RDS::DBProxyEndpoint.TargetRole": "CACHED",
   "AWS::RDS::DBSubnetGroup.DBSubnetGroupName": "CACHED",
   "AWS::Redshift::Cluster.NumberOfNodes": "CACHED",
   "AWS::ResourceGroups::Group.ResourceQuery.Type": "CACHED",

--- a/src/cfnlint/data/CloudSpecs/ca-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/ca-central-1.json
@@ -7145,6 +7145,7 @@
   "AWS::RDS::DBProxyEndpoint.DBProxyName": "CACHED",
   "AWS::RDS::DBProxyEndpoint.TagFormat.Key": "CACHED",
   "AWS::RDS::DBProxyEndpoint.TagFormat.Value": "CACHED",
+  "AWS::RDS::DBProxyEndpoint.TargetRole": "CACHED",
   "AWS::RDS::DBProxyTargetGroup.DBProxyName": "CACHED",
   "AWS::RDS::DBProxyTargetGroup.TargetGroupName": "CACHED",
   "AWS::RDS::DBSubnetGroup.DBSubnetGroupName": "CACHED",

--- a/src/cfnlint/data/CloudSpecs/cn-north-1.json
+++ b/src/cfnlint/data/CloudSpecs/cn-north-1.json
@@ -6255,6 +6255,7 @@
   "AWS::RDS::DBInstance.ProcessorFeature.Name": "CACHED",
   "AWS::RDS::DBInstance.PromotionTier": "CACHED",
   "AWS::RDS::DBParameterGroup.DBParameterGroupName": "CACHED",
+  "AWS::RDS::DBProxyEndpoint.TargetRole": "CACHED",
   "AWS::RDS::DBSubnetGroup.DBSubnetGroupName": "CACHED",
   "AWS::Redshift::Cluster.NumberOfNodes": "CACHED",
   "AWS::ResourceGroups::Group.ResourceQuery.Type": "CACHED",

--- a/src/cfnlint/data/CloudSpecs/cn-northwest-1.json
+++ b/src/cfnlint/data/CloudSpecs/cn-northwest-1.json
@@ -6898,6 +6898,7 @@
   "AWS::RDS::DBInstance.ProcessorFeature.Name": "CACHED",
   "AWS::RDS::DBInstance.PromotionTier": "CACHED",
   "AWS::RDS::DBParameterGroup.DBParameterGroupName": "CACHED",
+  "AWS::RDS::DBProxyEndpoint.TargetRole": "CACHED",
   "AWS::RDS::DBSubnetGroup.DBSubnetGroupName": "CACHED",
   "AWS::Redshift::Cluster.NumberOfNodes": "CACHED",
   "AWS::ResourceGroups::Group.ResourceQuery.Type": "CACHED",

--- a/src/cfnlint/data/CloudSpecs/eu-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-central-1.json
@@ -8076,6 +8076,7 @@
   "AWS::RDS::DBProxyEndpoint.DBProxyName": "CACHED",
   "AWS::RDS::DBProxyEndpoint.TagFormat.Key": "CACHED",
   "AWS::RDS::DBProxyEndpoint.TagFormat.Value": "CACHED",
+  "AWS::RDS::DBProxyEndpoint.TargetRole": "CACHED",
   "AWS::RDS::DBProxyTargetGroup.DBProxyName": "CACHED",
   "AWS::RDS::DBProxyTargetGroup.TargetGroupName": "CACHED",
   "AWS::RDS::DBSubnetGroup.DBSubnetGroupName": "CACHED",

--- a/src/cfnlint/data/CloudSpecs/eu-central-2.json
+++ b/src/cfnlint/data/CloudSpecs/eu-central-2.json
@@ -5700,6 +5700,7 @@
   "AWS::RDS::DBInstance.ProcessorFeature.Name": "CACHED",
   "AWS::RDS::DBInstance.PromotionTier": "CACHED",
   "AWS::RDS::DBParameterGroup.DBParameterGroupName": "CACHED",
+  "AWS::RDS::DBProxyEndpoint.TargetRole": "CACHED",
   "AWS::RDS::DBSubnetGroup.DBSubnetGroupName": "CACHED",
   "AWS::Redshift::Cluster.NumberOfNodes": "CACHED",
   "AWS::ResourceGroups::Group.ResourceQuery.Type": "CACHED",

--- a/src/cfnlint/data/CloudSpecs/eu-north-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-north-1.json
@@ -6272,6 +6272,7 @@
   "AWS::RDS::DBProxyEndpoint.DBProxyName": "CACHED",
   "AWS::RDS::DBProxyEndpoint.TagFormat.Key": "CACHED",
   "AWS::RDS::DBProxyEndpoint.TagFormat.Value": "CACHED",
+  "AWS::RDS::DBProxyEndpoint.TargetRole": "CACHED",
   "AWS::RDS::DBProxyTargetGroup.DBProxyName": "CACHED",
   "AWS::RDS::DBProxyTargetGroup.TargetGroupName": "CACHED",
   "AWS::RDS::DBSubnetGroup.DBSubnetGroupName": "CACHED",

--- a/src/cfnlint/data/CloudSpecs/eu-south-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-south-1.json
@@ -5976,6 +5976,7 @@
   "AWS::RDS::DBProxyEndpoint.DBProxyName": "CACHED",
   "AWS::RDS::DBProxyEndpoint.TagFormat.Key": "CACHED",
   "AWS::RDS::DBProxyEndpoint.TagFormat.Value": "CACHED",
+  "AWS::RDS::DBProxyEndpoint.TargetRole": "CACHED",
   "AWS::RDS::DBProxyTargetGroup.DBProxyName": "CACHED",
   "AWS::RDS::DBProxyTargetGroup.TargetGroupName": "CACHED",
   "AWS::RDS::DBSubnetGroup.DBSubnetGroupName": "CACHED",

--- a/src/cfnlint/data/CloudSpecs/eu-south-2.json
+++ b/src/cfnlint/data/CloudSpecs/eu-south-2.json
@@ -5645,6 +5645,7 @@
   "AWS::RDS::DBInstance.ProcessorFeature.Name": "CACHED",
   "AWS::RDS::DBInstance.PromotionTier": "CACHED",
   "AWS::RDS::DBParameterGroup.DBParameterGroupName": "CACHED",
+  "AWS::RDS::DBProxyEndpoint.TargetRole": "CACHED",
   "AWS::RDS::DBSubnetGroup.DBSubnetGroupName": "CACHED",
   "AWS::Redshift::Cluster.NumberOfNodes": "CACHED",
   "AWS::ResourceGroups::Group.ResourceQuery.Type": "CACHED",

--- a/src/cfnlint/data/CloudSpecs/eu-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-1.json
@@ -7262,6 +7262,7 @@
   "AWS::RDS::DBProxyEndpoint.DBProxyName": "CACHED",
   "AWS::RDS::DBProxyEndpoint.TagFormat.Key": "CACHED",
   "AWS::RDS::DBProxyEndpoint.TagFormat.Value": "CACHED",
+  "AWS::RDS::DBProxyEndpoint.TargetRole": "CACHED",
   "AWS::RDS::DBProxyTargetGroup.DBProxyName": "CACHED",
   "AWS::RDS::DBProxyTargetGroup.TargetGroupName": "CACHED",
   "AWS::RDS::DBSubnetGroup.DBSubnetGroupName": "CACHED",

--- a/src/cfnlint/data/CloudSpecs/eu-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-2.json
@@ -8076,6 +8076,7 @@
   "AWS::RDS::DBProxyEndpoint.DBProxyName": "CACHED",
   "AWS::RDS::DBProxyEndpoint.TagFormat.Key": "CACHED",
   "AWS::RDS::DBProxyEndpoint.TagFormat.Value": "CACHED",
+  "AWS::RDS::DBProxyEndpoint.TargetRole": "CACHED",
   "AWS::RDS::DBProxyTargetGroup.DBProxyName": "CACHED",
   "AWS::RDS::DBProxyTargetGroup.TargetGroupName": "CACHED",
   "AWS::RDS::DBSubnetGroup.DBSubnetGroupName": "CACHED",

--- a/src/cfnlint/data/CloudSpecs/eu-west-3.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-3.json
@@ -6399,6 +6399,7 @@
   "AWS::RDS::DBProxyEndpoint.DBProxyName": "CACHED",
   "AWS::RDS::DBProxyEndpoint.TagFormat.Key": "CACHED",
   "AWS::RDS::DBProxyEndpoint.TagFormat.Value": "CACHED",
+  "AWS::RDS::DBProxyEndpoint.TargetRole": "CACHED",
   "AWS::RDS::DBProxyTargetGroup.DBProxyName": "CACHED",
   "AWS::RDS::DBProxyTargetGroup.TargetGroupName": "CACHED",
   "AWS::RDS::DBSubnetGroup.DBSubnetGroupName": "CACHED",

--- a/src/cfnlint/data/CloudSpecs/me-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/me-central-1.json
@@ -6901,6 +6901,7 @@
   "AWS::RDS::DBInstance.ProcessorFeature.Name": "CACHED",
   "AWS::RDS::DBInstance.PromotionTier": "CACHED",
   "AWS::RDS::DBParameterGroup.DBParameterGroupName": "CACHED",
+  "AWS::RDS::DBProxyEndpoint.TargetRole": "CACHED",
   "AWS::RDS::DBSubnetGroup.DBSubnetGroupName": "CACHED",
   "AWS::Redshift::Cluster.NumberOfNodes": "CACHED",
   "AWS::ResourceGroups::Group.ResourceQuery.Type": "CACHED",

--- a/src/cfnlint/data/CloudSpecs/me-south-1.json
+++ b/src/cfnlint/data/CloudSpecs/me-south-1.json
@@ -5882,6 +5882,7 @@
   "AWS::RDS::DBProxyEndpoint.DBProxyName": "CACHED",
   "AWS::RDS::DBProxyEndpoint.TagFormat.Key": "CACHED",
   "AWS::RDS::DBProxyEndpoint.TagFormat.Value": "CACHED",
+  "AWS::RDS::DBProxyEndpoint.TargetRole": "CACHED",
   "AWS::RDS::DBProxyTargetGroup.DBProxyName": "CACHED",
   "AWS::RDS::DBProxyTargetGroup.TargetGroupName": "CACHED",
   "AWS::RDS::DBSubnetGroup.DBSubnetGroupName": "CACHED",

--- a/src/cfnlint/data/CloudSpecs/sa-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/sa-east-1.json
@@ -8022,6 +8022,7 @@
   "AWS::RDS::DBProxyEndpoint.DBProxyName": "CACHED",
   "AWS::RDS::DBProxyEndpoint.TagFormat.Key": "CACHED",
   "AWS::RDS::DBProxyEndpoint.TagFormat.Value": "CACHED",
+  "AWS::RDS::DBProxyEndpoint.TargetRole": "CACHED",
   "AWS::RDS::DBProxyTargetGroup.DBProxyName": "CACHED",
   "AWS::RDS::DBProxyTargetGroup.TargetGroupName": "CACHED",
   "AWS::RDS::DBSubnetGroup.DBSubnetGroupName": "CACHED",

--- a/src/cfnlint/data/CloudSpecs/us-east-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-2.json
@@ -7422,6 +7422,7 @@
   "AWS::RDS::DBProxyEndpoint.DBProxyName": "CACHED",
   "AWS::RDS::DBProxyEndpoint.TagFormat.Key": "CACHED",
   "AWS::RDS::DBProxyEndpoint.TagFormat.Value": "CACHED",
+  "AWS::RDS::DBProxyEndpoint.TargetRole": "CACHED",
   "AWS::RDS::DBProxyTargetGroup.DBProxyName": "CACHED",
   "AWS::RDS::DBProxyTargetGroup.TargetGroupName": "CACHED",
   "AWS::RDS::DBSubnetGroup.DBSubnetGroupName": "CACHED",

--- a/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
@@ -7648,6 +7648,7 @@
   "AWS::RDS::DBInstance.ProcessorFeature.Name": "CACHED",
   "AWS::RDS::DBInstance.PromotionTier": "CACHED",
   "AWS::RDS::DBParameterGroup.DBParameterGroupName": "CACHED",
+  "AWS::RDS::DBProxyEndpoint.TargetRole": "CACHED",
   "AWS::RDS::DBSubnetGroup.DBSubnetGroupName": "CACHED",
   "AWS::Redshift::Cluster.NumberOfNodes": "CACHED",
   "AWS::Redshift::EventSubscription.EventCategories": "CACHED",

--- a/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
@@ -9628,6 +9628,7 @@
   "AWS::RDS::DBInstance.ProcessorFeature.Name": "CACHED",
   "AWS::RDS::DBInstance.PromotionTier": "CACHED",
   "AWS::RDS::DBParameterGroup.DBParameterGroupName": "CACHED",
+  "AWS::RDS::DBProxyEndpoint.TargetRole": "CACHED",
   "AWS::RDS::DBSubnetGroup.DBSubnetGroupName": "CACHED",
   "AWS::Redshift::Cluster.NumberOfNodes": "CACHED",
   "AWS::Redshift::EventSubscription.EventCategories": "CACHED",

--- a/src/cfnlint/data/CloudSpecs/us-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-1.json
@@ -5673,6 +5673,7 @@
   "AWS::RDS::DBProxyEndpoint.DBProxyName": "CACHED",
   "AWS::RDS::DBProxyEndpoint.TagFormat.Key": "CACHED",
   "AWS::RDS::DBProxyEndpoint.TagFormat.Value": "CACHED",
+  "AWS::RDS::DBProxyEndpoint.TargetRole": "CACHED",
   "AWS::RDS::DBProxyTargetGroup.DBProxyName": "CACHED",
   "AWS::RDS::DBProxyTargetGroup.TargetGroupName": "CACHED",
   "AWS::RDS::DBSubnetGroup.DBSubnetGroupName": "CACHED",

--- a/src/cfnlint/data/CloudSpecs/us-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-2.json
@@ -7978,6 +7978,7 @@
   "AWS::RDS::DBProxyEndpoint.DBProxyName": "CACHED",
   "AWS::RDS::DBProxyEndpoint.TagFormat.Key": "CACHED",
   "AWS::RDS::DBProxyEndpoint.TagFormat.Value": "CACHED",
+  "AWS::RDS::DBProxyEndpoint.TargetRole": "CACHED",
   "AWS::RDS::DBProxyTargetGroup.DBProxyName": "CACHED",
   "AWS::RDS::DBProxyTargetGroup.TargetGroupName": "CACHED",
   "AWS::RDS::DBSubnetGroup.DBSubnetGroupName": "CACHED",

--- a/src/cfnlint/data/ExtendedSpecs/all/01_spec_patch.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/01_spec_patch.json
@@ -252,5 +252,18 @@
       "Required": false,
       "UpdateType": "Mutable"
     }
+  },
+  {
+    "op": "add",
+    "path": "/ResourceTypes/AWS::RDS::DBProxyEndpoint/Properties/TargetRole",
+    "value": {
+      "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-dbproxyendpoint.html#cfn-rds-dbproxyendpoint-targetrole",
+      "PrimitiveType": "String",
+      "Required": false,
+      "UpdateType": "Immutable",
+      "Value": {
+        "ValueType": "AWS::RDS::DBProxyEndpoint.TargetRole"
+      }
+    }
   }
 ]

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_rds.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_rds.json
@@ -36,5 +36,15 @@
     "path": "/ValueTypes/AWS::RDS::DBInstance.DBInstanceClass",
     "value": {
     }
+  },
+  {
+    "op": "add",
+    "path": "/ValueTypes/AWS::RDS::DBProxyEndpoint.TargetRole",
+    "value": {
+      "AllowedValues": [
+       "READ_WRITE",
+       "READ_ONLY"
+      ]
+    }
   }
 ]


### PR DESCRIPTION
*Issue #, if available:*
fix #2579 
*Description of changes:*
- Patch back in `TargetRole` for `AWS::RDS::DBProxyEndpoint.TargetRole`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
