### PR TITLE
Substitute Sub on serverless CodeUri

### DIFF
--- a/src/cfnlint/transform.py
+++ b/src/cfnlint/transform.py
@@ -218,7 +218,7 @@ class Transform:
         if isinstance(uri_property, dict):
             if len(uri_property) == 1:
                 for k in uri_property.keys():
-                    if k == "Ref":
+                    if k in ["Ref", "Fn::Sub"]:
                         resource_property_dict[property_key] = s3_uri_value
             return
         if Transform.is_s3_uri(uri_property):

--- a/test/fixtures/templates/good/transform/function_use_s3_uri.yaml
+++ b/test/fixtures/templates/good/transform/function_use_s3_uri.yaml
@@ -1,0 +1,28 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Transform:
+  - 'AWS::LanguageExtensions'
+  - 'AWS::Serverless-2016-10-31'
+
+Description: cfn-lint test case
+
+Mappings:
+  RegionMap:
+    us-east-1:
+      InsightsArn: arn:aws:lambda:us-east-1:580247275435:layer:LambdaInsightsExtension:21
+    us-west-2:
+      InsightsArn: arn:aws:lambda:us-west-2:580247275435:layer:LambdaInsightsExtension:21
+
+Resources:
+  Function:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: !Sub "my-custom-authorizer-${AWS::Region}"
+      Description: Custom authorizer for APIGW
+      Runtime: nodejs16.x
+      Handler: index.handler
+      CodeUri: !Sub "s3://custom-authz-${AWS::AccountId}-${AWS::Region}/function-v1.0.zip"
+      Policies:
+        - arn:aws:iam::aws:policy/CloudWatchLambdaInsightsExecutionRolePolicy
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Layers:
+        - !FindInMap [RegionMap, !Ref AWS::Region, "InsightsArn"]

--- a/test/unit/module/transform/test_transform.py
+++ b/test/unit/module/transform/test_transform.py
@@ -90,6 +90,21 @@ class TestTransform(BaseTestCase):
             {"Bucket": "bucket", "Key": "value"},
         )
 
+    def test_conversion_of_serverless_function_uri(self):
+        """Tests that the a serverless function can convert a CodeUri Sub"""
+        filename = "test/fixtures/templates/good/transform/function_use_s3_uri.yaml"
+        region = "us-east-1"
+        template = cfn_yaml.load(filename)
+        transformed_template = Transform(filename, template, region)
+        transformed_template.transform_template()
+        self.assertDictEqual(
+            transformed_template._template.get("Resources")
+            .get("Function")
+            .get("Properties")
+            .get("Code"),
+            {"S3Bucket": "bucket", "S3Key": "value"},
+        )
+
     def test_parameter_for_autopublish_version_bad(self):
         """Test Parameter is created for autopublish version run"""
         filename = "test/fixtures/templates/bad/transform/auto_publish_alias.yaml"


### PR DESCRIPTION
*Issue #, if available:*
fix #2658 
*Description of changes:*
- Update tranform function to replace CodeUri when using a `Fn::Sub`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
