### PR TITLE
Install cargo dependency on Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM python:3.11-alpine
 
+RUN apk add --no-cache cargo
 RUN pip install cfn-lint
 RUN pip install pydot
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

There was a [new version](https://github.com/python-jsonschema/jsonschema/releases/tag/v4.18.0) published for `jsonschema` one of the dependencies of `cfn-lint`. This resulted in the Docker image breaking when trying to build due to a dependency on `cargo`.

Reproduction: `docker build --progress=plain -t cfn-lint .`

```
#5 [2/3] RUN pip install cfn-lint
#5 6.058 Collecting cfn-lint
#5 6.157   Downloading cfn_lint-0.77.10-py3-none-any.whl (3.3 MB)
#5 6.383      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 3.3/3.3 MB 15.5 MB/s eta 0:00:00
#5 6.614 Collecting pyyaml>5.4 (from cfn-lint)
#5 6.626   Downloading PyYAML-6.0.tar.gz (124 kB)
#5 6.640      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 125.0/125.0 kB 12.6 MB/s eta 0:00:00
#5 7.122   Installing build dependencies: started
#5 15.87   Installing build dependencies: finished with status 'done'
#5 15.87   Getting requirements to build wheel: started
#5 22.25   Getting requirements to build wheel: finished with status 'done'
#5 22.28   Preparing metadata (pyproject.toml): started
#5 23.17   Preparing metadata (pyproject.toml): finished with status 'done'
#5 23.39 Collecting aws-sam-translator>=1.68.0 (from cfn-lint)
#5 23.42   Downloading aws_sam_translator-1.71.0-py3-none-any.whl (370 kB)
#5 23.45      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 370.1/370.1 kB 24.7 MB/s eta 0:00:00
#5 23.51 Collecting jsonpatch (from cfn-lint)
#5 23.55   Downloading jsonpatch-1.33-py2.py3-none-any.whl (12 kB)
#5 23.66 Collecting jsonschema<5,>=3.0 (from cfn-lint)
#5 23.67   Downloading jsonschema-4.18.0-py3-none-any.whl (81 kB)
#5 23.69      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 81.5/81.5 kB 6.6 MB/s eta 0:00:00
#5 23.88 Collecting networkx<4,>=2.4 (from cfn-lint)
#5 23.90   Downloading networkx-3.1-py3-none-any.whl (2.1 MB)
#5 24.01      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 2.1/2.1 MB 19.8 MB/s eta 0:00:00
#5 24.16 Collecting junit-xml~=1.9 (from cfn-lint)
#5 24.18   Downloading junit_xml-1.9-py2.py3-none-any.whl (7.1 kB)
#5 24.24 Collecting jschema-to-python~=1.2.3 (from cfn-lint)
#5 24.26   Downloading jschema_to_python-1.2.3-py3-none-any.whl (10 kB)
#5 24.30 Collecting sarif-om~=1.0.4 (from cfn-lint)
#5 24.31   Downloading sarif_om-1.0.4-py3-none-any.whl (30 kB)
#5 24.38 Collecting sympy>=1.0.0 (from cfn-lint)
#5 24.40   Downloading sympy-1.12-py3-none-any.whl (5.7 MB)
#5 24.63      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 5.7/5.7 MB 26.3 MB/s eta 0:00:00
#5 25.95 Collecting regex (from cfn-lint)
#5 25.97   Downloading regex-2023.6.3-cp311-cp311-musllinux_1_1_x86_64.whl (751 kB)
#5 26.01      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 751.1/751.1 kB 26.3 MB/s eta 0:00:00
#5 27.16 Collecting boto3==1.*,>=1.19.5 (from aws-sam-translator>=1.68.0->cfn-lint)
#5 27.17   Downloading boto3-1.27.1-py3-none-any.whl (135 kB)
#5 27.18      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 135.9/135.9 kB 17.2 MB/s eta 0:00:00
#5 27.24 Collecting typing-extensions<5,>=4.4 (from aws-sam-translator>=1.68.0->cfn-lint)
#5 27.26   Downloading typing_extensions-4.7.1-py3-none-any.whl (33 kB)
#5 27.47 Collecting pydantic~=1.8 (from aws-sam-translator>=1.68.0->cfn-lint)
#5 27.48   Downloading pydantic-1.10.11-cp311-cp311-musllinux_1_1_x86_64.whl (3.1 MB)
#5 27.57      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 3.1/3.1 MB 38.7 MB/s eta 0:00:00
#5 28.52 Collecting botocore<1.31.0,>=1.30.1 (from boto3==1.*,>=1.19.5->aws-sam-translator>=1.68.0->cfn-lint)
#5 28.57   Downloading botocore-1.30.1-py3-none-any.whl (11.0 MB)
#5 28.85      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 11.0/11.0 MB 40.8 MB/s eta 0:00:00
#5 28.99 Collecting jmespath<2.0.0,>=0.7.1 (from boto3==1.*,>=1.19.5->aws-sam-translator>=1.68.0->cfn-lint)
#5 29.01   Downloading jmespath-1.0.1-py3-none-any.whl (20 kB)
#5 29.11 Collecting s3transfer<0.7.0,>=0.6.0 (from boto3==1.*,>=1.19.5->aws-sam-translator>=1.68.0->cfn-lint)
#5 29.12   Downloading s3transfer-0.6.1-py3-none-any.whl (79 kB)
#5 29.14      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 79.8/79.8 kB 6.5 MB/s eta 0:00:00
#5 29.26 Collecting attrs (from jschema-to-python~=1.2.3->cfn-lint)
#5 29.28   Downloading attrs-23.1.0-py3-none-any.whl (61 kB)
#5 29.29      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 61.2/61.2 kB 7.9 MB/s eta 0:00:00
#5 29.36 Collecting jsonpickle (from jschema-to-python~=1.2.3->cfn-lint)
#5 29.38   Downloading jsonpickle-3.0.1-py2.py3-none-any.whl (40 kB)
#5 29.39      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 40.5/40.5 kB 5.0 MB/s eta 0:00:00
#5 29.60 Collecting pbr (from jschema-to-python~=1.2.3->cfn-lint)
#5 29.65   Downloading pbr-5.11.1-py2.py3-none-any.whl (112 kB)
#5 29.66      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 112.7/112.7 kB 10.5 MB/s eta 0:00:00
#5 29.79 Collecting jsonschema-specifications>=2023.03.6 (from jsonschema<5,>=3.0->cfn-lint)
#5 29.81   Downloading jsonschema_specifications-2023.6.1-py3-none-any.whl (17 kB)
#5 29.93 Collecting referencing>=0.28.4 (from jsonschema<5,>=3.0->cfn-lint)
#5 29.94   Downloading referencing-0.29.1-py3-none-any.whl (25 kB)
#5 30.06 Collecting rpds-py>=0.7.1 (from jsonschema<5,>=3.0->cfn-lint)
#5 30.08   Downloading rpds_py-0.8.3.tar.gz (15 kB)
#5 30.13   Installing build dependencies: started
#5 33.48   Installing build dependencies: finished with status 'done'
#5 33.48   Getting requirements to build wheel: started
#5 33.66   Getting requirements to build wheel: finished with status 'done'
#5 33.67   Preparing metadata (pyproject.toml): started
#5 33.75   Preparing metadata (pyproject.toml): finished with status 'error'
#5 33.76   error: subprocess-exited-with-error
#5 33.76   
#5 33.76   × Preparing metadata (pyproject.toml) did not run successfully.
#5 33.76   │ exit code: 1
#5 33.76   ╰─> [6 lines of output]
#5 33.76       
#5 33.76       Cargo, the Rust package manager, is not installed or is not on PATH.
#5 33.76       This package requires Rust and Cargo to compile extensions. Install it through
#5 33.76       the system's package manager or via https://rustup.rs/
#5 33.76       
#5 33.76       Checking for Rust toolchain....
#5 33.76       [end of output]
#5 33.76   
#5 33.76   note: This error originates from a subprocess, and is likely not a problem with pip.
#5 33.76 error: metadata-generation-failed
#5 33.76 
#5 33.76 × Encountered error while generating package metadata.
#5 33.76 ╰─> See above for output.
#5 33.76 
#5 33.76 note: This is an issue with the package mentioned above, not pip.
#5 33.76 hint: See above for details.
#5 ERROR: process "/bin/sh -c pip install cfn-lint" did not complete successfully: exit code: 1
------
 > [2/3] RUN pip install cfn-lint:
#5 33.76       [end of output]
#5 33.76   
#5 33.76   note: This error originates from a subprocess, and is likely not a problem with pip.
#5 33.76 error: metadata-generation-failed
#5 33.76 
#5 33.76 × Encountered error while generating package metadata.
#5 33.76 ╰─> See above for output.
#5 33.76 
#5 33.76 note: This is an issue with the package mentioned above, not pip.
#5 33.76 hint: See above for details.
------
Dockerfile:3
--------------------
   1 |     FROM python:3.11-alpine
   2 |     
   3 | >>> RUN pip install cfn-lint
   4 |     RUN pip install pydot
   5 |     
--------------------
ERROR: failed to solve: process "/bin/sh -c pip install cfn-lint" did not complete successfully: exit code: 1
```

This PR installs `cargo` on the Docker image.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
