### PR TITLE
Fix rule E2520 when empty lists are used

### DIFF
--- a/src/cfnlint/rules/resources/properties/Exclusive.py
+++ b/src/cfnlint/rules/resources/properties/Exclusive.py
@@ -40,7 +40,7 @@ class Exclusive(CloudFormationLintRule):
                     for prop in obj:
                         if prop == k:
                             for excl_property in exclusions[prop]:
-                                if excl_property in obj:
+                                if obj.get(excl_property):
                                     if property_set["Scenario"] is None:
                                         message = "Property {0} should NOT exist with {1} for {2}"
                                         matches.append(

--- a/test/fixtures/templates/good/resources/properties/exclusive.yaml
+++ b/test/fixtures/templates/good/resources/properties/exclusive.yaml
@@ -6,3 +6,46 @@ Resources:
       CidrIp: !Ref AWS::NoValue
       IpProtocol: "-1"
       GroupId: sg-abc1234567
+  Alarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "${AWS::StackName}-ALB-5XX-Percentage"
+      ActionsEnabled: true
+      OKActions: []
+      AlarmActions: []
+      InsufficientDataActions: []
+      Dimensions: []
+      EvaluationPeriods: 15
+      DatapointsToAlarm: 3
+      Threshold: 5
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+      Metrics:
+        - Id: e1
+          Label: ALB 5XX Percentage
+          ReturnData: true
+          Expression: (m2/(m1+m2+m3+0.001))*100
+        - Id: m1
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: AWS/ApplicationELB
+              MetricName: RequestCount
+            Period: 60
+            Stat: Sum
+        - Id: m2
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: AWS/ApplicationELB
+              MetricName: HTTPCode_ELB_5XX_Count
+            Period: 60
+            Stat: Sum
+        - Id: m3
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: AWS/ApplicationELB
+              MetricName: HTTPCode_ELB_4XX_Count
+            Period: 60
+            Stat: Sum

--- a/test/unit/rules/resources/properties/test_exclusive.py
+++ b/test/unit/rules/resources/properties/test_exclusive.py
@@ -16,6 +16,9 @@ class TestPropertyExclusive(BaseRuleTestCase):
         """Setup"""
         super(TestPropertyExclusive, self).setUp()
         self.collection.register(Exclusive())
+        self.success_templates = [
+            "test/fixtures/templates/good/resources/properties/exclusive.yaml"
+        ]
 
     def test_file_positive(self):
         """Test Positive"""


### PR DESCRIPTION
*Issue #, if available:*
fix #2890 
*Description of changes:*
- Fix rule E2520 when empty lists are used

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
