### PR TITLE
Can use SecurityGroupId in default vpc SGs

### DIFF
--- a/src/cfnlint/rules/resources/ectwo/SecurityGroupIngress.py
+++ b/src/cfnlint/rules/resources/ectwo/SecurityGroupIngress.py
@@ -36,19 +36,6 @@ class SecurityGroupIngress(CloudFormationLintRule):
                     )
                 )
 
-        else:
-            if properties.get("SourceSecurityGroupId", None):
-                path_error = path[:] + ["SourceSecurityGroupId"]
-                message = (
-                    "SourceSecurityGroupId shouldn't be specified for "
-                    "Non-Vpc Security Group at {0}"
-                )
-                matches.append(
-                    RuleMatch(
-                        path_error, message.format("/".join(map(str, path_error)))
-                    )
-                )
-
         return matches
 
     def match(self, cfn):

--- a/test/unit/rules/resources/ec2/test_sg_ingress.py
+++ b/test/unit/rules/resources/ec2/test_sg_ingress.py
@@ -27,5 +27,5 @@ class TestPropertySgIngress(BaseRuleTestCase):
     def test_file_negative(self):
         """Test failure"""
         self.helper_file_negative(
-            "test/fixtures/templates/bad/properties_sg_ingress.yaml", 2
+            "test/fixtures/templates/bad/properties_sg_ingress.yaml", 1
         )


### PR DESCRIPTION
*Issue #, if available:*
fix #2310 
*Description of changes:*
Can use SecurityGroupId in default vpc SGs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
