### PR TITLE
Updated DocumentDBEngineVersion AllowedValues

### DIFF
--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
@@ -117,12 +117,12 @@
    },
    "DocumentDBEngineVersion": {
     "AllowedValues": [
-      "3.6.0",
-      "3.6",
-      "4.0",
-      "4.0.0",
-      "5.0",
-      "5.0.0"
+     "3.6.0",
+     "3.6",
+     "4.0",
+     "4.0.0",
+     "5.0",
+     "5.0.0"
     ]
    },
    "DocumentDBInstanceClass": {

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
@@ -117,9 +117,12 @@
    },
    "DocumentDBEngineVersion": {
     "AllowedValues": [
-     "3.6.0",
-     "4.0",
-     "4.0.0"
+      "3.6.0",
+      "3.6",
+      "4.0",
+      "4.0.0",
+      "5.0",
+      "5.0.0"
     ]
    },
    "DocumentDBInstanceClass": {


### PR DESCRIPTION
*Issue #, if available:*
#2798
*Description of changes:*
This will add version 5.0 and other variations of 3.6 and 4.0 engine versions as AllowedValues

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
