### PR TITLE
Validate runtime is string before startswith

### DIFF
--- a/src/cfnlint/rules/resources/lmbd/SnapStartEnabled.py
+++ b/src/cfnlint/rules/resources/lmbd/SnapStartEnabled.py
@@ -23,7 +23,7 @@ class SnapStartEnabled(CloudFormationLintRule):
         self.resource_property_types.append("AWS::Lambda::Function")
 
     def validate(self, runtime, path):
-        if not runtime:
+        if not isinstance(runtime, str):
             return []
 
         if not (runtime.startswith("java")) and runtime not in ["java8.al2", "java8"]:

--- a/src/cfnlint/rules/resources/lmbd/SnapStartSupported.py
+++ b/src/cfnlint/rules/resources/lmbd/SnapStartSupported.py
@@ -39,6 +39,10 @@ class SnapStartSupported(CloudFormationLintRule):
             if snap_start.get("ApplyOn") != "PublishedVersions":
                 continue
 
+            # Validate runtime is a string before using startswith
+            if not isinstance(runtime, str):
+                continue
+
             if (
                 runtime
                 and (not runtime.startswith("java"))

--- a/test/fixtures/templates/good/resources/lambda/snapstart-supported.yaml
+++ b/test/fixtures/templates/good/resources/lambda/snapstart-supported.yaml
@@ -1,3 +1,6 @@
+Parameters:
+  Runtime:
+    Type: String
 Resources:
   LambdaRole:
     Type: AWS::IAM::Role
@@ -20,6 +23,21 @@ Resources:
         S3Bucket: my-bucket
         S3Key: function.zip
       Runtime: java17
+      SnapStart:
+        ApplyOn: PublishedVersions
+      TracingConfig:
+        Mode: Active
+
+  FunctionParameter:
+    Type: AWS::Lambda::Function
+    Properties:
+      Handler: index.handler
+      Role: !GetAtt LambdaRole.Arn
+      ReservedConcurrentExecutions: 20
+      Code:
+        S3Bucket: my-bucket
+        S3Key: function.zip
+      Runtime: !Ref Runtime
       SnapStart:
         ApplyOn: PublishedVersions
       TracingConfig:


### PR DESCRIPTION
*Issue #, if available:*
fix #2911 

*Description of changes:*
- Update rule `E2530` and `I2530` to make sure `Runtime` is a string before using `startswith`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
