### PR TITLE
fix(doc): Fix typo in custom_rules.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ The example below validates `example_template.yml` does not use any EC2 instance
 
 _custom_rule.txt_
 ```
-AWS::EC2::Instance InstanceSize NOT_EQUALS "m4.16xlarge" WARN "This is an expensive instance type, don't use it"
+AWS::EC2::Instance InstanceType NOT_EQUALS "m4.16xlarge" WARN "This is an expensive instance type, don't use it"
 ```
 
 _example_template.yml_


### PR DESCRIPTION
Fix Issue #2761

*Description of changes:*

In the custom_rules.txt example, there is no InstanceSize. It is a typo where you meant InstanceType instead.