### PR TITLE
Fix incorrect attribute names for Glue Job Name constraint check

### DIFF
--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_glue.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_glue.json
@@ -83,8 +83,8 @@
   "op": "add",
   "path": "/ValueTypes/AWS::Glue::Job.Name",
   "value": {
-   "NumberMax": 255,
-   "NumberMin": 1
+   "StringMax": 255,
+   "StringMin": 1
   }
  }
 ]


### PR DESCRIPTION
*Description of changes:*

PR #2816 added constraints for the Glue Job resource type, but with a wrong attribute name

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
