### PR TITLE
Add string length for Regex Pattern strings

### DIFF
--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_waf.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_waf.json
@@ -1,0 +1,10 @@
+[
+    {
+      "op": "add",
+      "path": "/ValueTypes/AWS::WAFRegional::RegexPatternSet.RegexPatternStrings",
+      "value": {
+        "StringMax": 200,
+        "StringMin": 0
+      }
+    }
+  ]

--- a/src/cfnlint/data/ExtendedSpecs/all/04_property_values/aws_waf.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/04_property_values/aws_waf.json
@@ -1,0 +1,9 @@
+[
+  {
+    "op": "add",
+    "path": "/ResourceTypes/AWS::WAFRegional::RegexPatternSet/Properties/RegexPatternStrings/Value",
+    "value": {
+      "ValueType": "AWS::WAFRegional::RegexPatternSet.RegexPatternStrings"
+    }
+  }
+]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Add string length for `AWS::WAFRegional::RegexPatternSet.RegexPatternStrings` strings

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
