### PR TITLE
remove AWS::Logs::LogGroup.RetentionInDays AllowedValues

### DIFF
--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_logs.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_logs.json
@@ -9,35 +9,6 @@
   },
   {
     "op": "add",
-    "path": "/ValueTypes/AWS::Logs::LogGroup.Retention",
-    "value": {
-      "AllowedValues": [
-        "1",
-        "3",
-        "5",
-        "7",
-        "14",
-        "30",
-        "60",
-        "90",
-        "120",
-        "150",
-        "180",
-        "365",
-        "400",
-        "545",
-        "731",
-        "1827",
-        "2192",
-        "2557",
-        "2922",
-        "3288",
-        "3653"
-      ]
-    }
-  },
-  {
-    "op": "add",
     "path": "/ValueTypes/AWS::Logs::MetricFilter.MetricTransformation.MetricValue",
     "value": {
       "AllowedPatternRegex": "^(([0-9]*)|(\\$.*))$"

--- a/src/cfnlint/data/ExtendedSpecs/all/04_property_values/aws_logs.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/04_property_values/aws_logs.json
@@ -8,13 +8,6 @@
   },
   {
     "op": "add",
-    "path": "/ResourceTypes/AWS::Logs::LogGroup/Properties/RetentionInDays/Value",
-    "value": {
-      "ValueType": "AWS::Logs::LogGroup.Retention"
-    }
-  },
-  {
-    "op": "add",
     "path": "/PropertyTypes/AWS::Logs::MetricFilter.MetricTransformation/Properties/MetricValue/Value",
     "value": {
       "ValueType": "AWS::Logs::MetricFilter.MetricTransformation.MetricValue"


### PR DESCRIPTION
[`AWS::Logs::LogGroup.RetentionInDays`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-logs-loggroup.html#cfn-logs-loggroup-retentionindays)

fix https://github.com/aws-cloudformation/cfn-lint/issues/2603

[resource provider schema](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/resource-type-schemas.html) has this value:

```yaml
    "RetentionInDays" : {
      "description" : "The number of days to retain the log events in the specified log group. Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1096, 1827, and 3653.",
      "type" : "integer",
      "enum" : [ 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1096, 1827, 2192, 2557, 2922, 3288, 3653 ]
    },
```

so we should get rid of this old manually maintained list