### PR TITLE
Patch AWS::Cognito::UserPool.UserPoolTags spec

### DIFF
--- a/src/cfnlint/data/CloudSpecs/cn-north-1.json
+++ b/src/cfnlint/data/CloudSpecs/cn-north-1.json
@@ -2847,8 +2847,9 @@
     },
     "UserPoolTags": {
      "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cognito-userpool.html#cfn-cognito-userpool-userpooltags",
-     "PrimitiveType": "Json",
+     "PrimitiveItemType": "String",
      "Required": false,
+     "Type": "Map",
      "UpdateType": "Mutable"
     },
     "UsernameAttributes": {

--- a/src/cfnlint/data/CloudSpecs/eu-south-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-south-1.json
@@ -3240,8 +3240,9 @@
     },
     "UserPoolTags": {
      "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cognito-userpool.html#cfn-cognito-userpool-userpooltags",
-     "PrimitiveType": "Json",
+     "PrimitiveItemType": "String",
      "Required": false,
+     "Type": "Map",
      "UpdateType": "Mutable"
     },
     "UsernameAttributes": {

--- a/src/cfnlint/data/CloudSpecs/sa-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/sa-east-1.json
@@ -5924,8 +5924,9 @@
     },
     "UserPoolTags": {
      "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cognito-userpool.html#cfn-cognito-userpool-userpooltags",
-     "PrimitiveType": "Json",
+     "PrimitiveItemType": "String",
      "Required": false,
+     "Type": "Map",
      "UpdateType": "Mutable"
     },
     "UsernameAttributes": {

--- a/src/cfnlint/data/ExtendedSpecs/all/01_spec_patch.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/01_spec_patch.json
@@ -25,6 +25,20 @@
   "value": true
  },
  {
+  "op": "add",
+  "path": "/ResourceTypes/AWS::Cognito::UserPool/Properties/UserPoolTags/PrimitiveItemType",
+  "value": "String"
+ },
+ {
+  "op": "remove",
+  "path": "/ResourceTypes/AWS::Cognito::UserPool/Properties/UserPoolTags/PrimitiveType"
+ },
+ {
+  "op": "add",
+  "path": "/ResourceTypes/AWS::Cognito::UserPool/Properties/UserPoolTags/Type",
+  "value": "Map"
+ },
+ {
   "op": "replace",
   "path": "/ResourceTypes/AWS::DynamoDB::Table/Properties/AttributeDefinitions/Required",
   "value": true

--- a/src/cfnlint/data/ExtendedSpecs/cn-north-1/07_ssm_service_addition.json
+++ b/src/cfnlint/data/ExtendedSpecs/cn-north-1/07_ssm_service_addition.json
@@ -252,8 +252,9 @@
     },
     "UserPoolTags": {
      "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cognito-userpool.html#cfn-cognito-userpool-userpooltags",
-     "PrimitiveType": "Json",
+     "PrimitiveItemType": "String",
      "Required": false,
+     "Type": "Map",
      "UpdateType": "Mutable"
     },
     "UsernameAttributes": {

--- a/src/cfnlint/data/ExtendedSpecs/eu-south-1/07_ssm_service_addition.json
+++ b/src/cfnlint/data/ExtendedSpecs/eu-south-1/07_ssm_service_addition.json
@@ -252,8 +252,9 @@
     },
     "UserPoolTags": {
      "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cognito-userpool.html#cfn-cognito-userpool-userpooltags",
-     "PrimitiveType": "Json",
+     "PrimitiveItemType": "String",
      "Required": false,
+     "Type": "Map",
      "UpdateType": "Mutable"
     },
     "UsernameAttributes": {

--- a/src/cfnlint/data/ExtendedSpecs/sa-east-1/07_ssm_service_addition.json
+++ b/src/cfnlint/data/ExtendedSpecs/sa-east-1/07_ssm_service_addition.json
@@ -1372,8 +1372,9 @@
     },
     "UserPoolTags": {
      "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cognito-userpool.html#cfn-cognito-userpool-userpooltags",
-     "PrimitiveType": "Json",
+     "PrimitiveItemType": "String",
      "Required": false,
+     "Type": "Map",
      "UpdateType": "Mutable"
     },
     "UsernameAttributes": {

--- a/test/fixtures/specs/us-east-1.json
+++ b/test/fixtures/specs/us-east-1.json
@@ -25095,9 +25095,10 @@
       },
       "Properties": {
         "UserPoolTags": {
-          "Required": false,
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cognito-userpool.html#cfn-cognito-userpool-userpooltags",
-          "PrimitiveType": "Json",
+          "PrimitiveItemType": "String",
+          "Required": false,
+          "Type": "Map",
           "UpdateType": "Mutable"
         },
         "Policies": {

--- a/test/fixtures/templates/bad/resources_cognito_userpool_tag_is_list.yaml
+++ b/test/fixtures/templates/bad/resources_cognito_userpool_tag_is_list.yaml
@@ -1,0 +1,20 @@
+AWSTemplateFormatVersion: 2010-09-09
+Resources:
+  MyCognitoUserPool:
+    Type: AWS::Cognito::UserPool
+    Properties:
+      UserPoolName: userpool
+      Policies:
+        PasswordPolicy:
+          MinimumLength: 8
+      UsernameAttributes:
+        - email
+      Schema:
+        - AttributeDataType: String
+          Name: email
+          Required: false
+      UserPoolTags:
+        - Key: Key1
+          Value: Value1
+        - Key: Key2
+          Value: Value2

--- a/test/fixtures/templates/good/resources_cognito_userpool_tag_is_string_map.yaml
+++ b/test/fixtures/templates/good/resources_cognito_userpool_tag_is_string_map.yaml
@@ -1,0 +1,18 @@
+AWSTemplateFormatVersion: 2010-09-09
+Resources:
+  MyCognitoUserPool:
+    Type: AWS::Cognito::UserPool
+    Properties:
+      UserPoolName: userpool
+      Policies:
+        PasswordPolicy:
+          MinimumLength: 8
+      UsernameAttributes:
+        - email
+      Schema:
+        - AttributeDataType: String
+          Name: email
+          Required: false
+      UserPoolTags:
+        Key1: Value1
+        Key2: Value2

--- a/test/integration/test_good_templates.py
+++ b/test/integration/test_good_templates.py
@@ -91,6 +91,38 @@ class TestQuickStartTemplates(BaseCliTestCase):
             "exit_code": 0,
         },
         {
+            "filename": "test/fixtures/templates/good/resources_cognito_userpool_tag_is_string_map.yaml",
+            "results": [],
+            "exit_code": 0,
+        },
+        {
+            "filename": "test/fixtures/templates/bad/resources_cognito_userpool_tag_is_list.yaml",
+            "results": [
+                {
+                    "Filename": "test/fixtures/templates/bad/resources_cognito_userpool_tag_is_list.yaml",
+                    "Level": "Error",
+                    "Location": {
+                        "Start": {"ColumnNumber": 7, "LineNumber": 16},
+                        "End": {"ColumnNumber": 19, "LineNumber": 16},
+                        "Path": [
+                            "Resources",
+                            "MyCognitoUserPool",
+                            "Properties",
+                            "UserPoolTags",
+                        ],
+                    },
+                    "Message": "Map must be an object of key-value pairs",
+                    "Rule": {
+                        "Description": "Checks resource property values with Primitive Types for values that match those types.",
+                        "Id": "E3012",
+                        "ShortDescription": "Check resource properties values",
+                        "Source": "https://github.com/aws-cloudformation/cfn-python-lint/blob/main/docs/cfn-resource-specification.md#valueprimitivetype",
+                    },
+                }
+            ],
+            "exit_code": 2,
+        },
+        {
             "filename": "test/fixtures/templates/good/transform_serverless_api.yaml",
             "results": [],
             "exit_code": 0,


### PR DESCRIPTION
*Issue #, if available:*
#2574

*Description of changes:*
Patch spec to narrow `UserPoolTags` type from `json` to `Map/String`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
