### PR TITLE
Add in colons to sub regex for pseudo params

### DIFF
--- a/src/cfnlint/template/transforms/_language_extensions.py
+++ b/src/cfnlint/template/transforms/_language_extensions.py
@@ -161,12 +161,13 @@ class _Transform:
     def _replace_string_params(
         self, s: str, params: Mapping[str, Any]
     ) -> Tuple[bool, str]:
-        if not re.search(r"\${[a-zA-Z0-9]+}", s):
+        pattern = r"\${[a-zA-Z0-9:]+}"
+        if not re.search(pattern, s):
             return (True, s)
         for k, v in params.items():
             s = re.sub(rf"\${{{k}}}", v, s)
 
-        return (not (bool(re.search(r"\${[a-zA-Z0-9]+}", s))), s)
+        return (not (bool(re.search(pattern, s))), s)
 
 
 class _ForEachValue:


### PR DESCRIPTION
*Issue #, if available:*
issue #2811 
*Description of changes:*
- Fix an issue with the regex in language extensions removing a sub when pseudo parameters remained

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
