### PR TITLE
RDS DB Cluster remove MasterUserPassword from exclusion with MasterUsername

### DIFF
--- a/src/cfnlint/data/AdditionalSpecs/Exclusive.json
+++ b/src/cfnlint/data/AdditionalSpecs/Exclusive.json
@@ -100,8 +100,7 @@
   },
   "AWS::RDS::DBCluster": {
    "SnapshotIdentifier": [
-    "MasterUsername",
-    "MasterUserPassword"
+    "MasterUsername"
    ]
   },
   "AWS::RDS::DBInstance": {


### PR DESCRIPTION
…

*Issue #, if available:*
- RDS DB Cluster remove MasterUserPassword from exclusion with MasterUsername

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
