### PR TITLE
Language transformation return empty objects

### DIFF
--- a/src/cfnlint/template/transforms/_language_extensions.py
+++ b/src/cfnlint/template/transforms/_language_extensions.py
@@ -181,10 +181,11 @@ class _Transform:
                     # a sub object may be none or we have returned
                     # an empty object.  We don't want to remove empty
                     # strings "" or 0 (zeros)
-                    if sub_value is None or sub_value == {}:
+                    # Remove `or sub_value == {}` for issue #2896
+                    if sub_value is None:
                         del obj[k]
                     else:
-                        obj[k] = self._walk(v, params, cfn)
+                        obj[k] = sub_value
         elif isinstance(obj, list):
             for i, v in enumerate(obj):
                 obj[i] = self._walk(v, params, cfn)


### PR DESCRIPTION
*Issue #, if available:*
fix #2896 

*Description of changes:*
Update Language transformation to return empty objects

This undoes some of the changes in #2827 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
