### PR TITLE
Bugfix: Allow comments and new lines in custom rules file

### DIFF
--- a/docs/custom_rules.md
+++ b/docs/custom_rules.md
@@ -13,7 +13,8 @@ The template used for each custom rules have been included below. Angle brackets
 
 * The ruleID is auto-generated based on the line number. The E9XXX and W9XXX blocks are allocated towards custom rules.
     * As an example, custom rule on line 4 of the rules file which has error level “ERROR” would become E9004
-* Comments are supported through the use of the # symbol at the beginning of a line (e.g `#This is a comment`)
+* Comments are supported through the use of the # symbol at the beginning of a line (e.g `# This is a comment`)
+* New lines are supported throughout the rules file
 * The syntax is "quote-flexible" and will support all permutations shown below
 ```
 AWS::EC2::Instance Property EQUALS "Cloud Formation"
@@ -69,6 +70,7 @@ Pre-Requisites: The Custom Error Message requires an error level to be specified
 A custom error message can be used to override the existing fallback messages. (e.g `Show me this custom message`)
 
 ## Example
+
 This following example shows how a you can create a custom rule.
  
 This rule validates all EC2 instances in a template aren’t using the instance type “p3.2xlarge”.
@@ -84,5 +86,3 @@ AWS::Lambda::Function Environment.Variables.NODE_ENV IS DEFINED
 ```
 
 To include this rules, include your custom rules text file using the `-z custom_rules.txt` argument when running cfn-lint.
-
-

--- a/src/cfnlint/rules/custom/__init__.py
+++ b/src/cfnlint/rules/custom/__init__.py
@@ -42,73 +42,79 @@ def make_rule(line, lineNumber):
         return raw_value
 
     line = line.rstrip()
-    rule_id = lineNumber + 9000
-    line = line.split(" ", 3)
-    error_level = "E"
-    if len(line) == 4:
-        resourceType = line[0]
-        prop = line[1]
-        operator = line[2]
-        value = None
-        error_message = None
-        if "WARN" in line[3]:
-            error_level = "W"
-            value, error_message = set_arguments(line[3], "WARN")
-        elif "ERROR" in line[3]:
-            error_level = "E"
-            value, error_message = set_arguments(line[3], "ERROR")
-        else:
-            value = process_sets(line[3])
-            value = get_value(line[3])
+    # check line is not a comment or empty line
+    if not line.startswith("#") and line != "":
+        rule_id = lineNumber + 9000
+        line = line.split(" ", 3)
+        error_level = "E"
+        if len(line) == 4:
+            resourceType = line[0]
+            prop = line[1]
+            operator = line[2]
+            value = None
+            error_message = None
+            if "WARN" in line[3]:
+                error_level = "W"
+                value, error_message = set_arguments(line[3], "WARN")
+            elif "ERROR" in line[3]:
+                error_level = "E"
+                value, error_message = set_arguments(line[3], "ERROR")
+            else:
+                value = process_sets(line[3])
+                value = get_value(line[3])
 
-        if isinstance(value, str):
-            value = value.strip().strip('"')
+            if isinstance(value, str):
+                value = value.strip().strip('"')
 
-        if operator in ["EQUALS", "=="]:
-            return cfnlint.rules.custom.Operators.CreateEqualsRule(
-                error_level + str(rule_id), resourceType, prop, value, error_message
-            )
-        if operator in ["NOT_EQUALS", "!="]:
-            return cfnlint.rules.custom.Operators.CreateNotEqualsRule(
-                error_level + str(rule_id), resourceType, prop, value, error_message
-            )
-        if operator == "REGEX_MATCH":
-            return cfnlint.rules.custom.Operators.CreateRegexMatchRule(
-                error_level + str(rule_id), resourceType, prop, value, error_message
-            )
-        if operator == "IN":
-            return cfnlint.rules.custom.Operators.CreateInSetRule(
-                error_level + str(rule_id), resourceType, prop, value, error_message
-            )
-        if operator == "NOT_IN":
-            return cfnlint.rules.custom.Operators.CreateNotInSetRule(
-                error_level + str(rule_id), resourceType, prop, value, error_message
-            )
-        if operator == ">":
-            return cfnlint.rules.custom.Operators.CreateGreaterRule(
-                error_level + str(rule_id), resourceType, prop, value, error_message
-            )
-        if operator == ">=":
-            return cfnlint.rules.custom.Operators.CreateGreaterEqualRule(
-                error_level + str(rule_id), resourceType, prop, value, error_message
-            )
-        if operator == "<":
-            return cfnlint.rules.custom.Operators.CreateLesserRule(
-                error_level + str(rule_id), resourceType, prop, value, error_message
-            )
-        if operator == "<=":
-            return cfnlint.rules.custom.Operators.CreateLesserEqualRule(
-                error_level + str(rule_id), resourceType, prop, value, error_message
-            )
-        if operator == "IS":
-            if value in ["DEFINED", "NOT_DEFINED"]:
-                return cfnlint.rules.custom.Operators.CreateCustomIsDefinedRule(
+            if operator in ["EQUALS", "=="]:
+                return cfnlint.rules.custom.Operators.CreateEqualsRule(
                     error_level + str(rule_id), resourceType, prop, value, error_message
                 )
-            return cfnlint.rules.custom.Operators.CreateInvalidRule(
-                "E" + str(rule_id), f"{operator} {value}"
-            )
+            if operator in ["NOT_EQUALS", "!="]:
+                return cfnlint.rules.custom.Operators.CreateNotEqualsRule(
+                    error_level + str(rule_id), resourceType, prop, value, error_message
+                )
+            if operator == "REGEX_MATCH":
+                return cfnlint.rules.custom.Operators.CreateRegexMatchRule(
+                    error_level + str(rule_id), resourceType, prop, value, error_message
+                )
+            if operator == "IN":
+                return cfnlint.rules.custom.Operators.CreateInSetRule(
+                    error_level + str(rule_id), resourceType, prop, value, error_message
+                )
+            if operator == "NOT_IN":
+                return cfnlint.rules.custom.Operators.CreateNotInSetRule(
+                    error_level + str(rule_id), resourceType, prop, value, error_message
+                )
+            if operator == ">":
+                return cfnlint.rules.custom.Operators.CreateGreaterRule(
+                    error_level + str(rule_id), resourceType, prop, value, error_message
+                )
+            if operator == ">=":
+                return cfnlint.rules.custom.Operators.CreateGreaterEqualRule(
+                    error_level + str(rule_id), resourceType, prop, value, error_message
+                )
+            if operator == "<":
+                return cfnlint.rules.custom.Operators.CreateLesserRule(
+                    error_level + str(rule_id), resourceType, prop, value, error_message
+                )
+            if operator == "<=":
+                return cfnlint.rules.custom.Operators.CreateLesserEqualRule(
+                    error_level + str(rule_id), resourceType, prop, value, error_message
+                )
+            if operator == "IS":
+                if value in ["DEFINED", "NOT_DEFINED"]:
+                    return cfnlint.rules.custom.Operators.CreateCustomIsDefinedRule(
+                        error_level + str(rule_id),
+                        resourceType,
+                        prop,
+                        value,
+                        error_message,
+                    )
+                return cfnlint.rules.custom.Operators.CreateInvalidRule(
+                    "E" + str(rule_id), f"{operator} {value}"
+                )
 
-    return cfnlint.rules.custom.Operators.CreateInvalidRule(
-        "E" + str(rule_id), operator
-    )
+        return cfnlint.rules.custom.Operators.CreateInvalidRule(
+            "E" + str(rule_id), operator
+        )

--- a/test/fixtures/custom_rules/good/custom_rule_perfect.txt
+++ b/test/fixtures/custom_rules/good/custom_rule_perfect.txt
@@ -1,3 +1,4 @@
+#This is a comment to ensure comments in custom rules work
 AWS::IAM::Role AssumeRolePolicyDocument.Version EQUALS "2012-10-17"
 AWS::IAM::Role AssumeRolePolicyDocument.Version IN [2012-10-16,2012-10-17,2012-10-18]
 AWS::IAM::Role AssumeRolePolicyDocument.Version NOT_EQUALS "2012-10-15"
@@ -6,6 +7,8 @@ AWS::IAM::Policy PolicyName EQUALS "root" WARN ABC
 AWS::IAM::Policy PolicyName IN [2012-10-16,root,2012-10-18] ERROR ABC
 AWS::IAM::Policy PolicyName NOT_EQUALS "user" WARN ABC
 AWS::IAM::Policy PolicyName NOT_IN [2012-10-16,2012-11-20,2012-10-18] ERROR ABC
+# Adding a comment in the middle of custom rules and new line for readability
+
 AWS::EC2::Instance BlockDeviceMappings.Ebs.VolumeSize >= 20 WARN
 AWS::EC2::Instance BlockDeviceMappings.Ebs.VolumeSize > 10 ERROR ABC
 AWS::EC2::Instance BlockDeviceMappings.Ebs.VolumeSize <= 50 ERROR DEF


### PR DESCRIPTION
*Issue:*
Closes #2069 
Closes #2756

*Description of changes:*
In the documentation, comments are allowed to start with `#`.
Currently, `cfn-lint` throws an error of `not in supported operators` which means the comment is being parsed as a custom error. This is now fixed to allow any amount of comments anywhere in the custom rules file.

New lines are now allowed just for readability.
Currently, `cfn-lint` throws a traceback error of `UnboundLocalError: cannot access local variable 'operator' where it is not associated with a value` which is not an intuitive error message just for a blank new line. This is now fixed to allow new lines anywhere in the custom rules file.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice. ✅ 

**Testing**

Example `rules.txt`
```
# Check that there is a description provided
AWS::Serverless::Function Description IS DEFINED ERROR "Description must be supplied"

AWS::Serverless::Function Runtime IS DEFINED ERROR "Runtime must be supplied"
```

Current `cfn-lint` failing with comments
```
> cfn-lint -t cft.yml -z custom_rules.txt --format pretty

cft.yml
1:1:                E9001     "that" not in supported operators: [EQUALS, NOT_EQUALS, REGEX_MATCH, ==, !=, IN, NOT_IN, >, <, >=, <=, IS DEFINED, IS NOT_DEFINED]

Cfn-lint scanned 1 templates against 132 rules and found 1 errors, 0 warnings, and 0 informational violations
```

Passing integration tests for comments with changes
```
> cfn-lint -t cft.yml -z custom_rules.txt  --format pretty

Cfn-lint scanned 1 templates against 129 rules and found 0 errors, 0 warnings, and 0 informational violations
```

Current `cfn-lint` failing with new lines
```
> cfn-lint -t cft.yml -z custom_rules.txt --format pretty

Traceback (most recent call last):
  File "/opt/homebrew/bin/cfn-lint", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/opt/homebrew/lib/python3.11/site-packages/cfnlint/__main__.py", line 39, in main
    matches = list(cfnlint.core.get_matches(filenames, args))
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.11/site-packages/cfnlint/core.py", line 169, in get_matches
    (template, rules, errors) = get_template_rules(filename, args)
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.11/site-packages/cfnlint/core.py", line 310, in get_template_rules
    _build_rule_cache(args)
  File "/opt/homebrew/lib/python3.11/site-packages/cfnlint/core.py", line 270, in _build_rule_cache
    __CACHED_RULES = cfnlint.core.get_rules(
                     ^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.11/site-packages/cfnlint/core.py", line 158, in get_rules
    rules.create_from_custom_rules_file(custom_rules)
  File "/opt/homebrew/lib/python3.11/site-packages/cfnlint/rules/__init__.py", line 603, in create_from_custom_rules_file
    custom_rule = cfnlint.rules.custom.make_rule(line, line_number)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.11/site-packages/cfnlint/rules/custom/__init__.py", line 113, in make_rule
    "E" + str(rule_id), operator
                        ^^^^^^^^
UnboundLocalError: cannot access local variable 'operator' where it is not associated with a value
```

Passing integration tests for new lines with the new changes
```
> cfn-lint -t cft.yml -z custom_rules.txt  --format pretty

Cfn-lint scanned 1 templates against 129 rules and found 0 errors, 0 warnings, and 0 informational violations
```