### PR TITLE
Add in LoadBalancerArn to LoadBalancerV2Arn

### DIFF
--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
@@ -292,7 +292,9 @@
     }
    },
    "LoadBalancerV2Arn": {
-    "GetAtt": {},
+    "GetAtt": {
+     "AWS::ElasticLoadBalancingV2::LoadBalancer": "LoadBalancerArn"
+    },
     "Ref": {
      "Parameters": [
       "String"


### PR DESCRIPTION
*Issue #, if available:*
fix #2934 

*Description of changes:*
- Add in `AWS::ElasticLoadBalancingV2::LoadBalancer.LoadBalancerArn` to `LoadBalancerV2Arn`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
