### PR TITLE
Fix SAM templates treated as normal by api

### DIFF
--- a/src/cfnlint/api.py
+++ b/src/cfnlint/api.py
@@ -47,6 +47,7 @@ def lint(s: str, rules: RulesCollection, regions: List[str]) -> Matches:
         verbosity=0,
         mandatory_rules=None,
     )
+    runner.transform()
     return runner.run()
 
 

--- a/test/unit/module/test_api.py
+++ b/test/unit/module/test_api.py
@@ -66,3 +66,8 @@ class TestLint(TestCase):
         filename = "test/fixtures/templates/bad/issues.yaml"
         matches = self.helper_lint_string_from_file(filename)
         self.assertEqual(["E1012"], [match.rule.id for match in matches])
+
+    def test_sam_template(self):
+        filename = "test/fixtures/templates/good/transform/list_transform_many.yaml"
+        matches = self.helper_lint_string_from_file(filename)
+        self.assertEqual([], matches)


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*

Hi, this PR fixes an issue where SAM templates were treated as normal Cloudformation templates by the api, by calling `.transform` on the runner.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
