### PR TITLE
Make sure resource types are strings before assuming

### DIFF
--- a/src/cfnlint/rules/resources/PrimaryIdentifiers.py
+++ b/src/cfnlint/rules/resources/PrimaryIdentifiers.py
@@ -127,7 +127,9 @@ class PrimaryIdentifiers(CloudFormationLintRule):
     def match(self, cfn):
         tS = set()
         for _, resource_properties in cfn.get_resources().items():
-            tS.add(resource_properties.get("Type"))
+            t = resource_properties.get("Type")
+            if isinstance(t, str):
+                tS.add(t)
 
         matches = []
         for t in tS:

--- a/src/cfnlint/rules/resources/properties/Properties.py
+++ b/src/cfnlint/rules/resources/properties/Properties.py
@@ -71,7 +71,7 @@ class Properties(BaseJsonSchema):
         )
 
         t = instance.get("Type")
-        if not t:
+        if not validator.is_type(t, "string"):
             return
 
         if t.startswith("Custom::"):

--- a/test/fixtures/templates/bad/resources/primary_identifiers.yaml
+++ b/test/fixtures/templates/bad/resources/primary_identifiers.yaml
@@ -152,3 +152,5 @@ Resources:
         - IsUsEast1
         - us-east-1
         - !Ref 'AWS::NoValue'
+  BadType:
+    Type: !Ref AWS::Region


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Make sure resource types are strings before assuming

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
