### PR TITLE
fix IS custom op on intrinsic functions

### DIFF
--- a/test/fixtures/templates/good/custom/is-defined.yaml
+++ b/test/fixtures/templates/good/custom/is-defined.yaml
@@ -1,29 +1,84 @@
----
 AWSTemplateFormatVersion: "2010-09-09"
 Description: >
   Testing for IS DEFINED rule
+Parameter:
+  NodeEnv:
+    Type: String
 Resources:
   LambdaExecutionRole:
-    Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
-        Version: "2012-10-17"
         Statement:
-          - Effect: Allow
+          - Action:
+              - sts:AssumeRole
+            Effect: Allow
             Principal:
               Service:
                 - lambda.amazonaws.com
                 - ec2.amazonaws.com
-            Action:
-              - sts:AssumeRole
+        Version: "2012-10-17"
       Path: "/"
-  LambdaFunctionTestDefined:
-    Type: AWS::Lambda::Function
+    Type: AWS::IAM::Role
+  LambdaFunctionTestDefinedArray:
     Properties:
+      Code: ./
+      Environment:
+        Variables:
+          NODE_ENV:
+            - 1
+            - 2
       Handler: index.handler
-      Role: !GetAtt LambdaExecutionRole.Arn
+      Role: !GetAtt "LambdaExecutionRole.Arn"
+      Runtime: nodejs18.x
+    Type: AWS::Lambda::Function
+  LambdaFunctionTestDefinedEmpty:
+    Properties:
+      Code: ./
       Environment:
         Variables:
           NODE_ENV: ""
-      Code: ./
+      Handler: index.handler
+      Role: !GetAtt "LambdaExecutionRole.Arn"
       Runtime: nodejs18.x
+    Type: AWS::Lambda::Function
+  LambdaFunctionTestDefinedGetAttr:
+    Properties:
+      Code: ./
+      Environment:
+        Variables:
+          NODE_ENV: !GetAtt "LambdaExecutionRole.Arn"
+      Handler: index.handler
+      Role: !GetAtt "LambdaExecutionRole.Arn"
+      Runtime: nodejs18.x
+    Type: AWS::Lambda::Function
+  LambdaFunctionTestDefinedObject:
+    Properties:
+      Code: ./
+      Environment:
+        Variables:
+          NODE_ENV:
+            A: 1
+      Handler: index.handler
+      Role: !GetAtt "LambdaExecutionRole.Arn"
+      Runtime: nodejs18.x
+    Type: AWS::Lambda::Function
+  LambdaFunctionTestDefinedRef:
+    Properties:
+      Code: ./
+      Environment:
+        Variables:
+          NODE_ENV: !Ref 'NodeEnv'
+      Handler: index.handler
+      Role: !GetAtt "LambdaExecutionRole.Arn"
+      Runtime: nodejs18.x
+    Type: AWS::Lambda::Function
+  LambdaFunctionTestDefinedValue:
+    Properties:
+      Code: ./
+      Environment:
+        Variables:
+          NODE_ENV: value
+      Handler: index.handler
+      Role: !GetAtt "LambdaExecutionRole.Arn"
+      Runtime: nodejs18.x
+    Type: AWS::Lambda::Function

--- a/test/fixtures/templates/good/custom/is-not-defined.yaml
+++ b/test/fixtures/templates/good/custom/is-not-defined.yaml
@@ -1,36 +1,54 @@
----
 AWSTemplateFormatVersion: "2010-09-09"
 Description: >
   Testing for IS NOT_DEFINED rule
 Resources:
   LambdaExecutionRole:
-    Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
-        Version: "2012-10-17"
         Statement:
-          - Effect: Allow
+          - Action:
+              - sts:AssumeRole
+            Effect: Allow
             Principal:
               Service:
                 - lambda.amazonaws.com
                 - ec2.amazonaws.com
-            Action:
-              - sts:AssumeRole
+        Version: "2012-10-17"
       Path: "/"
-  LambdaFunctionTestNotDefined1:
-    Type: AWS::Lambda::Function
+    Type: AWS::IAM::Role
+  LambdaFunctionTestNotDefinedFromParent:
     Properties:
-      Handler: index.handler
-      Role: !GetAtt LambdaExecutionRole.Arn
       Code: ./
-      Runtime: nodejs18.x
-  LambdaFunctionTestNotDefined2:
-    Type: AWS::Lambda::Function
-    Properties:
+      Environment:
+        Variables: !GetAtt "LambdaExecutionRole.Arn"
       Handler: index.handler
-      Role: !GetAtt LambdaExecutionRole.Arn
+      Role: !GetAtt "LambdaExecutionRole.Arn"
+      Runtime: nodejs18.x
+    Type: AWS::Lambda::Function
+  LambdaFunctionTestNotDefinedFromProperties:
+    Properties:
+      Code: ./
+      Handler: index.handler
+      Role: !GetAtt "LambdaExecutionRole.Arn"
+      Runtime: nodejs18.x
+    Type: AWS::Lambda::Function
+  LambdaFunctionTestNotDefinedRefAWSNoValue:
+    Properties:
+      Code: ./
+      Environment:
+        Variables:
+          NODE_ENV: !Ref "AWS::NoValue"
+      Handler: index.handler
+      Role: !GetAtt "LambdaExecutionRole.Arn"
+      Runtime: nodejs18.x
+    Type: AWS::Lambda::Function
+  LambdaFunctionTestNotDefinedWithSiblings:
+    Properties:
+      Code: ./
       Environment:
         Variables:
           OTHER_VARS: ""
-      Code: ./
+      Handler: index.handler
+      Role: !GetAtt "LambdaExecutionRole.Arn"
       Runtime: nodejs18.x
+    Type: AWS::Lambda::Function

--- a/test/unit/rules/custom/test_is_defined.py
+++ b/test/unit/rules/custom/test_is_defined.py
@@ -32,5 +32,5 @@ class TestIsDefinedRule(BaseRuleTestCase):
     def test_file_negative(self):
         """Test failure"""
         self.helper_file_negative(
-            "test/fixtures/templates/good/custom/is-not-defined.yaml", 2
+            "test/fixtures/templates/good/custom/is-not-defined.yaml", 4
         )

--- a/test/unit/rules/custom/test_is_not_defined.py
+++ b/test/unit/rules/custom/test_is_not_defined.py
@@ -32,5 +32,5 @@ class TestIsDefinedRule(BaseRuleTestCase):
     def test_file_negative(self):
         """Test failure"""
         self.helper_file_negative(
-            "test/fixtures/templates/good/custom/is-defined.yaml", 1
+            "test/fixtures/templates/good/custom/is-defined.yaml", 6
         )


### PR DESCRIPTION
*Issue #, if available:*
#2656 

*Description of changes:*

Previous implementation does not work with intrinsic functions, e.g. !Ref, !GetAtt, ...
This patch fixed the issue.
- !Ref AWS::NoValue is considered NOT_DEFINED
- !Ref AnyOther, !GetAtt ... are considered DEFINED

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
