### PR TITLE
Add various resource constraints for StringMax/StringMin

### DIFF
--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_amplify.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_amplify.json
@@ -1,0 +1,58 @@
+[
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::Amplify::App.AutoBranchCreationConfig.PullRequestEnvironmentName",
+  "value": {
+   "StringMax": 20,
+   "StringMin": 1
+  }
+ },
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::Amplify::App.Description",
+  "value": {
+   "StringMax": 1000,
+   "StringMin": 1
+  }
+ },
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::Amplify::App.EnvironmentVariable.Name",
+  "value": {
+   "StringMax": 255,
+   "StringMin": 1
+  }
+ },
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::Amplify::Branch.Description",
+  "value": {
+   "StringMax": 1000,
+   "StringMin": 1
+  }
+ },
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::Amplify::Branch.EnvironmentVariable.Name",
+  "value": {
+   "StringMax": 255,
+   "StringMin": 1
+  }
+ },
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::Amplify::Branch.PullRequestEnvironmentName",
+  "value": {
+   "StringMax": 20,
+   "StringMin": 1
+  }
+ },
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::Amplify::Domain.DomainName",
+  "value": {
+   "StringMax": 255,
+   "StringMin": 1
+  }
+ }
+]

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_appflow.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_appflow.json
@@ -1,0 +1,82 @@
+[
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::AppFlow::Connector.Description",
+  "value": {
+   "StringMax": 1024,
+   "StringMin": 1
+  }
+ },
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::AppFlow::ConnectorProfile.ConnectorProfileName",
+  "value": {
+   "StringMax": 256,
+   "StringMin": 1
+  }
+ },
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::AppFlow::ConnectorProfile.SAPODataConnectorProfileProperties.PrivateLinkServiceName",
+  "value": {
+   "StringMax": 512,
+   "StringMin": 1
+  }
+ },
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::AppFlow::ConnectorProfile.SnowflakeConnectorProfileProperties.AccountName",
+  "value": {
+   "StringMax": 512,
+   "StringMin": 1
+  }
+ },
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::AppFlow::ConnectorProfile.SnowflakeConnectorProfileProperties.PrivateLinkServiceName",
+  "value": {
+   "StringMax": 512,
+   "StringMin": 1
+  }
+ },
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::AppFlow::Flow.CustomConnectorDestinationProperties.EntityName",
+  "value": {
+   "StringMax": 1024,
+   "StringMin": 1
+  }
+ },
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::AppFlow::Flow.CustomConnectorSourceProperties.EntityName",
+  "value": {
+   "StringMax": 1024,
+   "StringMin": 1
+  }
+ },
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::AppFlow::Flow.Description",
+  "value": {
+   "StringMax": 2048,
+   "StringMin": 1
+  }
+ },
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::AppFlow::Flow.DestinationFlowConfig.ConnectorProfileName",
+  "value": {
+   "StringMax": 256,
+   "StringMin": 1
+  }
+ },
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::AppFlow::Flow.SourceFlowConfig.ConnectorProfileName",
+  "value": {
+   "StringMax": 256,
+   "StringMin": 1
+  }
+ }
+]

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_athena.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_athena.json
@@ -1,0 +1,18 @@
+[
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::Athena::CapacityReservation.Name",
+  "value": {
+   "StringMax": 128,
+   "StringMin": 1
+  }
+ },
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::Athena::WorkGroup.Name",
+  "value": {
+   "StringMax": 128,
+   "StringMin": 1
+  }
+ }
+]

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_backup.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_backup.json
@@ -32,5 +32,13 @@
     ]
    }
   }
+ },
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::Backup::ReportPlan.ReportPlanDescription",
+  "value": {
+   "StringMax": 1024,
+   "StringMin": 0
+  }
  }
 ]

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_cassandra.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_cassandra.json
@@ -1,0 +1,18 @@
+[
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::Cassandra::Keyspace.KeyspaceName",
+  "value": {
+   "StringMax": 255,
+   "StringMin": 3
+  }
+ },
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::Cassandra::Table.TableName",
+  "value": {
+   "StringMax": 255,
+   "StringMin": 3
+  }
+ }
+]

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_ce.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_ce.json
@@ -1,0 +1,18 @@
+[
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::CE::AnomalyMonitor.MonitorName",
+  "value": {
+   "StringMax": 1024,
+   "StringMin": 0
+  }
+ },
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::CE::AnomalySubscription.SubscriptionName",
+  "value": {
+   "StringMax": 1024,
+   "StringMin": 0
+  }
+ }
+]

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_cleanrooms.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_cleanrooms.json
@@ -1,0 +1,42 @@
+[
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::CleanRooms::ConfiguredTable.Description",
+  "value": {
+   "StringMax": 255,
+   "StringMin": 0
+  }
+ },
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::CleanRooms::ConfiguredTable.GlueTableReference.DatabaseName",
+  "value": {
+   "StringMax": 128,
+   "StringMin": 0
+  }
+ },
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::CleanRooms::ConfiguredTable.GlueTableReference.TableName",
+  "value": {
+   "StringMax": 128,
+   "StringMin": 0
+  }
+ },
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::CleanRooms::ConfiguredTableAssociation.Description",
+  "value": {
+   "StringMax": 255,
+   "StringMin": 0
+  }
+ },
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::CleanRooms::ConfiguredTableAssociation.Name",
+  "value": {
+   "StringMax": 128,
+   "StringMin": 0
+  }
+ }
+]

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_cloudformation.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_cloudformation.json
@@ -13,5 +13,85 @@
   "value": {
    "botocore": "cloudformation/2010-05-15/PermissionModels"
   }
+ },
+ {
+   "op": "add",
+   "path": "/ValueTypes/AWS::CloudFormation::HookDefaultVersion.TypeName",
+   "value": {
+     "StringMax": 255,
+     "StringMin": 1
+   }
+ },
+ {
+   "op": "add",
+   "path": "/ValueTypes/AWS::CloudFormation::HookTypeConfig.TypeName",
+   "value": {
+     "StringMax": 196,
+     "StringMin": 10
+   }
+ },
+ {
+   "op": "add",
+   "path": "/ValueTypes/AWS::CloudFormation::HookVersion.TypeName",
+   "value": {
+     "StringMax": 196,
+     "StringMin": 10
+   }
+ },
+ {
+   "op": "add",
+   "path": "/ValueTypes/AWS::CloudFormation::ModuleDefaultVersion.ModuleName",
+   "value": {
+     "StringMax": 204,
+     "StringMin": 10
+   }
+ },
+ {
+   "op": "add",
+   "path": "/ValueTypes/AWS::CloudFormation::ModuleVersion.ModuleName",
+   "value": {
+     "StringMax": 204,
+     "StringMin": 10
+   }
+ },
+ {
+   "op": "add",
+   "path": "/ValueTypes/AWS::CloudFormation::PublicTypeVersion.TypeName",
+   "value": {
+     "StringMax": 204,
+     "StringMin": 10
+   }
+ },
+ {
+   "op": "add",
+   "path": "/ValueTypes/AWS::CloudFormation::ResourceDefaultVersion.TypeName",
+   "value": {
+     "StringMax": 204,
+     "StringMin": 10
+   }
+ },
+ {
+   "op": "add",
+   "path": "/ValueTypes/AWS::CloudFormation::ResourceVersion.TypeName",
+   "value": {
+     "StringMax": 204,
+     "StringMin": 10
+   }
+ },
+ {
+   "op": "add",
+   "path": "/ValueTypes/AWS::CloudFormation::StackSet.StackSetName",
+   "value": {
+     "StringMax": 128,
+     "StringMin": 1
+   }
+ },
+ {
+   "op": "add",
+   "path": "/ValueTypes/AWS::CloudFormation::TypeActivation.TypeName",
+   "value": {
+     "StringMax": 204,
+     "StringMin": 10
+   }
  }
 ]

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_connect.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_connect.json
@@ -1,0 +1,10 @@
+[
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::Connect::ContactFlowModule.Description",
+  "value": {
+   "StringMax": 500,
+   "StringMin": 0
+  }
+ }
+]

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_customerprofiles.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_customerprofiles.json
@@ -1,0 +1,26 @@
+[
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::CustomerProfiles::Integration.FlowDefinition.Description",
+  "value": {
+   "StringMax": 2048,
+   "StringMin": 0
+  }
+ },
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::CustomerProfiles::Integration.FlowDefinition.FlowName",
+  "value": {
+   "StringMax": 256,
+   "StringMin": 0
+  }
+ },
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::CustomerProfiles::Integration.SourceFlowConfig.ConnectorProfileName",
+  "value": {
+   "StringMax": 256,
+   "StringMin": 0
+  }
+ }
+]

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_datasync.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_datasync.json
@@ -1,0 +1,10 @@
+[
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::DataSync::LocationHDFS.NameNode.Hostname",
+  "value": {
+   "StringMax": 255,
+   "StringMin": 1
+  }
+ }
+]

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_events.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_events.json
@@ -28,6 +28,14 @@
  },
  {
   "op": "add",
+  "path": "/ValueTypes/AWS::Events::Endpoint.Description",
+  "value": {
+   "StringMax": 512,
+   "StringMin": 0
+  }
+ },
+ {
+  "op": "add",
   "path": "/ValueTypes/AWS::Events::Rule.Name",
   "value": {
    "StringMax": 64,

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_finspace.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_finspace.json
@@ -1,0 +1,18 @@
+[
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::FinSpace::Environment.Description",
+  "value": {
+   "StringMax": 1000,
+   "StringMin": 1
+  }
+ },
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::FinSpace::Environment.Name",
+  "value": {
+   "StringMax": 255,
+   "StringMin": 1
+  }
+ }
+]

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_fms.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_fms.json
@@ -1,0 +1,18 @@
+[
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::FMS::Policy.PolicyDescription",
+  "value": {
+   "StringMax": 256,
+   "StringMin": 0
+  }
+ },
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::FMS::ResourceSet.Description",
+  "value": {
+   "StringMax": 256,
+   "StringMin": 0
+  }
+ }
+]

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_grafana.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_grafana.json
@@ -1,0 +1,10 @@
+[
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::Grafana::Workspace.Name",
+  "value": {
+   "StringMax": 255,
+   "StringMin": 1
+  }
+ }
+]

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_iam.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_iam.json
@@ -85,7 +85,9 @@
     ],
     "Resources": [
      "AWS::IAM::InstanceProfile"
-    ]
+    ],
+    "StringMax": 128,
+    "StringMin": 1
    }
   }
  },

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_iotanalytics.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_iotanalytics.json
@@ -1,0 +1,10 @@
+[
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::IoTAnalytics::Dataset.OutputFileUriValue.FileName",
+  "value": {
+   "StringMax": 255,
+   "StringMin": 1
+  }
+ }
+]

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_iotwireless.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_iotwireless.json
@@ -1,0 +1,18 @@
+[
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::IoTWireless::Destination.Name",
+  "value": {
+   "StringMax": 128,
+   "StringMin": 1
+  }
+ },
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::IoTWireless::WirelessDeviceImportTask.DestinationName",
+  "value": {
+   "StringMax": 128,
+   "StringMin": 1
+  }
+ }
+]

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_ivs.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_ivs.json
@@ -1,0 +1,26 @@
+[
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::IVS::Channel.Name",
+  "value": {
+   "StringMax": 128,
+   "StringMin": 0
+  }
+ },
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::IVS::PlaybackKeyPair.Name",
+  "value": {
+   "StringMax": 128,
+   "StringMin": 0
+  }
+ },
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::IVS::RecordingConfiguration.Name",
+  "value": {
+   "StringMax": 128,
+   "StringMin": 0
+  }
+ }
+]

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_ivschat.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_ivschat.json
@@ -1,0 +1,18 @@
+[
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::IVSChat::LoggingConfiguration.Name",
+  "value": {
+   "StringMax": 128,
+   "StringMin": 0
+  }
+ },
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::IVSChat::Room.Name",
+  "value": {
+   "StringMax": 128,
+   "StringMin": 0
+  }
+ }
+]

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_m2.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_m2.json
@@ -1,0 +1,18 @@
+[
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::M2::Application.Name",
+  "value": {
+   "StringMax": 60,
+   "StringMin": 1
+  }
+ },
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::M2::Environment.Name",
+  "value": {
+   "StringMax": 60,
+   "StringMin": 1
+  }
+ }
+]

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_memorydb.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_memorydb.json
@@ -1,0 +1,16 @@
+[
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::MemoryDB::ACL.ACLName",
+  "value": {
+   "StringMin": 1
+  }
+ },
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::MemoryDB::Cluster.ACLName",
+  "value": {
+   "StringMin": 1
+  }
+ }
+]

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_networkfirewall.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_networkfirewall.json
@@ -1,0 +1,10 @@
+[
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::NetworkFirewall::Firewall.Description",
+  "value": {
+   "StringMax": 512,
+   "StringMin": 0
+  }
+ }
+]

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_opsworkscm.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_opsworkscm.json
@@ -1,0 +1,10 @@
+[
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::OpsWorksCM::Server.EngineAttribute.Name",
+  "value": {
+   "StringMax": 10000,
+   "StringMin": 0
+  }
+ }
+]

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_organizations.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_organizations.json
@@ -1,0 +1,10 @@
+[
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::Organizations::Policy.Description",
+  "value": {
+   "StringMax": 512,
+   "StringMin": 0
+  }
+ }
+]

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_panorama.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_panorama.json
@@ -1,0 +1,10 @@
+[
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::Panorama::ApplicationInstance.Description",
+  "value": {
+   "StringMax": 255,
+   "StringMin": 0
+  }
+ }
+]

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_rds.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_rds.json
@@ -38,6 +38,14 @@
  },
  {
   "op": "add",
+  "path": "/ValueTypes/AWS::RDS::DBParameterGroup.DBParameterGroupName",
+  "value": {
+   "StringMax": 255,
+   "StringMin": 1
+  }
+ },
+ {
+  "op": "add",
   "path": "/ValueTypes/AWS::RDS::DBProxyEndpoint.TargetRole",
   "value": {
    "AllowedValues": [

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_redshift.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_redshift.json
@@ -6,5 +6,45 @@
    "NumberMax": 100,
    "NumberMin": 1
   }
+ },
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::Redshift::EndpointAccess.EndpointName",
+  "value": {
+   "StringMax": 2147483647,
+   "StringMin": 0
+  }
+ },
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::Redshift::EndpointAccess.SubnetGroupName",
+  "value": {
+   "StringMax": 2147483647,
+   "StringMin": 0
+  }
+ },
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::Redshift::EventSubscription.SubscriptionName",
+  "value": {
+   "StringMax": 2147483647,
+   "StringMin": 0
+  }
+ },
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::Redshift::ScheduledAction.ScheduledActionDescription",
+  "value": {
+   "StringMax": 2147483647,
+   "StringMin": 0
+  }
+ },
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::Redshift::ScheduledAction.ScheduledActionName",
+  "value": {
+   "StringMax": 2147483647,
+   "StringMin": 0
+  }
  }
 ]

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_resourceexplorer2.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_resourceexplorer2.json
@@ -1,0 +1,10 @@
+[
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::ResourceExplorer2::View.ViewName",
+  "value": {
+   "StringMax": 64,
+   "StringMin": 1
+  }
+ }
+]

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_route53.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_route53.json
@@ -1,0 +1,10 @@
+[
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::Route53::KeySigningKey.Name",
+  "value": {
+   "StringMax": 128,
+   "StringMin": 3
+  }
+ }
+]

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_route53resolver.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_route53resolver.json
@@ -1,0 +1,10 @@
+[
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::Route53Resolver::FirewallRuleGroupAssociation.Name",
+  "value": {
+   "StringMax": 64,
+   "StringMin": 1
+  }
+ }
+]

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_ses.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_ses.json
@@ -1,0 +1,18 @@
+[
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::SES::ConfigurationSet.Name",
+  "value": {
+   "StringMax": 64,
+   "StringMin": 1
+  }
+ },
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::SES::ConfigurationSetEventDestination.EventDestination.Name",
+  "value": {
+   "StringMax": 64,
+   "StringMin": 1
+  }
+ }
+]

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_ssm.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_ssm.json
@@ -1,6 +1,46 @@
 [
  {
   "op": "add",
+  "path": "/ValueTypes/AWS::SSM::Association.AssociationName",
+  "value": {
+   "StringMax": 128,
+   "StringMin": 3
+  }
+ },
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::SSM::Association.Name",
+  "value": {
+   "StringMax": 128,
+   "StringMin": 3
+  }
+ },
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::SSM::Document.DocumentRequires.Name",
+  "value": {
+   "StringMax": 128,
+   "StringMin": 3
+  }
+ },
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::SSM::Document.Name",
+  "value": {
+   "StringMax": 128,
+   "StringMin": 3
+  }
+ },
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::SSM::Document.VersionName",
+  "value": {
+   "StringMax": 128,
+   "StringMin": 1
+  }
+ },
+ {
+  "op": "add",
   "path": "/ValueTypes/AWS::SSM::MaintenanceWindow.Cutoff",
   "value": {
    "NumberMax": 23,

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_ssmcontacts.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_ssmcontacts.json
@@ -1,0 +1,10 @@
+[
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::SSMContacts::Rotation.Name",
+  "value": {
+   "StringMax": 255,
+   "StringMin": 1
+  }
+ }
+]

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_synthetics.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_synthetics.json
@@ -1,0 +1,10 @@
+[
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::Synthetics::Canary.Name",
+  "value": {
+   "StringMax": 21,
+   "StringMin": 1
+  }
+ }
+]

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_timestream.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_timestream.json
@@ -1,0 +1,18 @@
+[
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::Timestream::Table.DatabaseName",
+  "value": {
+   "StringMax": 256,
+   "StringMin": 3
+  }
+ },
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::Timestream::Table.TableName",
+  "value": {
+   "StringMax": 256,
+   "StringMin": 3
+  }
+ }
+]

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_transfer.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_transfer.json
@@ -1,0 +1,10 @@
+[
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::Transfer::Workflow.Description",
+  "value": {
+   "StringMax": 256,
+   "StringMin": 0
+  }
+ }
+]

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_wafv2.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_wafv2.json
@@ -1,0 +1,122 @@
+[
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::WAFv2::IPSet.Description",
+  "value": {
+   "StringMax": 256,
+   "StringMin": 1
+  }
+ },
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::WAFv2::IPSet.Name",
+  "value": {
+   "StringMax": 128,
+   "StringMin": 1
+  }
+ },
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::WAFv2::RegexPatternSet.Description",
+  "value": {
+   "StringMax": 256,
+   "StringMin": 1
+  }
+ },
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::WAFv2::RegexPatternSet.Name",
+  "value": {
+   "StringMax": 128,
+   "StringMin": 1
+  }
+ },
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::WAFv2::RuleGroup.Description",
+  "value": {
+   "StringMax": 256,
+   "StringMin": 1
+  }
+ },
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::WAFv2::RuleGroup.Label.Name",
+  "value": {
+   "StringMax": 1024,
+   "StringMin": 1
+  }
+ },
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::WAFv2::RuleGroup.LabelSummary.Name",
+  "value": {
+   "StringMax": 1024,
+   "StringMin": 1
+  }
+ },
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::WAFv2::RuleGroup.Name",
+  "value": {
+   "StringMax": 128,
+   "StringMin": 1
+  }
+ },
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::WAFv2::RuleGroup.Rule.Name",
+  "value": {
+   "StringMax": 128,
+   "StringMin": 1
+  }
+ },
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::WAFv2::WebACL.Description",
+  "value": {
+   "StringMax": 256,
+   "StringMin": 1
+  }
+ },
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::WAFv2::WebACL.ExcludedRule.Name",
+  "value": {
+   "StringMax": 0,
+   "StringMin": 0
+  }
+ },
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::WAFv2::WebACL.Label.Name",
+  "value": {
+   "StringMax": 1024,
+   "StringMin": 1
+  }
+ },
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::WAFv2::WebACL.ManagedRuleGroupStatement.Name",
+  "value": {
+   "StringMax": 128,
+   "StringMin": 1
+  }
+ },
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::WAFv2::WebACL.Name",
+  "value": {
+   "StringMax": 128,
+   "StringMin": 1
+  }
+ },
+ {
+  "op": "add",
+  "path": "/ValueTypes/AWS::WAFv2::WebACL.Rule.Name",
+  "value": {
+   "StringMax": 128,
+   "StringMin": 1
+  }
+ }
+]


### PR DESCRIPTION
*Description of changes:*

Based on the exchange in #2797 with @kddejong I whipped up a small script to scan the various resources for `Name` and `Description` and see if they were missing their constraints. This is the result of that.

For `Description` if an explicit maximum was given, but no minimum I reasoned that `0` is valid since it's only descriptive and an empty string is okay. For `Name`, as it is typically (always) an identifier it should always have a minimum of `1`. Is this a fair assumption?

I initially wanted to add the `AllowedPatternRegexp` information, but the syntax at first seems all over the place in the CloudFormation documentation.

There are still some mistakes in this that I need to rectify, but they also depend on my question above.

I also have not done any checking against botocore to reference their specified constraints for this. What do we prefer, reference their data to avoid repeating and potential discrepencies?

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
