### PR TITLE
Support Python 3.12

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python: [ 3.7, 3.8, 3.9, "3.10", "3.11" ]
+        python: [ 3.7, 3.8, 3.9, "3.10", "3.11", "3.12" ]
 
     steps:
       - uses: actions/checkout@v4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,7 @@ Tox test suites available:
 * **py39**: Unit tests (Python 3.9)
 * **py310**: Unit tests (Python 3.10)
 * **py311**: Unit tests (Python 3.11)
+* **py312**: Unit tests (Python 3.12)
 * **style**: Python syntax check
 
 ## Contributing via Pull Requests

--- a/setup.py
+++ b/setup.py
@@ -74,5 +74,6 @@ that could potentially be improved'),
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{37,38,39,310,311},style
+envlist = py{37,38,39,310,311,312},style
 
 [testenv]
 commands =


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*  Run tests against Python 3.12 and add trove classifier.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
