### PR TITLE
Read cached ValueTypes from us-east-1

### DIFF
--- a/src/cfnlint/rules/parameters/AllowedPattern.py
+++ b/src/cfnlint/rules/parameters/AllowedPattern.py
@@ -126,15 +126,24 @@ class AllowedPattern(CloudFormationLintRule):
                         property_type = (
                             property_specs.get("Properties").get(prop).get("Type")
                         )
+                        value_specs = (
+                            RESOURCE_SPECS.get(cfn.regions[0])
+                            .get("ValueTypes")
+                            .get(value_type, {})
+                        )
+                        if value_specs == "CACHED":
+                            value_specs = (
+                                RESOURCE_SPECS.get("us-east-1")
+                                .get("ValueTypes")
+                                .get(value_type, {})
+                            )
                         matches.extend(
                             cfn.check_value(
                                 p_value,
                                 prop,
                                 p_path,
                                 check_ref=self.check_value_ref,
-                                value_specs=RESOURCE_SPECS.get(cfn.regions[0])
-                                .get("ValueTypes")
-                                .get(value_type, {}),
+                                value_specs=value_specs,
                                 cfn=cfn,
                                 property_type=property_type,
                                 property_name=prop,

--- a/src/cfnlint/rules/resources/properties/AllowedPattern.py
+++ b/src/cfnlint/rules/resources/properties/AllowedPattern.py
@@ -93,15 +93,24 @@ class AllowedPattern(CloudFormationLintRule):
                         property_type = (
                             property_specs.get("Properties").get(prop).get("Type")
                         )
+                        value_specs = (
+                            RESOURCE_SPECS.get(cfn.regions[0])
+                            .get("ValueTypes")
+                            .get(value_type, {})
+                        )
+                        if value_specs == "CACHED":
+                            value_specs = (
+                                RESOURCE_SPECS.get("us-east-1")
+                                .get("ValueTypes")
+                                .get(value_type, {})
+                            )
                         matches.extend(
                             cfn.check_value(
                                 p_value,
                                 prop,
                                 p_path,
                                 check_value=self.check_value,
-                                value_specs=RESOURCE_SPECS.get(cfn.regions[0])
-                                .get("ValueTypes")
-                                .get(value_type, {}),
+                                value_specs=value_specs,
                                 cfn=cfn,
                                 property_type=property_type,
                                 property_name=prop,

--- a/src/cfnlint/rules/resources/properties/AllowedValue.py
+++ b/src/cfnlint/rules/resources/properties/AllowedValue.py
@@ -31,7 +31,6 @@ class AllowedValue(CloudFormationLintRule):
     def check_value(self, value, path, property_name, **kwargs):
         """Check Value"""
         matches = []
-
         allowed_value_specs = kwargs.get("value_specs", {}).get("AllowedValues", {})
 
         if allowed_value_specs:
@@ -62,15 +61,24 @@ class AllowedValue(CloudFormationLintRule):
                         property_type = (
                             property_specs.get("Properties").get(prop).get("Type")
                         )
+                        value_type_details = (
+                            RESOURCE_SPECS.get(cfn.regions[0])
+                            .get("ValueTypes")
+                            .get(value_type, {})
+                        )
+                        if value_type_details == "CACHED":
+                            value_type_details = (
+                                RESOURCE_SPECS.get("us-east-1")
+                                .get("ValueTypes")
+                                .get(value_type, {})
+                            )
                         matches.extend(
                             cfn.check_value(
                                 p_value,
                                 prop,
                                 p_path,
                                 check_value=self.check_value,
-                                value_specs=RESOURCE_SPECS.get(cfn.regions[0])
-                                .get("ValueTypes")
-                                .get(value_type, {}),
+                                value_specs=value_type_details,
                                 cfn=cfn,
                                 property_type=property_type,
                                 property_name=prop,

--- a/src/cfnlint/rules/resources/properties/NumberSize.py
+++ b/src/cfnlint/rules/resources/properties/NumberSize.py
@@ -79,6 +79,12 @@ class NumberSize(CloudFormationLintRule):
                             .get("ValueTypes")
                             .get(value_type, {})
                         )
+                        if value_specs == "CACHED":
+                            value_specs = (
+                                RESOURCE_SPECS.get("us-east-1")
+                                .get("ValueTypes")
+                                .get(value_type, {})
+                            )
                         if (
                             value_specs.get("NumberMax") is not None
                             and value_specs.get("NumberMin") is not None

--- a/src/cfnlint/rules/resources/properties/StringSize.py
+++ b/src/cfnlint/rules/resources/properties/StringSize.py
@@ -66,7 +66,12 @@ class StringSize(CloudFormationLintRule):
                             .get("ValueTypes")
                             .get(value_type, {})
                         )
-
+                        if value_specs == "CACHED":
+                            value_specs = (
+                                RESOURCE_SPECS.get("us-east-1")
+                                .get("ValueTypes")
+                                .get(value_type, {})
+                            )
                         if value_specs.get("StringMax") and value_specs.get(
                             "StringMin"
                         ):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Read cached `ValueTypes` from `us-east-1`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
