### PR TITLE
Fix custom rule inequality comparison (#2612)

### DIFF
--- a/src/cfnlint/rules/custom/Operators.py
+++ b/src/cfnlint/rules/custom/Operators.py
@@ -132,8 +132,8 @@ def CreateNotEqualsRule(rule_id, resourceType, prop, value, error_message):
 def CreateGreaterRule(rule_id, resourceType, prop, value, error_message):
     def rule_func(value, expected_value, path):
         matches = []
-        if checkInt(value.strip()) and checkInt(str(expected_value).strip()):
-            if value.strip().lower() < str(expected_value).strip().lower():
+        if checkInt(str(value).strip()) and checkInt(str(expected_value).strip()):
+            if int(str(value).strip()) < int(str(expected_value).strip()):
                 matches.append(
                     cfnlint.rules.RuleMatch(
                         path, error_message or "Greater than check failed"
@@ -163,8 +163,8 @@ def CreateGreaterRule(rule_id, resourceType, prop, value, error_message):
 def CreateLesserRule(rule_id, resourceType, prop, value, error_message):
     def rule_func(value, expected_value, path):
         matches = []
-        if checkInt(value.strip()) and checkInt(str(expected_value).strip()):
-            if value.strip().lower() > str(expected_value).strip().lower():
+        if checkInt(str(value).strip()) and checkInt(str(expected_value).strip()):
+            if int(str(value).strip()) > int(str(expected_value).strip()):
                 matches.append(
                     cfnlint.rules.RuleMatch(
                         path, error_message or "Lesser than check failed"

--- a/test/fixtures/templates/good/custom/numeric-inequalities-large.yaml
+++ b/test/fixtures/templates/good/custom/numeric-inequalities-large.yaml
@@ -1,0 +1,36 @@
+---
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  Testing for custom inequality rules
+Resources:
+  LambdaExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          -
+            Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+                - ec2.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Path: "/"
+  TimeoutInNumericsFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      Handler: index.handler
+      Role: !GetAtt LambdaExecutionRole.Arn
+      Code: ./
+      Runtime: nodejs4.3
+      Timeout: 100
+  TimeoutInStringFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      Handler: index.handler
+      Role: !GetAtt LambdaExecutionRole.Arn
+      Code: ./
+      Runtime: nodejs4.3
+      Timeout: '100'

--- a/test/fixtures/templates/good/custom/numeric-inequalities-small.yaml
+++ b/test/fixtures/templates/good/custom/numeric-inequalities-small.yaml
@@ -1,0 +1,36 @@
+---
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  Testing for custom inequality rules
+Resources:
+  LambdaExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          -
+            Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+                - ec2.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Path: "/"
+  TimeoutInNumericsFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      Handler: index.handler
+      Role: !GetAtt LambdaExecutionRole.Arn
+      Code: ./
+      Runtime: nodejs4.3
+      Timeout: 9
+  TimeoutInStringFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      Handler: index.handler
+      Role: !GetAtt LambdaExecutionRole.Arn
+      Code: ./
+      Runtime: nodejs4.3
+      Timeout: '9'

--- a/test/unit/rules/custom/__init__.py
+++ b/test/unit/rules/custom/__init__.py
@@ -1,0 +1,4 @@
+"""
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+"""

--- a/test/unit/rules/custom/test_greater_operator.py
+++ b/test/unit/rules/custom/test_greater_operator.py
@@ -4,7 +4,7 @@ SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase
 
-from cfnlint.rules.custom.Operators import CreateGreaterRule # pylint: disable=E0401
+from cfnlint.rules.custom.Operators import CreateGreaterRule  # pylint: disable=E0401
 
 
 class TestGreaterOperator(BaseRuleTestCase):
@@ -13,9 +13,19 @@ class TestGreaterOperator(BaseRuleTestCase):
     def setUp(self):
         """Setup"""
         super(TestGreaterOperator, self).setUp()
-        self.collection.register(CreateGreaterRule("E9001","AWS::Lambda::Function","Timeout","50","Timeout should be greater than 50"))
+        self.collection.register(
+            CreateGreaterRule(
+                "E9001",
+                "AWS::Lambda::Function",
+                "Timeout",
+                "50",
+                "Timeout should be greater than 50",
+            )
+        )
 
-    success_templates = ["test/fixtures/templates/good/custom/numeric-inequalities-large.yaml"]
+    success_templates = [
+        "test/fixtures/templates/good/custom/numeric-inequalities-large.yaml"
+    ]
 
     def test_file_positive(self):
         """Test Positive"""
@@ -23,4 +33,6 @@ class TestGreaterOperator(BaseRuleTestCase):
 
     def test_file_negative(self):
         """Test failure"""
-        self.helper_file_negative("test/fixtures/templates/good/custom/numeric-inequalities-small.yaml", 2)
+        self.helper_file_negative(
+            "test/fixtures/templates/good/custom/numeric-inequalities-small.yaml", 2
+        )

--- a/test/unit/rules/custom/test_greater_operator.py
+++ b/test/unit/rules/custom/test_greater_operator.py
@@ -1,0 +1,26 @@
+"""
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+"""
+from test.unit.rules import BaseRuleTestCase
+
+from cfnlint.rules.custom.Operators import CreateGreaterRule # pylint: disable=E0401
+
+
+class TestGreaterOperator(BaseRuleTestCase):
+    """Test template mapping configurations"""
+
+    def setUp(self):
+        """Setup"""
+        super(TestGreaterOperator, self).setUp()
+        self.collection.register(CreateGreaterRule("E9001","AWS::Lambda::Function","Timeout","50","Timeout should be greater than 50"))
+
+    success_templates = ["test/fixtures/templates/good/custom/numeric-inequalities-large.yaml"]
+
+    def test_file_positive(self):
+        """Test Positive"""
+        self.helper_file_positive()
+
+    def test_file_negative(self):
+        """Test failure"""
+        self.helper_file_negative("test/fixtures/templates/good/custom/numeric-inequalities-small.yaml", 2)

--- a/test/unit/rules/custom/test_lesser_operator.py
+++ b/test/unit/rules/custom/test_lesser_operator.py
@@ -1,0 +1,26 @@
+"""
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+"""
+from test.unit.rules import BaseRuleTestCase
+
+from cfnlint.rules.custom.Operators import CreateLesserRule # pylint: disable=E0401
+
+
+class TestLesserOperator(BaseRuleTestCase):
+    """Test template mapping configurations"""
+
+    def setUp(self):
+        """Setup"""
+        super(TestLesserOperator, self).setUp()
+        self.collection.register(CreateLesserRule("E9001","AWS::Lambda::Function","Timeout","50","Timeout should be less than 50"))
+
+    success_templates = ["test/fixtures/templates/good/custom/numeric-inequalities-small.yaml"]
+
+    def test_file_positive(self):
+        """Test Positive"""
+        self.helper_file_positive()
+
+    def test_file_negative(self):
+        """Test failure"""
+        self.helper_file_negative("test/fixtures/templates/good/custom/numeric-inequalities-large.yaml", 2)

--- a/test/unit/rules/custom/test_lesser_operator.py
+++ b/test/unit/rules/custom/test_lesser_operator.py
@@ -4,7 +4,7 @@ SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase
 
-from cfnlint.rules.custom.Operators import CreateLesserRule # pylint: disable=E0401
+from cfnlint.rules.custom.Operators import CreateLesserRule  # pylint: disable=E0401
 
 
 class TestLesserOperator(BaseRuleTestCase):
@@ -13,9 +13,19 @@ class TestLesserOperator(BaseRuleTestCase):
     def setUp(self):
         """Setup"""
         super(TestLesserOperator, self).setUp()
-        self.collection.register(CreateLesserRule("E9001","AWS::Lambda::Function","Timeout","50","Timeout should be less than 50"))
+        self.collection.register(
+            CreateLesserRule(
+                "E9001",
+                "AWS::Lambda::Function",
+                "Timeout",
+                "50",
+                "Timeout should be less than 50",
+            )
+        )
 
-    success_templates = ["test/fixtures/templates/good/custom/numeric-inequalities-small.yaml"]
+    success_templates = [
+        "test/fixtures/templates/good/custom/numeric-inequalities-small.yaml"
+    ]
 
     def test_file_positive(self):
         """Test Positive"""
@@ -23,4 +33,6 @@ class TestLesserOperator(BaseRuleTestCase):
 
     def test_file_negative(self):
         """Test failure"""
-        self.helper_file_negative("test/fixtures/templates/good/custom/numeric-inequalities-large.yaml", 2)
+        self.helper_file_negative(
+            "test/fixtures/templates/good/custom/numeric-inequalities-large.yaml", 2
+        )


### PR DESCRIPTION
*Issue #, if available:*
#2612 

*Description of changes:*
- Fix corresponding operators by type conversions
- Add 1 good 1 bad test case for custom rule Greater / Lesser operator regarding
  - numerical comparison
  - number presented in python `int` type

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
