### PR TITLE
Add string restraints for glue job and event jobs

### DIFF
--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_events.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_events.json
@@ -25,5 +25,29 @@
     "StringEquals"
    ]
   }
+ },
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::Events::Rule.Name",
+  "value": {
+   "StringMax": 64,
+   "StringMin": 1
+  }
+ },
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::Events::Rule.EventBusName",
+  "value": {
+   "StringMax": 256,
+   "StringMin": 1
+  }
+ },
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::Events::Rule.Description",
+  "value": {
+   "StringMax": 512,
+   "StringMin": 1
+  }
  }
 ]

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_glue.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_glue.json
@@ -78,5 +78,13 @@
    "NumberMax": 100,
    "NumberMin": 1
   }
+ },
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::Glue::Job.Name",
+  "value": {
+   "NumberMax": 255,
+   "NumberMin": 1
+  }
  }
 ]

--- a/src/cfnlint/data/ExtendedSpecs/all/04_property_values/aws_events.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/04_property_values/aws_events.json
@@ -26,5 +26,26 @@
   "value": {
    "ValueType": "AWS::Default::Default.EnabledState"
   }
+ },
+ {
+  "op": "add",
+  "path": "/ResourceTypes/AWS::Events::Rule/Properties/Name/Value",
+  "value": {
+   "ValueType": "AWS::Events::Rule.Name"
+  }
+ },
+ {
+  "op": "add",
+  "path": "/ResourceTypes/AWS::Events::Rule/Properties/EventBusName/Value",
+  "value": {
+   "ValueType": "AWS::Events::Rule.EventBusName"
+  }
+ },
+ {
+  "op": "add",
+  "path": "/ResourceTypes/AWS::Events::Rule/Properties/Description/Value",
+  "value": {
+   "ValueType": "AWS::Events::Rule.Description"
+  }
  }
 ]

--- a/src/cfnlint/data/ExtendedSpecs/all/04_property_values/aws_glue.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/04_property_values/aws_glue.json
@@ -90,5 +90,12 @@
   "value": {
    "ValueType": "AWS::Glue::MLTransform.MaxCapacity"
   }
+ },
+ {
+  "op": "add",
+  "path": "/ResourceTypes/AWS::Glue::Job/Properties/Name/Value",
+  "value": {
+   "ValueType": "AWS::Glue::Job.Name"
+  }
  }
 ]


### PR DESCRIPTION
*Issue #, if available:*
fix #2797 

*Description of changes:*
- Add string restraints for glue job and event jobs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
