### PR TITLE
Another character limit for WAFv2

### DIFF
--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_waf.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_waf.json
@@ -6,5 +6,13 @@
         "StringMax": 200,
         "StringMin": 0
       }
+    },
+    {
+      "op": "add",
+      "path": "/ValueTypes/AWS::WAFv2::RegexPatternSet.RegularExpressionList",
+      "value": {
+        "StringMax": 200,
+        "StringMin": 0
+      }
     }
   ]

--- a/src/cfnlint/data/ExtendedSpecs/all/04_property_values/aws_waf.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/04_property_values/aws_waf.json
@@ -5,5 +5,12 @@
     "value": {
       "ValueType": "AWS::WAFRegional::RegexPatternSet.RegexPatternStrings"
     }
+  },
+  {
+    "op": "add",
+    "path": "/ResourceTypes/AWS::WAFv2::RegexPatternSet/Properties/RegularExpressionList/Value",
+    "value": {
+      "ValueType": "AWS::WAFv2::RegexPatternSet.RegularExpressionList"
+    }
   }
 ]


### PR DESCRIPTION
*Issue #, if available:*
fix #2621 
*Description of changes:*
- Add character limits to `AWS::WAFv2::RegexPatternSet.RegularExpressionList`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
