### PR TITLE
Security groups are now supported for network load balancers

### DIFF
--- a/src/cfnlint/rules/resources/elb/Elb.py
+++ b/src/cfnlint/rules/resources/elb/Elb.py
@@ -157,25 +157,6 @@ HTTPS has certificate HTTP has no certificate"
         scenarios = cfn.get_object_without_nested_conditions(resource_properties, path)
         for scenario in scenarios:
             properties = scenario.get("Object")
-            if self.get_loadbalancer_type(properties) == "network":
-                if properties.get("SecurityGroups"):
-                    if scenario.get("Scenario"):
-                        scenario_text = " and ".join(
-                            [
-                                f'when condition "{k}" is {v}'
-                                for (k, v) in scenario.get("Scenario").items()
-                            ]
-                        )
-                        message = f'Security groups are not supported for load balancers with type "network" {scenario_text}'
-                        matches.append(RuleMatch(path, message))
-                    else:
-                        path = path + ["SecurityGroups"]
-                        matches.append(
-                            RuleMatch(
-                                path,
-                                'Security groups are not supported for load balancers with type "network"',
-                            )
-                        )
 
             matches.extend(
                 self.check_alb_subnets(properties, path, scenario.get("Scenario"))

--- a/test/unit/rules/resources/elb/test_elb.py
+++ b/test/unit/rules/resources/elb/test_elb.py
@@ -25,7 +25,7 @@ class TestPropertyElb(BaseRuleTestCase):
     def test_file_negative(self):
         """Test failure"""
         self.helper_file_negative(
-            "test/fixtures/templates/bad/resources/elb/properties.yaml", 8
+            "test/fixtures/templates/bad/resources/elb/properties.yaml", 6
         )
 
     def test_alb_subnets(self):


### PR DESCRIPTION
Issue #, if available: None

*Description of changes:*

Network load balancers [do now support security groups](https://aws.amazon.com/about-aws/whats-new/2023/08/network-load-balancer-supports-security-groups/). This change will cause security groups on network load balancers to not show for E2503.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice. ✔️
