### PR TITLE
Fix typo in linting error

### DIFF
--- a/src/cfnlint/template/transforms/_language_extensions.py
+++ b/src/cfnlint/template/transforms/_language_extensions.py
@@ -131,7 +131,7 @@ class _Transform:
                                 obj[f_k] = f_v
                             else:
                                 raise _ValueError(
-                                    f"Duplicate {f_k} while doing tranformation",
+                                    f"Duplicate {f_k} while doing transformation",
                                     f_k,
                                 )
                     del obj[k]


### PR DESCRIPTION
*Issue #, if available:*
No issue available.

*Description of changes:*
This fixes a typo in the linter error that I noticed while using the tool.  No tests seems to check the error text, so this seems to be the only piece required to be changed.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
