### PR TITLE
Force regex to be at least 2022 for typing parameter

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ that could potentially be improved'),
         'jschema_to_python~=1.2.3',
         'sarif-om~=1.0.4',
         'sympy>=1.0.0',
-        'regex',
+        'regex>=2021.7.1',
     ],
     python_requires='>=3.7, <=4.0, !=4.0',
     entry_points={


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Force regex to be at least 2022 because of typing being available.  cfn-lint will fail when regex is lower than 2022

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
