### PR TITLE
Fix globbing guidance for bash

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Lint all `yaml` files in `path` and all subdirectories (recursive):
 - `cfn-lint path/**/*.yaml`
 
 *Note*: If using sh/bash/zsh, you must enable globbing.
-(`setopt -s globstar` for sh/bash, `setopt extended_glob` for zsh).
+(`shopt -s globstar` for sh/bash, `setopt extended_glob` for zsh).
 
 ##### Exit Codes
 `cfn-lint` will return a non zero exit if there are any issues with your template. The value is dependent on the severity of the issues found.  For each level of discovered error `cfn-lint` will use bitwise OR to determine the final exit code.  This will result in these possibilities.


### PR DESCRIPTION
(there is no issue number - this is a minor documentation change)

*Description of changes:*
Setting additional shell behavior in bash is performed via the `shopt` command.
https://www.gnu.org/software/bash/manual/html_node/The-Shopt-Builtin.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
