### PR TITLE
Switch to using path and resource names for directives

### DIFF
--- a/src/cfnlint/runner.py
+++ b/src/cfnlint/runner.py
@@ -56,22 +56,15 @@ class Runner:
                             return_matches.append(match)
                             break
                     else:
-                        for directive in directives.get(match.rule.id):
-                            start = directive.get("start")
-                            end = directive.get("end")
-                            if start[0] < match.linenumber < end[0]:
-                                break
-                            if (
-                                start[0] == match.linenumber
-                                and start[1] <= match.columnnumber
-                            ):
-                                break
-                            if (
-                                end[0] == match.linenumber
-                                and end[1] >= match.columnnumberend
-                            ):
-                                break
-                        else:
-                            return_matches.append(match)
+                        path = getattr(match, "path", None)
+                        if path:
+                            if len(path) >= 2:
+                                if path[0] != "Resources":
+                                    return_matches.append(match)
+                                    continue
+                                if path[1] not in directives[match.rule.id]:
+                                    return_matches.append(match)
+                            else:
+                                return_matches.append(match)
 
         return return_matches

--- a/src/cfnlint/template/template.py
+++ b/src/cfnlint/template/template.py
@@ -323,14 +323,7 @@ class Template:  # pylint: disable=R0904,too-many-lines,too-many-instance-attrib
                     for ignore_rule_id in ignore_rule_ids:
                         if ignore_rule_id not in results:
                             results[ignore_rule_id] = []
-                        value_location = self._loc(resource_values)
-                        name_location = self._loc(resource_name)
-                        results[ignore_rule_id].append(
-                            {
-                                "start": (name_location[0] + 1, name_location[1] + 1),
-                                "end": (value_location[2] + 1, value_location[3] + 1),
-                            }
-                        )
+                        results[ignore_rule_id].append(resource_name)
         return results
 
     # pylint: disable=too-many-locals

--- a/test/unit/module/runner/test_runner.py
+++ b/test/unit/module/runner/test_runner.py
@@ -27,6 +27,9 @@ class TestRunner(BaseTestCase):
             AWSTemplateFormatVersion: "2010-09-09"
             Description: >
                 Template with all error levels: Warning, Error and Informational
+            # Adding in an issue outside of the Resources for validating
+            Conditions: 
+                IsUsEast1: !Equals ["a", "b", "c"]
             Resources:
                 myTable:
                     Metadata:
@@ -35,6 +38,7 @@ class TestRunner(BaseTestCase):
                                 ignore_checks:
                                 - I3011
                                 - W1020
+                                - E8003 # condition error #
                     Type: "AWS::DynamoDB::Table"
                     Properties:
                         TableName: !Sub "TableName"
@@ -47,6 +51,21 @@ class TestRunner(BaseTestCase):
                         ProvisionedThroughput:
                             ReadCapacityUnits: 5
                             WriteCapacityUnits: "5"
+                myTable2:
+                    # With no ignore_checks so we 
+                    # should still get issues from this
+                    Type: "AWS::DynamoDB::Table"
+                    Properties:
+                        TableName: !Sub "TableName"
+                        AttributeDefinitions:
+                            - AttributeName: "Id"
+                              AttributeType: "S" # Valid AllowedValue
+                        KeySchema:
+                            - AttributeName: "Id"
+                              KeyType: "HASH"
+                        ProvisionedThroughput:
+                            ReadCapacityUnits: !If [IsUsEast1, 5, 5]
+                            WriteCapacityUnits: "5"
         """
         )
 
@@ -55,7 +74,7 @@ class TestRunner(BaseTestCase):
         runner = Runner(self.collection, "", self.template, ["us-east-1"], [])
         runner.transform()
         failures = runner.run()
-        assert [] == failures, "Got failures {}".format(failures)
+        self.assertEqual(len(failures), 3, "Got failures {}".format(failures))
 
     def test_runner_mandatory_rules(self):
         """Success test"""
@@ -64,11 +83,11 @@ class TestRunner(BaseTestCase):
         )
         runner.transform()
         failures = runner.run()
-        self.assertEqual(len(failures), 1)
+        self.assertEqual(len(failures), 4, "Got failures {}".format(failures))
 
         runner = Runner(
             self.collection, "", self.template, ["us-east-1"], mandatory_rules=["W9000"]
         )
         runner.transform()
         failures = runner.run()
-        self.assertEqual(len(failures), 0)
+        self.assertEqual(len(failures), 3, "Got failures {}".format(failures))

--- a/test/unit/module/test_template.py
+++ b/test/unit/module/test_template.py
@@ -1228,14 +1228,7 @@ ElasticLoadBalancer -> MyEC2Instance  [color=black, key=0, label=Ref, source_pat
         )
         directives = template.get_directives()
         expected_result = {
-            "E3012": [
-                {"end": (23, 10), "start": (10, 9)},
-                {"end": (36, 10), "start": (24, 9)},
-            ],
-            "I1001": [{"end": (23, 10), "start": (10, 9)}],
+            "E3012": ["myBucket1", "myBucket2"],
+            "I1001": ["myBucket1"],
         }
-        self.assertEqual(len(expected_result), len(directives))
-        for key, items in directives.items():
-            self.assertIn(key, expected_result)
-            if key in expected_result:
-                self.assertEqualListOfDicts(items, expected_result.get(key))
+        self.assertDictEqual(directives, expected_result)


### PR DESCRIPTION
*Issue #, if available:*
#3028 
*Description of changes:*
- Switch to using path and resource names for directives

During SAM translation line numbers can be confused.  This method relies on the path of a Match and using directives to look at the resource names to determine if a directive should be applied. This should remove the need to have to worry about line numbers and path should be a more reliable source since that is determined by the metadata which as part of recent charges is transferred to all the applicable resources.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
