### PR TITLE
#2849 Added ItemReader key to StateMachine Map State

### DIFF
--- a/src/cfnlint/rules/resources/stepfunctions/StateMachine.py
+++ b/src/cfnlint/rules/resources/stepfunctions/StateMachine.py
@@ -61,6 +61,7 @@ class StateMachine(CloudFormationLintRule):
                 "Iterator",
                 "ItemsPath",
                 "ItemProcessor",
+                "ItemReader",
                 "ItemSelector",
                 "ResultPath",
                 "ResultSelector",


### PR DESCRIPTION
#2849 

Added ItemReader key to the list of allowed keys in StateMachine Map State.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
