### PR TITLE
Pin python 3.7 because of a recent build issue with 3.7.17

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python: [ 3.7, 3.8, 3.9, "3.10", "3.11" ]
+        python: [ 3.7.16, 3.8, 3.9, "3.10", "3.11" ]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Pin python 3.7 because of a recent build issue with 3.7.17

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
