### PR TITLE
new rule E3689 to validate DBCluster monitoring config

### DIFF
--- a/src/cfnlint/data/schemas/extensions/aws_rds_dbcluster/monitoring.json
+++ b/src/cfnlint/data/schemas/extensions/aws_rds_dbcluster/monitoring.json
@@ -1,0 +1,41 @@
+{
+ "additionalProperties": true,
+ "description": "If MonitoringRoleArn is specified, also set MonitoringInterval to a value other than 0",
+ "else": {
+  "if": {
+   "properties": {
+    "MonitoringInterval": {
+     "exclusiveMinimum": 0
+    }
+   },
+   "required": [
+    "MonitoringInterval"
+   ],
+   "type": "object"
+  },
+  "then": {
+   "required": [
+    "MonitoringRoleArn"
+   ]
+  }
+ },
+ "if": {
+  "properties": {
+   "MonitoringRoleArn": true
+  },
+  "required": [
+   "MonitoringRoleArn"
+  ],
+  "type": "object"
+ },
+ "then": {
+  "properties": {
+   "MonitoringInterval": {
+    "exclusiveMinimum": 0
+   }
+  },
+  "required": [
+   "MonitoringInterval"
+  ]
+ }
+}

--- a/src/cfnlint/rules/resources/rds/DbClusterMonitoring.py
+++ b/src/cfnlint/rules/resources/rds/DbClusterMonitoring.py
@@ -1,0 +1,39 @@
+"""
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import cfnlint.data.schemas.extensions.aws_rds_dbcluster
+from cfnlint.jsonschema import ValidationError
+from cfnlint.rules.jsonschema.CfnLintJsonSchema import CfnLintJsonSchema, SchemaDetails
+
+
+class DbClusterMonitoring(CfnLintJsonSchema):
+    id = "E3689"
+    shortdesc = "Validate MonitoringInterval and MonitoringRoleArn are used together"
+    description = (
+        "When MonitoringInterval is greater than 0 you need to specify "
+        "MonitoringRoleArn. If MonitoringRoleArn is specified "
+        "MonitoringInterval has to be greather than 0."
+    )
+    tags = ["resources"]
+    source_url = "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-dbcluster.html#cfn-rds-dbcluster-monitoringinterval"
+
+    def __init__(self) -> None:
+        super().__init__(
+            keywords=["AWS::RDS::DBCluster/Properties"],
+            schema_details=SchemaDetails(
+                module=cfnlint.data.schemas.extensions.aws_rds_dbcluster,
+                filename="monitoring.json",
+            ),
+        )
+
+    def message(self, instance: Any, err: ValidationError) -> str:
+        return (
+            "You must have 'MonitoringRoleArn' specified with "
+            "'MonitoringInterval' greater than 0"
+        )

--- a/test/unit/rules/resources/rds/test_db_cluster_monitoring.py
+++ b/test/unit/rules/resources/rds/test_db_cluster_monitoring.py
@@ -1,0 +1,100 @@
+"""
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+"""
+
+from collections import deque
+
+import pytest
+
+from cfnlint.jsonschema import CfnTemplateValidator, ValidationError
+from cfnlint.rules.resources.rds.DbClusterMonitoring import DbClusterMonitoring
+
+
+@pytest.fixture(scope="module")
+def rule():
+    rule = DbClusterMonitoring()
+    yield rule
+
+
+@pytest.fixture(scope="module")
+def validator():
+    yield CfnTemplateValidator(schema={})
+
+
+@pytest.mark.parametrize(
+    "name,instance,expected",
+    [
+        (
+            "Valid monitoring configuration",
+            {
+                "MonitoringInterval": 1,
+                "MonitoringRoleArn": "arn",
+            },
+            [],
+        ),
+        (
+            "Valid empty monitoring",
+            {},
+            [],
+        ),
+        (
+            "Invalid with just monitoringInterval",
+            {"MonitoringInterval": "1"},
+            [
+                ValidationError(
+                    (
+                        "You must have 'MonitoringRoleArn' specified "
+                        "with 'MonitoringInterval' greater than 0"
+                    ),
+                    rule=DbClusterMonitoring(),
+                    path=deque([]),
+                    schema_path=deque(["else", "then", "required"]),
+                    validator="required",
+                )
+            ],
+        ),
+        (
+            "Invalid with just monitoringRoleArn",
+            {
+                "MonitoringRoleArn": "arn",
+            },
+            [
+                ValidationError(
+                    (
+                        "You must have 'MonitoringRoleArn' specified "
+                        "with 'MonitoringInterval' greater than 0"
+                    ),
+                    rule=DbClusterMonitoring(),
+                    path=deque([]),
+                    schema_path=deque(["then", "required"]),
+                    validator="required",
+                )
+            ],
+        ),
+        (
+            "Invalid with MonitoringInterval is 0",
+            {
+                "MonitoringRoleArn": "arn",
+                "MonitoringInterval": "0",
+            },
+            [
+                ValidationError(
+                    (
+                        "You must have 'MonitoringRoleArn' specified "
+                        "with 'MonitoringInterval' greater than 0"
+                    ),
+                    rule=DbClusterMonitoring(),
+                    path=deque(["MonitoringInterval"]),
+                    schema_path=deque(
+                        ["then", "properties", "MonitoringInterval", "exclusiveMinimum"]
+                    ),
+                    validator="exclusiveMinimum",
+                )
+            ],
+        ),
+    ],
+)
+def test_validate(name, instance, expected, rule, validator):
+    errs = list(rule.validate(validator, "", instance, {}))
+    assert errs == expected, f"Test {name!r} for expected {expected!r} got {errs!r}"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- new rule E3689 to validate DBCluster monitoring config

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
