### PR TITLE
Update schemas for DBInstance KmsKeyId

### DIFF
--- a/scripts/update_schemas_manually.py
+++ b/scripts/update_schemas_manually.py
@@ -1321,13 +1321,22 @@ patches.extend(
                     values={
                         "dependencies": {
                             "SourceDBInstanceIdentifier": {
+                                "notDescription": "['CharacterSetName', 'MasterUserPassword', 'MasterUsername', and 'StorageEncrypted'] should not be included with 'SourceDBInstanceIdentifier'",
+                                "not": {
+                                    "anyOf": [
+                                        {"required": ["CharacterSetName"]},
+                                        {"required": ["MasterUserPassword"]},
+                                        {"required": ["MasterUsername"]},
+                                        {"required": ["StorageEncrypted"]},
+                                    ]
+                                },
+                            },
+                            "KmsKeyId": {
                                 "properties": {
-                                    "StorageEncrypted": False,
-                                    "MasterUsername": False,
-                                    "MasterUserPassword": False,
-                                    "CharacterSetName": False,
-                                }
-                            }
+                                    "StorageEncrypted": {"enum": ["true", "True", True]}
+                                },
+                                "required": ["StorageEncrypted"],
+                            },
                         }
                     },
                     path="/",

--- a/src/cfnlint/data/DownloadsMetadata/227d6e59c86482f7153466759080e65963a1bf4413531ad420ff60a5a0d7965d.meta.json
+++ b/src/cfnlint/data/DownloadsMetadata/227d6e59c86482f7153466759080e65963a1bf4413531ad420ff60a5a0d7965d.meta.json
@@ -1,1 +1,1 @@
-{"etag": "\"b5c89f186c5e4f99cfd241bf0411e4a7\"", "url": "https://schema.cloudformation.me-south-1.amazonaws.com/CloudformationSchema.zip"}
+{"etag": "\"e66593754e392c10b5ca50bbf9c25aa2\"", "url": "https://schema.cloudformation.me-south-1.amazonaws.com/CloudformationSchema.zip"}

--- a/src/cfnlint/data/DownloadsMetadata/f54eee6f8ad9619f41835b700369cdbb41c64a9c91b2fa5b4928c0d9b2f780b0.meta.json
+++ b/src/cfnlint/data/DownloadsMetadata/f54eee6f8ad9619f41835b700369cdbb41c64a9c91b2fa5b4928c0d9b2f780b0.meta.json
@@ -1,1 +1,1 @@
-{"etag": "\"bd541cc660f08b31649a41edca102406\"", "url": "https://schema.cloudformation.us-east-1.amazonaws.com/CloudformationSchema.zip"}
+{"etag": "\"16bd7ecdde6801014ac6d5d0db40e721\"", "url": "https://schema.cloudformation.us-east-1.amazonaws.com/CloudformationSchema.zip"}

--- a/src/cfnlint/data/schemas/patches/extensions/all/aws_rds_dbinstance/manual.json
+++ b/src/cfnlint/data/schemas/patches/extensions/all/aws_rds_dbinstance/manual.json
@@ -54,13 +54,46 @@
   "op": "add",
   "path": "/dependencies",
   "value": {
-   "SourceDBInstanceIdentifier": {
+   "KmsKeyId": {
     "properties": {
-     "CharacterSetName": false,
-     "MasterUserPassword": false,
-     "MasterUsername": false,
-     "StorageEncrypted": false
-    }
+     "StorageEncrypted": {
+      "enum": [
+       "true",
+       "True",
+       true
+      ]
+     }
+    },
+    "required": [
+     "StorageEncrypted"
+    ]
+   },
+   "SourceDBInstanceIdentifier": {
+    "not": {
+     "anyOf": [
+      {
+       "required": [
+        "CharacterSetName"
+       ]
+      },
+      {
+       "required": [
+        "MasterUserPassword"
+       ]
+      },
+      {
+       "required": [
+        "MasterUsername"
+       ]
+      },
+      {
+       "required": [
+        "StorageEncrypted"
+       ]
+      }
+     ]
+    },
+    "notDescription": "['CharacterSetName', 'MasterUserPassword', 'MasterUsername', and 'StorageEncrypted'] should not be included with 'SourceDBInstanceIdentifier'"
    }
   }
  }

--- a/src/cfnlint/data/schemas/providers/af_south_1/aws-rds-dbinstance.json
+++ b/src/cfnlint/data/schemas/providers/af_south_1/aws-rds-dbinstance.json
@@ -145,13 +145,46 @@
   }
  },
  "dependencies": {
-  "SourceDBInstanceIdentifier": {
+  "KmsKeyId": {
    "properties": {
-    "CharacterSetName": false,
-    "MasterUserPassword": false,
-    "MasterUsername": false,
-    "StorageEncrypted": false
-   }
+    "StorageEncrypted": {
+     "enum": [
+      "true",
+      "True",
+      true
+     ]
+    }
+   },
+   "required": [
+    "StorageEncrypted"
+   ]
+  },
+  "SourceDBInstanceIdentifier": {
+   "not": {
+    "anyOf": [
+     {
+      "required": [
+       "CharacterSetName"
+      ]
+     },
+     {
+      "required": [
+       "MasterUserPassword"
+      ]
+     },
+     {
+      "required": [
+       "MasterUsername"
+      ]
+     },
+     {
+      "required": [
+       "StorageEncrypted"
+      ]
+     }
+    ]
+   },
+   "notDescription": "['CharacterSetName', 'MasterUserPassword', 'MasterUsername', and 'StorageEncrypted'] should not be included with 'SourceDBInstanceIdentifier'"
   }
  },
  "deprecatedProperties": [

--- a/src/cfnlint/data/schemas/providers/ap_east_1/aws-rds-dbinstance.json
+++ b/src/cfnlint/data/schemas/providers/ap_east_1/aws-rds-dbinstance.json
@@ -145,13 +145,46 @@
   }
  },
  "dependencies": {
-  "SourceDBInstanceIdentifier": {
+  "KmsKeyId": {
    "properties": {
-    "CharacterSetName": false,
-    "MasterUserPassword": false,
-    "MasterUsername": false,
-    "StorageEncrypted": false
-   }
+    "StorageEncrypted": {
+     "enum": [
+      "true",
+      "True",
+      true
+     ]
+    }
+   },
+   "required": [
+    "StorageEncrypted"
+   ]
+  },
+  "SourceDBInstanceIdentifier": {
+   "not": {
+    "anyOf": [
+     {
+      "required": [
+       "CharacterSetName"
+      ]
+     },
+     {
+      "required": [
+       "MasterUserPassword"
+      ]
+     },
+     {
+      "required": [
+       "MasterUsername"
+      ]
+     },
+     {
+      "required": [
+       "StorageEncrypted"
+      ]
+     }
+    ]
+   },
+   "notDescription": "['CharacterSetName', 'MasterUserPassword', 'MasterUsername', and 'StorageEncrypted'] should not be included with 'SourceDBInstanceIdentifier'"
   }
  },
  "deprecatedProperties": [

--- a/src/cfnlint/data/schemas/providers/ap_south_2/aws-rds-dbinstance.json
+++ b/src/cfnlint/data/schemas/providers/ap_south_2/aws-rds-dbinstance.json
@@ -145,13 +145,46 @@
   }
  },
  "dependencies": {
-  "SourceDBInstanceIdentifier": {
+  "KmsKeyId": {
    "properties": {
-    "CharacterSetName": false,
-    "MasterUserPassword": false,
-    "MasterUsername": false,
-    "StorageEncrypted": false
-   }
+    "StorageEncrypted": {
+     "enum": [
+      "true",
+      "True",
+      true
+     ]
+    }
+   },
+   "required": [
+    "StorageEncrypted"
+   ]
+  },
+  "SourceDBInstanceIdentifier": {
+   "not": {
+    "anyOf": [
+     {
+      "required": [
+       "CharacterSetName"
+      ]
+     },
+     {
+      "required": [
+       "MasterUserPassword"
+      ]
+     },
+     {
+      "required": [
+       "MasterUsername"
+      ]
+     },
+     {
+      "required": [
+       "StorageEncrypted"
+      ]
+     }
+    ]
+   },
+   "notDescription": "['CharacterSetName', 'MasterUserPassword', 'MasterUsername', and 'StorageEncrypted'] should not be included with 'SourceDBInstanceIdentifier'"
   }
  },
  "deprecatedProperties": [

--- a/src/cfnlint/data/schemas/providers/ap_southeast_3/aws-rds-dbinstance.json
+++ b/src/cfnlint/data/schemas/providers/ap_southeast_3/aws-rds-dbinstance.json
@@ -145,13 +145,46 @@
   }
  },
  "dependencies": {
-  "SourceDBInstanceIdentifier": {
+  "KmsKeyId": {
    "properties": {
-    "CharacterSetName": false,
-    "MasterUserPassword": false,
-    "MasterUsername": false,
-    "StorageEncrypted": false
-   }
+    "StorageEncrypted": {
+     "enum": [
+      "true",
+      "True",
+      true
+     ]
+    }
+   },
+   "required": [
+    "StorageEncrypted"
+   ]
+  },
+  "SourceDBInstanceIdentifier": {
+   "not": {
+    "anyOf": [
+     {
+      "required": [
+       "CharacterSetName"
+      ]
+     },
+     {
+      "required": [
+       "MasterUserPassword"
+      ]
+     },
+     {
+      "required": [
+       "MasterUsername"
+      ]
+     },
+     {
+      "required": [
+       "StorageEncrypted"
+      ]
+     }
+    ]
+   },
+   "notDescription": "['CharacterSetName', 'MasterUserPassword', 'MasterUsername', and 'StorageEncrypted'] should not be included with 'SourceDBInstanceIdentifier'"
   }
  },
  "deprecatedProperties": [

--- a/src/cfnlint/data/schemas/providers/ap_southeast_4/aws-rds-dbinstance.json
+++ b/src/cfnlint/data/schemas/providers/ap_southeast_4/aws-rds-dbinstance.json
@@ -145,13 +145,46 @@
   }
  },
  "dependencies": {
-  "SourceDBInstanceIdentifier": {
+  "KmsKeyId": {
    "properties": {
-    "CharacterSetName": false,
-    "MasterUserPassword": false,
-    "MasterUsername": false,
-    "StorageEncrypted": false
-   }
+    "StorageEncrypted": {
+     "enum": [
+      "true",
+      "True",
+      true
+     ]
+    }
+   },
+   "required": [
+    "StorageEncrypted"
+   ]
+  },
+  "SourceDBInstanceIdentifier": {
+   "not": {
+    "anyOf": [
+     {
+      "required": [
+       "CharacterSetName"
+      ]
+     },
+     {
+      "required": [
+       "MasterUserPassword"
+      ]
+     },
+     {
+      "required": [
+       "MasterUsername"
+      ]
+     },
+     {
+      "required": [
+       "StorageEncrypted"
+      ]
+     }
+    ]
+   },
+   "notDescription": "['CharacterSetName', 'MasterUserPassword', 'MasterUsername', and 'StorageEncrypted'] should not be included with 'SourceDBInstanceIdentifier'"
   }
  },
  "deprecatedProperties": [

--- a/src/cfnlint/data/schemas/providers/ca_west_1/aws-rds-dbinstance.json
+++ b/src/cfnlint/data/schemas/providers/ca_west_1/aws-rds-dbinstance.json
@@ -67,13 +67,46 @@
   }
  },
  "dependencies": {
-  "SourceDBInstanceIdentifier": {
+  "KmsKeyId": {
    "properties": {
-    "CharacterSetName": false,
-    "MasterUserPassword": false,
-    "MasterUsername": false,
-    "StorageEncrypted": false
-   }
+    "StorageEncrypted": {
+     "enum": [
+      "true",
+      "True",
+      true
+     ]
+    }
+   },
+   "required": [
+    "StorageEncrypted"
+   ]
+  },
+  "SourceDBInstanceIdentifier": {
+   "not": {
+    "anyOf": [
+     {
+      "required": [
+       "CharacterSetName"
+      ]
+     },
+     {
+      "required": [
+       "MasterUserPassword"
+      ]
+     },
+     {
+      "required": [
+       "MasterUsername"
+      ]
+     },
+     {
+      "required": [
+       "StorageEncrypted"
+      ]
+     }
+    ]
+   },
+   "notDescription": "['CharacterSetName', 'MasterUserPassword', 'MasterUsername', and 'StorageEncrypted'] should not be included with 'SourceDBInstanceIdentifier'"
   }
  },
  "description": "Resource Type definition for AWS::RDS::DBInstance",

--- a/src/cfnlint/data/schemas/providers/cn_north_1/aws-rds-dbinstance.json
+++ b/src/cfnlint/data/schemas/providers/cn_north_1/aws-rds-dbinstance.json
@@ -145,13 +145,46 @@
   }
  },
  "dependencies": {
-  "SourceDBInstanceIdentifier": {
+  "KmsKeyId": {
    "properties": {
-    "CharacterSetName": false,
-    "MasterUserPassword": false,
-    "MasterUsername": false,
-    "StorageEncrypted": false
-   }
+    "StorageEncrypted": {
+     "enum": [
+      "true",
+      "True",
+      true
+     ]
+    }
+   },
+   "required": [
+    "StorageEncrypted"
+   ]
+  },
+  "SourceDBInstanceIdentifier": {
+   "not": {
+    "anyOf": [
+     {
+      "required": [
+       "CharacterSetName"
+      ]
+     },
+     {
+      "required": [
+       "MasterUserPassword"
+      ]
+     },
+     {
+      "required": [
+       "MasterUsername"
+      ]
+     },
+     {
+      "required": [
+       "StorageEncrypted"
+      ]
+     }
+    ]
+   },
+   "notDescription": "['CharacterSetName', 'MasterUserPassword', 'MasterUsername', and 'StorageEncrypted'] should not be included with 'SourceDBInstanceIdentifier'"
   }
  },
  "deprecatedProperties": [

--- a/src/cfnlint/data/schemas/providers/cn_northwest_1/aws-rds-dbinstance.json
+++ b/src/cfnlint/data/schemas/providers/cn_northwest_1/aws-rds-dbinstance.json
@@ -145,13 +145,46 @@
   }
  },
  "dependencies": {
-  "SourceDBInstanceIdentifier": {
+  "KmsKeyId": {
    "properties": {
-    "CharacterSetName": false,
-    "MasterUserPassword": false,
-    "MasterUsername": false,
-    "StorageEncrypted": false
-   }
+    "StorageEncrypted": {
+     "enum": [
+      "true",
+      "True",
+      true
+     ]
+    }
+   },
+   "required": [
+    "StorageEncrypted"
+   ]
+  },
+  "SourceDBInstanceIdentifier": {
+   "not": {
+    "anyOf": [
+     {
+      "required": [
+       "CharacterSetName"
+      ]
+     },
+     {
+      "required": [
+       "MasterUserPassword"
+      ]
+     },
+     {
+      "required": [
+       "MasterUsername"
+      ]
+     },
+     {
+      "required": [
+       "StorageEncrypted"
+      ]
+     }
+    ]
+   },
+   "notDescription": "['CharacterSetName', 'MasterUserPassword', 'MasterUsername', and 'StorageEncrypted'] should not be included with 'SourceDBInstanceIdentifier'"
   }
  },
  "deprecatedProperties": [

--- a/src/cfnlint/data/schemas/providers/eu_central_2/aws-rds-dbinstance.json
+++ b/src/cfnlint/data/schemas/providers/eu_central_2/aws-rds-dbinstance.json
@@ -145,13 +145,46 @@
   }
  },
  "dependencies": {
-  "SourceDBInstanceIdentifier": {
+  "KmsKeyId": {
    "properties": {
-    "CharacterSetName": false,
-    "MasterUserPassword": false,
-    "MasterUsername": false,
-    "StorageEncrypted": false
-   }
+    "StorageEncrypted": {
+     "enum": [
+      "true",
+      "True",
+      true
+     ]
+    }
+   },
+   "required": [
+    "StorageEncrypted"
+   ]
+  },
+  "SourceDBInstanceIdentifier": {
+   "not": {
+    "anyOf": [
+     {
+      "required": [
+       "CharacterSetName"
+      ]
+     },
+     {
+      "required": [
+       "MasterUserPassword"
+      ]
+     },
+     {
+      "required": [
+       "MasterUsername"
+      ]
+     },
+     {
+      "required": [
+       "StorageEncrypted"
+      ]
+     }
+    ]
+   },
+   "notDescription": "['CharacterSetName', 'MasterUserPassword', 'MasterUsername', and 'StorageEncrypted'] should not be included with 'SourceDBInstanceIdentifier'"
   }
  },
  "deprecatedProperties": [

--- a/src/cfnlint/data/schemas/providers/eu_south_1/aws-rds-dbinstance.json
+++ b/src/cfnlint/data/schemas/providers/eu_south_1/aws-rds-dbinstance.json
@@ -145,13 +145,46 @@
   }
  },
  "dependencies": {
-  "SourceDBInstanceIdentifier": {
+  "KmsKeyId": {
    "properties": {
-    "CharacterSetName": false,
-    "MasterUserPassword": false,
-    "MasterUsername": false,
-    "StorageEncrypted": false
-   }
+    "StorageEncrypted": {
+     "enum": [
+      "true",
+      "True",
+      true
+     ]
+    }
+   },
+   "required": [
+    "StorageEncrypted"
+   ]
+  },
+  "SourceDBInstanceIdentifier": {
+   "not": {
+    "anyOf": [
+     {
+      "required": [
+       "CharacterSetName"
+      ]
+     },
+     {
+      "required": [
+       "MasterUserPassword"
+      ]
+     },
+     {
+      "required": [
+       "MasterUsername"
+      ]
+     },
+     {
+      "required": [
+       "StorageEncrypted"
+      ]
+     }
+    ]
+   },
+   "notDescription": "['CharacterSetName', 'MasterUserPassword', 'MasterUsername', and 'StorageEncrypted'] should not be included with 'SourceDBInstanceIdentifier'"
   }
  },
  "deprecatedProperties": [

--- a/src/cfnlint/data/schemas/providers/eu_south_2/aws-rds-dbinstance.json
+++ b/src/cfnlint/data/schemas/providers/eu_south_2/aws-rds-dbinstance.json
@@ -145,13 +145,46 @@
   }
  },
  "dependencies": {
-  "SourceDBInstanceIdentifier": {
+  "KmsKeyId": {
    "properties": {
-    "CharacterSetName": false,
-    "MasterUserPassword": false,
-    "MasterUsername": false,
-    "StorageEncrypted": false
-   }
+    "StorageEncrypted": {
+     "enum": [
+      "true",
+      "True",
+      true
+     ]
+    }
+   },
+   "required": [
+    "StorageEncrypted"
+   ]
+  },
+  "SourceDBInstanceIdentifier": {
+   "not": {
+    "anyOf": [
+     {
+      "required": [
+       "CharacterSetName"
+      ]
+     },
+     {
+      "required": [
+       "MasterUserPassword"
+      ]
+     },
+     {
+      "required": [
+       "MasterUsername"
+      ]
+     },
+     {
+      "required": [
+       "StorageEncrypted"
+      ]
+     }
+    ]
+   },
+   "notDescription": "['CharacterSetName', 'MasterUserPassword', 'MasterUsername', and 'StorageEncrypted'] should not be included with 'SourceDBInstanceIdentifier'"
   }
  },
  "deprecatedProperties": [

--- a/src/cfnlint/data/schemas/providers/me_central_1/aws-rds-dbinstance.json
+++ b/src/cfnlint/data/schemas/providers/me_central_1/aws-rds-dbinstance.json
@@ -145,13 +145,46 @@
   }
  },
  "dependencies": {
-  "SourceDBInstanceIdentifier": {
+  "KmsKeyId": {
    "properties": {
-    "CharacterSetName": false,
-    "MasterUserPassword": false,
-    "MasterUsername": false,
-    "StorageEncrypted": false
-   }
+    "StorageEncrypted": {
+     "enum": [
+      "true",
+      "True",
+      true
+     ]
+    }
+   },
+   "required": [
+    "StorageEncrypted"
+   ]
+  },
+  "SourceDBInstanceIdentifier": {
+   "not": {
+    "anyOf": [
+     {
+      "required": [
+       "CharacterSetName"
+      ]
+     },
+     {
+      "required": [
+       "MasterUserPassword"
+      ]
+     },
+     {
+      "required": [
+       "MasterUsername"
+      ]
+     },
+     {
+      "required": [
+       "StorageEncrypted"
+      ]
+     }
+    ]
+   },
+   "notDescription": "['CharacterSetName', 'MasterUserPassword', 'MasterUsername', and 'StorageEncrypted'] should not be included with 'SourceDBInstanceIdentifier'"
   }
  },
  "deprecatedProperties": [

--- a/src/cfnlint/data/schemas/providers/me_south_1/aws-rds-dbinstance.json
+++ b/src/cfnlint/data/schemas/providers/me_south_1/aws-rds-dbinstance.json
@@ -145,13 +145,46 @@
   }
  },
  "dependencies": {
-  "SourceDBInstanceIdentifier": {
+  "KmsKeyId": {
    "properties": {
-    "CharacterSetName": false,
-    "MasterUserPassword": false,
-    "MasterUsername": false,
-    "StorageEncrypted": false
-   }
+    "StorageEncrypted": {
+     "enum": [
+      "true",
+      "True",
+      true
+     ]
+    }
+   },
+   "required": [
+    "StorageEncrypted"
+   ]
+  },
+  "SourceDBInstanceIdentifier": {
+   "not": {
+    "anyOf": [
+     {
+      "required": [
+       "CharacterSetName"
+      ]
+     },
+     {
+      "required": [
+       "MasterUserPassword"
+      ]
+     },
+     {
+      "required": [
+       "MasterUsername"
+      ]
+     },
+     {
+      "required": [
+       "StorageEncrypted"
+      ]
+     }
+    ]
+   },
+   "notDescription": "['CharacterSetName', 'MasterUserPassword', 'MasterUsername', and 'StorageEncrypted'] should not be included with 'SourceDBInstanceIdentifier'"
   }
  },
  "deprecatedProperties": [

--- a/src/cfnlint/data/schemas/providers/us_east_1/aws-rds-dbinstance.json
+++ b/src/cfnlint/data/schemas/providers/us_east_1/aws-rds-dbinstance.json
@@ -145,13 +145,46 @@
   }
  },
  "dependencies": {
-  "SourceDBInstanceIdentifier": {
+  "KmsKeyId": {
    "properties": {
-    "CharacterSetName": false,
-    "MasterUserPassword": false,
-    "MasterUsername": false,
-    "StorageEncrypted": false
-   }
+    "StorageEncrypted": {
+     "enum": [
+      "true",
+      "True",
+      true
+     ]
+    }
+   },
+   "required": [
+    "StorageEncrypted"
+   ]
+  },
+  "SourceDBInstanceIdentifier": {
+   "not": {
+    "anyOf": [
+     {
+      "required": [
+       "CharacterSetName"
+      ]
+     },
+     {
+      "required": [
+       "MasterUserPassword"
+      ]
+     },
+     {
+      "required": [
+       "MasterUsername"
+      ]
+     },
+     {
+      "required": [
+       "StorageEncrypted"
+      ]
+     }
+    ]
+   },
+   "notDescription": "['CharacterSetName', 'MasterUserPassword', 'MasterUsername', and 'StorageEncrypted'] should not be included with 'SourceDBInstanceIdentifier'"
   }
  },
  "deprecatedProperties": [

--- a/src/cfnlint/data/schemas/providers/us_gov_east_1/aws-rds-dbinstance.json
+++ b/src/cfnlint/data/schemas/providers/us_gov_east_1/aws-rds-dbinstance.json
@@ -145,13 +145,46 @@
   }
  },
  "dependencies": {
-  "SourceDBInstanceIdentifier": {
+  "KmsKeyId": {
    "properties": {
-    "CharacterSetName": false,
-    "MasterUserPassword": false,
-    "MasterUsername": false,
-    "StorageEncrypted": false
-   }
+    "StorageEncrypted": {
+     "enum": [
+      "true",
+      "True",
+      true
+     ]
+    }
+   },
+   "required": [
+    "StorageEncrypted"
+   ]
+  },
+  "SourceDBInstanceIdentifier": {
+   "not": {
+    "anyOf": [
+     {
+      "required": [
+       "CharacterSetName"
+      ]
+     },
+     {
+      "required": [
+       "MasterUserPassword"
+      ]
+     },
+     {
+      "required": [
+       "MasterUsername"
+      ]
+     },
+     {
+      "required": [
+       "StorageEncrypted"
+      ]
+     }
+    ]
+   },
+   "notDescription": "['CharacterSetName', 'MasterUserPassword', 'MasterUsername', and 'StorageEncrypted'] should not be included with 'SourceDBInstanceIdentifier'"
   }
  },
  "deprecatedProperties": [

--- a/src/cfnlint/data/schemas/providers/us_gov_west_1/aws-rds-dbinstance.json
+++ b/src/cfnlint/data/schemas/providers/us_gov_west_1/aws-rds-dbinstance.json
@@ -145,13 +145,46 @@
   }
  },
  "dependencies": {
-  "SourceDBInstanceIdentifier": {
+  "KmsKeyId": {
    "properties": {
-    "CharacterSetName": false,
-    "MasterUserPassword": false,
-    "MasterUsername": false,
-    "StorageEncrypted": false
-   }
+    "StorageEncrypted": {
+     "enum": [
+      "true",
+      "True",
+      true
+     ]
+    }
+   },
+   "required": [
+    "StorageEncrypted"
+   ]
+  },
+  "SourceDBInstanceIdentifier": {
+   "not": {
+    "anyOf": [
+     {
+      "required": [
+       "CharacterSetName"
+      ]
+     },
+     {
+      "required": [
+       "MasterUserPassword"
+      ]
+     },
+     {
+      "required": [
+       "MasterUsername"
+      ]
+     },
+     {
+      "required": [
+       "StorageEncrypted"
+      ]
+     }
+    ]
+   },
+   "notDescription": "['CharacterSetName', 'MasterUserPassword', 'MasterUsername', and 'StorageEncrypted'] should not be included with 'SourceDBInstanceIdentifier'"
   }
  },
  "deprecatedProperties": [

--- a/src/cfnlint/jsonschema/_validators.py
+++ b/src/cfnlint/jsonschema/_validators.py
@@ -341,8 +341,11 @@ def multipleOf(
 def not_(
     validator: Validator, not_schema: Any, instance: Any, schema: Dict[str, Any]
 ) -> ValidationResult:
+    description = schema.get("notDescription")
     if validator.evolve(schema=not_schema).is_valid(instance):
-        message = f"{instance!r} should not be valid under {not_schema!r}"
+        message = (
+            description or f"{instance!r} should not be valid under {not_schema!r}"
+        )
         yield ValidationError(message)
 
 


### PR DESCRIPTION
*Issue #, if available:*
fix #2965 
*Description of changes:*
- Update schemas to validate when KmsKeyId is specified that StorageEncrypted is also specified

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
