### PR TITLE
Update E2532 to support ToleratedFailurePercentage and ItemBatcher to Map

### DIFF
--- a/src/cfnlint/rules/resources/stepfunctions/StateMachine.py
+++ b/src/cfnlint/rules/resources/stepfunctions/StateMachine.py
@@ -68,6 +68,8 @@ class StateMachine(CloudFormationLintRule):
                 "Retry",
                 "Catch",
                 "Parameters",
+                "ToleratedFailurePercentage",
+                "ItemBatcher",
             ],
             "Choice": ["Choices", "Default"],
             "Wait": ["Seconds", "Timestamp", "SecondsPath", "TimestampPath"],


### PR DESCRIPTION
*Issue #, if available:*
fix #2852 
*Description of changes:*
- Update `E2532` to support `ToleratedFailurePercentage` and `ItemBatcher` to `Map`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
