### PR TITLE
Add Trunk Check instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,16 +68,17 @@ docker run --rm -v `pwd`:/data cfn-python-lint:latest /data/template.yaml
 
 ### Trunk Check
 
-Trunk Check [docs](https://docs.trunk.io/check)
+Trunk Check ([docs](https://docs.trunk.io/check))
+
 Source to integration [here](https://github.com/trunk-io/plugins/blob/main/linters/cfnlint/plugin.yaml).
 
 In repository to be linted:
 
 ```shell
-     # to enable the latest version
-     trunk check enable cfnlint
-     # to enable a specific version
-     trunk check enable cfnlint@0.58.2
+# to enable the latest version
+trunk check enable cfnlint
+# to enable a specific version
+trunk check enable cfnlint@0.58.2
 ```
 
 ### Editor Plugins

--- a/README.md
+++ b/README.md
@@ -66,6 +66,20 @@ In repository to be linted:
 docker run --rm -v `pwd`:/data cfn-python-lint:latest /data/template.yaml
 ```
 
+### Trunk Check
+
+Trunk Check [docs](https://docs.trunk.io/check)
+Source to integration [here](https://github.com/trunk-io/plugins/blob/main/linters/cfnlint/plugin.yaml).
+
+In repository to be linted:
+
+```shell
+     # to enable the latest version
+     trunk check enable cfnlint
+     # to enable a specific version
+     trunk check enable cfnlint@0.58.2
+```
+
 ### Editor Plugins
 
 There are IDE plugins available to get direct linter feedback from you favorite editor:

--- a/README.md
+++ b/README.md
@@ -68,9 +68,7 @@ docker run --rm -v `pwd`:/data cfn-python-lint:latest /data/template.yaml
 
 ### Trunk Check
 
-Trunk Check ([docs](https://docs.trunk.io/check))
-
-Source to integration [here](https://github.com/trunk-io/plugins/blob/main/linters/cfnlint/plugin.yaml).
+Trunk Check: [docs](https://docs.trunk.io/check) and integration [source](https://github.com/trunk-io/plugins/blob/main/linters/cfnlint/plugin.yaml)
 
 In repository to be linted:
 


### PR DESCRIPTION
Hi. I'm an engineer at Trunk, a free extensible super-linter that uses and automates cfn-lint. This PR just adds instructions for installing and enabling cfn-lint if you already have Trunk Check installed. Please let me know if this isn't appropriate. Thanks.