### PR TITLE
Add CausePath and ErrorPath key types to Fail state

### DIFF
--- a/src/cfnlint/rules/resources/stepfunctions/StateMachine.py
+++ b/src/cfnlint/rules/resources/stepfunctions/StateMachine.py
@@ -72,7 +72,7 @@ class StateMachine(CloudFormationLintRule):
             "Choice": ["Choices", "Default"],
             "Wait": ["Seconds", "Timestamp", "SecondsPath", "TimestampPath"],
             "Succeed": [],
-            "Fail": ["Cause", "Error"],
+            "Fail": ["Cause", "CausePath", "Error", "ErrorPath"],
             "Parallel": [
                 "Branches",
                 "ResultPath",


### PR DESCRIPTION
*Description of changes:*
New key types, CausePath and ErrorPath, were added to the Fail state.

Docs: https://docs.aws.amazon.com/step-functions/latest/dg/amazon-states-language-fail-state.html