### PR TITLE
Add DefinitionBody to SAM APIs with DisableExecuteApiEndpoint

### DIFF
--- a/src/cfnlint/transform.py
+++ b/src/cfnlint/transform.py
@@ -113,6 +113,7 @@ class Transform:
                     "DefinitionBody" not in resource_dict
                     and "Auth" not in resource_dict
                     and "Cors" not in resource_dict
+                    and "DisableExecuteApiEndpoint" not in resource_dict
                 ):
                     Transform._update_to_s3_uri("DefinitionUri", resource_dict)
                 else:


### PR DESCRIPTION
*Issue #, if available:*
fix #2585 

*Description of changes:*
- Add DefinitionBody to SAM APIs with DisableExecuteApiEndpoint

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
