### PR TITLE
E1018 Split doesn't support dynamic references

### DIFF
--- a/src/cfnlint/helpers.py
+++ b/src/cfnlint/helpers.py
@@ -77,9 +77,9 @@ REGEX_IPV6 = re.compile(
     re.I | re.S,
 )
 REGEX_DYN_REF = re.compile(r"^.*{{resolve:.+}}.*$")
-REGEX_DYN_REF_SSM = re.compile(r"^.*{{resolve:ssm:[a-zA-Z0-9_\.\-/]+:\d+}}.*$")
+REGEX_DYN_REF_SSM = re.compile(r"^.*{{resolve:ssm:[a-zA-Z0-9_\.\-/]+(:\d+)?}}.*$")
 REGEX_DYN_REF_SSM_SECURE = re.compile(
-    r"^.*{{resolve:ssm-secure:[a-zA-Z0-9_\.\-/]+:\d+}}.*$"
+    r"^.*{{resolve:ssm-secure:[a-zA-Z0-9_\.\-/]+(:\d+)?}}.*$"
 )
 
 

--- a/test/fixtures/templates/bad/functions_split.yaml
+++ b/test/fixtures/templates/bad/functions_split.yaml
@@ -31,3 +31,10 @@ Resources:
       AvailabilityZone: !Select
       - 0
       - Fn::Split: {Ref: AWS::Region}
+  myInstance4:
+    Type: AWS::EC2::Instance
+    Properties:
+      ImageId: String
+      AvailabilityZone: !Select
+      - 0
+      - !Split [":", "{{resolve:ssm:/vpc/subnets/private}}"]

--- a/test/unit/rules/functions/test_split.py
+++ b/test/unit/rules/functions/test_split.py
@@ -21,7 +21,7 @@ class TestRulesSplit(BaseRuleTestCase):
 
     def test_file_negative(self):
         """Test failure"""
-        self.helper_file_negative("test/fixtures/templates/bad/functions_split.yaml", 3)
+        self.helper_file_negative("test/fixtures/templates/bad/functions_split.yaml", 4)
 
     def test_split_parts(self):
         rule = Split()


### PR DESCRIPTION
*Issue #, if available:*
fix #2181 

*Description of changes:*
- Update rule E1018 to validate that there are no dynamic references

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
