### PR TITLE
Ignore_checks was being ignored when the rule was a parent

### DIFF
--- a/src/cfnlint/rules/resources/Type.py
+++ b/src/cfnlint/rules/resources/Type.py
@@ -51,4 +51,5 @@ class Type(BaseJsonSchema):
                 yield ValidationError(
                     f"Resource type `{resource_type}` does not exist in '{region}'",
                     path=deque(["Type"]),
+                    rule=self,
                 )

--- a/src/cfnlint/rules/resources/iam/RoleArnPattern.py
+++ b/src/cfnlint/rules/resources/iam/RoleArnPattern.py
@@ -27,4 +27,7 @@ class RoleArnPattern(BaseJsonSchema):
         patrn = "^arn:(aws[a-zA-Z-]*)?:iam::\\d{12}:role/[a-zA-Z_0-9+=,.@\\-_/]+$"
 
         if not re.match(patrn, arn):
-            yield ValidationError(f"{arn!r} does not match {patrn!r}")
+            yield ValidationError(
+                f"{arn!r} does not match {patrn!r}",
+                rule=self,
+            )

--- a/test/unit/rules/resources/test_type.py
+++ b/test/unit/rules/resources/test_type.py
@@ -53,6 +53,7 @@ class TestType(BaseRuleTestCase):
                     "Resource type `Foo::Bar::Type` does not exist in 'us-east-1'",
                     path=deque(["Type"]),
                     schema_path=deque([]),
+                    rule=Type(),
                 ),
             ],
             errors,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- We have to run parent rules no matter what.  We had dropped the ignore_checks validation of matches against the ignored checks

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
