### PR TITLE
Disable and configure certain rules when template is from CDK

### DIFF
--- a/src/cfnlint/rules/resources/HardCodedArnProperties.py
+++ b/src/cfnlint/rules/resources/HardCodedArnProperties.py
@@ -74,6 +74,10 @@ class HardCodedArnProperties(CloudFormationLintRule):
     def match(self, cfn):
         matches = []
 
+        # Skip rule if CDK
+        if cfn.is_cdk_template():
+            return matches
+
         transforms = cfn.transform_pre["Transform"]
         transforms = transforms if isinstance(transforms, list) else [transforms]
         if "AWS::Serverless-2016-10-31" in cfn.transform_pre["Transform"]:

--- a/src/cfnlint/rules/resources/properties/AvailabilityZone.py
+++ b/src/cfnlint/rules/resources/properties/AvailabilityZone.py
@@ -63,6 +63,10 @@ class AvailabilityZone(CloudFormationLintRule):
         """Check itself"""
         matches = []
 
+        # Skip rule if CDK
+        if cfn.is_cdk_template():
+            return matches
+
         matches.extend(
             cfn.check_value(
                 properties,

--- a/src/cfnlint/template/template.py
+++ b/src/cfnlint/template/template.py
@@ -202,6 +202,23 @@ class Template:  # pylint: disable=R0904,too-many-lines,too-many-instance-attrib
         )
         return bool(lang_extensions_transform in transform_type)
 
+    def is_cdk_template(self) -> bool:
+        """Check if the template was created by CDK"""
+        resources = self.template.get("Resources")
+        if not isinstance(resources, dict):
+            return False
+
+        for _, properties in resources.items():
+            if not isinstance(properties, dict):
+                continue
+            resource_type = properties.get("Type")
+            if not isinstance(resource_type, str):
+                continue
+            if resource_type == "AWS::CDK::Metadata":
+                return True
+
+        return False
+
     def get_resources(self, resource_type=[]):
         """
         Get Resources

--- a/test/fixtures/templates/good/resources/properties/az_cdk.yaml
+++ b/test/fixtures/templates/good/resources/properties/az_cdk.yaml
@@ -1,0 +1,8 @@
+Resources:
+  CdkMetadata:
+    Type: AWS::CDK::Metadata
+  Instance:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: vpc-1234567
+      AvailabilityZone: us-east-1a

--- a/test/fixtures/templates/good/resources/properties/hard_coded_arn_properties_cdk.yaml
+++ b/test/fixtures/templates/good/resources/properties/hard_coded_arn_properties_cdk.yaml
@@ -1,0 +1,82 @@
+AWSTemplateFormatVersion: 2010-09-09
+Resources:
+  CdkMetadata:
+    Type: AWS::CDK::Metadata
+
+  S3BadBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      AccessControl: Private
+      NotificationConfiguration:
+        TopicConfigurations:
+        - Topic: !Sub arn:aws:sns:us-east-1:123456789012:TestTopic
+          Event: s3:ReducedRedundancyLostObject
+
+  SampleBadBucketPolicy: 
+    Type: AWS::S3::BucketPolicy
+    Properties: 
+      Bucket: !Ref S3BadBucket
+      PolicyDocument: 
+        Statement: 
+          - Action: 
+              - s3:GetObject
+            Effect: Allow
+            Resource: !Sub arn:aws:s3:::${S3BadBucket}
+            Principal: "*"
+
+  SampleRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+              - ec2.amazonaws.com
+            Action:
+              - 'sts:AssumeRole'
+      Path: /
+
+
+  SampleBadIAMPolicy1:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Action:
+              - sns:Publish
+            Resource: !Sub arn:${AWS::Partition}:sns:us-east-1:${AWS::AccountId}:TestTopic
+      Roles:
+        - !Ref SampleRole
+
+  SampleBadIAMPolicy2:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Action:
+              - sns:Publish
+            Resource: 
+              - !Sub arn:${AWS::Partition}:sns:us-east-1:${AWS::AccountId}:TestTopic
+              - !Sub arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:TestTopic
+      Roles:
+        - !Ref SampleRole
+
+  SampleBadIAMPolicy3:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Action:
+              - sns:Publish
+            Resource: 
+              - !Sub arn:${AWS::Partition}:sns:${AWS::Partition}:${AWS::AccountId}:TestTopic
+      Roles:
+        - !Ref SampleRole

--- a/test/unit/module/test_template.py
+++ b/test/unit/module/test_template.py
@@ -1254,3 +1254,58 @@ ElasticLoadBalancer -> MyEC2Instance  [color=black, key=0, label=Ref, source_pat
                 },
                 self.template.get_valid_getatts(),
             )
+
+    def test_is_cdk_bad_type(self):
+        template = {
+            "Resources": {
+                "CDK": {
+                    "Type": ["AWS::CDK::Metadata"],
+                    "Properties": {
+                        "AssumeRolePolicyDocument": {
+                            "Version": "2012-10-17",
+                        }
+                    },
+                }
+            },
+        }
+
+        template = Template("test.yaml", template)
+        self.assertFalse(template.is_cdk_template())
+
+    def test_is_cdk_bad_resources(self):
+        template = {
+            "Resources": [
+                {
+                    "CDK": {
+                        "Type": ["AWS::CDK::Metadata"],
+                        "Properties": {
+                            "AssumeRolePolicyDocument": {
+                                "Version": "2012-10-17",
+                            }
+                        },
+                    }
+                }
+            ],
+        }
+
+        template = Template("test.yaml", template)
+        self.assertFalse(template.is_cdk_template())
+
+    def test_is_cdk_bad_resource_props(self):
+        template = {
+            "Resources": {
+                "CDK": [
+                    {
+                        "Type": ["AWS::CDK::Metadata"],
+                        "Properties": {
+                            "AssumeRolePolicyDocument": {
+                                "Version": "2012-10-17",
+                            }
+                        },
+                    }
+                ]
+            },
+        }
+
+        template = Template("test.yaml", template)
+        self.assertFalse(template.is_cdk_template())

--- a/test/unit/rules/resources/properties/test_availability_zone.py
+++ b/test/unit/rules/resources/properties/test_availability_zone.py
@@ -18,7 +18,8 @@ class TestPropertyAvailabilityZone(BaseRuleTestCase):
         super(TestPropertyAvailabilityZone, self).setUp()
         self.collection.register(AvailabilityZone())
         self.success_templates = [
-            "test/fixtures/templates/good/resources/properties/az.yaml"
+            "test/fixtures/templates/good/resources/properties/az.yaml",
+            "test/fixtures/templates/good/resources/properties/az_cdk.yaml",
         ]
 
     def test_file_positive(self):

--- a/test/unit/rules/resources/test_hardcodedarnproperties.py
+++ b/test/unit/rules/resources/test_hardcodedarnproperties.py
@@ -19,6 +19,7 @@ class TestHardCodedArnProperties(BaseRuleTestCase):
         self.collection.register(HardCodedArnProperties())
         self.success_templates = [
             "test/fixtures/templates/good/resources/properties/hard_coded_arn_properties_sam.yaml",
+            "test/fixtures/templates/good/resources/properties/hard_coded_arn_properties_cdk.yaml",
         ]
 
     def test_file_positive(self):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Disable and configure certain rules when template is from CDK

CDK synthesizes templates reducing the amount of pseudo parameters and intrinsic functions that are used.  As a result we want to change how certain rules work when the template is from CDK.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
