### PR TITLE
Lambda runtime deprecation updates

### DIFF
--- a/src/cfnlint/data/AdditionalSpecs/LmbdRuntimeLifecycle.json
+++ b/src/cfnlint/data/AdditionalSpecs/LmbdRuntimeLifecycle.json
@@ -25,22 +25,22 @@
   "successor": "dotnet8"
  },
  "dotnet6": {
-  "deprecated": "",
+  "deprecated": "2025-02-11",
   "eol": "2024-11-12",
   "successor": "dotnet8"
  },
  "dotnet7": {
-  "deprecated": "",
+  "deprecated": "2024-05-14",
   "eol": "2024-05-14",
   "successor": "dotnet8"
  },
  "go1.x": {
-  "deprecated": "",
+  "deprecated": "2024-03-12",
   "eol": "2024-01-08",
   "successor": "provided.al2023"
  },
  "java8": {
-  "deprecated": "",
+  "deprecated": "2024-03-12",
   "eol": "2024-01-08",
   "successor": "java21"
  },
@@ -60,12 +60,12 @@
   "successor": "nodejs20.x"
  },
  "nodejs14.x": {
-  "deprecated": "",
+  "deprecated": "2024-02-08",
   "eol": "2023-12-04",
   "successor": "nodejs20.x"
  },
  "nodejs16.x": {
-  "deprecated": "",
+  "deprecated": "2024-08-15",
   "eol": "2024-06-12",
   "successor": "nodejs20.x"
  },
@@ -90,7 +90,7 @@
   "successor": "nodejs20.x"
  },
  "provided": {
-  "deprecated": "",
+  "deprecated": "2024-03-12",
   "eol": "2024-01-08",
   "successor": "provided.al2023"
  },
@@ -105,12 +105,12 @@
   "successor": "python3.12"
  },
  "python3.7": {
-  "deprecated": "",
+  "deprecated": "2024-02-08",
   "eol": "2023-12-04",
   "successor": "python3.12"
  },
  "python3.8": {
-  "deprecated": "",
+  "deprecated": "2025-01-07",
   "eol": "2024-10-14",
   "successor": "python3.12"
  },
@@ -120,7 +120,7 @@
   "successor": "ruby3.2"
  },
  "ruby2.7": {
-  "deprecated": "",
+  "deprecated": "2024-02-08",
   "eol": "2023-12-07",
   "successor": "ruby3.2"
  }

--- a/src/cfnlint/data/AdditionalSpecs/LmbdRuntimeLifecycle.json
+++ b/src/cfnlint/data/AdditionalSpecs/LmbdRuntimeLifecycle.json
@@ -2,71 +2,126 @@
  "dotnetcore1.0": {
   "deprecated": "2019-07-31",
   "eol": "2019-06-27",
-  "successor": "dotnet6"
+  "successor": "dotnet8"
  },
  "dotnetcore2.0": {
   "deprecated": "2019-05-30",
   "eol": "2019-04-30",
-  "successor": "dotnet6"
+  "successor": "dotnet8"
  },
  "dotnetcore2.1": {
   "deprecated": "2021-09-23",
   "eol": "2021-08-23",
-  "successor": "dotnet6"
+  "successor": "dotnet8"
  },
  "dotnetcore3.1": {
   "deprecated": "2023-02-20",
   "eol": "2023-01-20",
-  "successor": "dotnet6"
+  "successor": "dotnet8"
+ },
+ "dotnet5.0": {
+  "deprecated": "2022-05-10",
+  "eol": "2022-05-10",
+  "successor": "dotnet8"
+ },
+ "dotnet6": {
+  "deprecated": "",
+  "eol": "2024-11-12",
+  "successor": "dotnet8"
+ },
+ "dotnet7": {
+  "deprecated": "",
+  "eol": "2024-05-14",
+  "successor": "dotnet8"
+ },
+ "go1.x": {
+  "deprecated": "",
+  "eol": "2024-01-08",
+  "successor": "provided.al2023"
+ },
+ "java8": {
+  "deprecated": "",
+  "eol": "2024-01-08",
+  "successor": "java21"
  },
  "nodejs": {
   "deprecated": "2016-10-31",
   "eol": "2016-10-31",
-  "successor": "nodejs16.x"
+  "successor": "nodejs20.x"
  },
  "nodejs10.x": {
   "deprecated": "2021-08-30",
   "eol": "2021-07-30",
-  "successor": "nodejs16.x"
+  "successor": "nodejs20.x"
  },
  "nodejs12.x": {
   "deprecated": "2022-12-14",
   "eol": "2022-11-14",
-  "successor": "nodejs16.x"
+  "successor": "nodejs20.x"
+ },
+ "nodejs14.x": {
+  "deprecated": "",
+  "eol": "2023-12-04",
+  "successor": "nodejs20.x"
+ },
+ "nodejs16.x": {
+  "deprecated": "",
+  "eol": "2024-06-12",
+  "successor": "nodejs20.x"
  },
  "nodejs4.3": {
   "deprecated": "2019-04-30",
   "eol": "2018-04-30",
-  "successor": "nodejs16.x"
+  "successor": "nodejs20.x"
  },
  "nodejs4.3-edge": {
   "deprecated": "2019-04-30",
   "eol": "2018-04-30",
-  "successor": "nodejs16.x"
+  "successor": "nodejs20.x"
  },
  "nodejs6.10": {
   "deprecated": "2019-08-12",
   "eol": "2019-04-30",
-  "successor": "nodejs16.x"
+  "successor": "nodejs20.x"
  },
  "nodejs8.10": {
   "deprecated": "2020-02-03",
   "eol": "2019-12-31",
-  "successor": "nodejs16.x"
+  "successor": "nodejs20.x"
+ },
+ "provided": {
+  "deprecated": "",
+  "eol": "2024-01-08",
+  "successor": "provided.al2023"
  },
  "python2.7": {
   "deprecated": "2021-09-30",
   "eol": "2021-07-15",
-  "successor": "python3.9"
+  "successor": "python3.12"
  },
  "python3.6": {
   "deprecated": "2022-08-17",
   "eol": "2022-07-18",
-  "successor": "python3.9"
+  "successor": "python3.12"
+ },
+ "python3.7": {
+  "deprecated": "",
+  "eol": "2023-12-04",
+  "successor": "python3.12"
+ },
+ "python3.8": {
+  "deprecated": "",
+  "eol": "2024-10-14",
+  "successor": "python3.12"
  },
  "ruby2.5": {
   "deprecated": "2021-08-30",
   "eol": "2021-07-30",
-  "successor": "ruby2.7"
+  "successor": "ruby3.2"
+ },
+ "ruby2.7": {
+  "deprecated": "",
+  "eol": "2023-12-07",
+  "successor": "ruby3.2"
  }
 }

--- a/test/fixtures/results/public/lambda-poller.json
+++ b/test/fixtures/results/public/lambda-poller.json
@@ -18,7 +18,7 @@
                 "LineNumber": 151
             }
         },
-        "Message": "Deprecated runtime (nodejs6.10) specified. Updating disabled since 2019-08-12. Please consider updating to nodejs16.x",
+        "Message": "Deprecated runtime (nodejs6.10) specified. Updating disabled since 2019-08-12. Please consider updating to nodejs20.x",
         "Rule": {
             "Description": "Check if an EOL Lambda Runtime is specified and give an error if used. ",
             "Id": "E2531",

--- a/test/fixtures/results/quickstart/nist_config_rules.json
+++ b/test/fixtures/results/quickstart/nist_config_rules.json
@@ -72,7 +72,7 @@
                 "LineNumber": 94
             }
         },
-        "Message": "Deprecated runtime (nodejs) specified. Updating disabled since 2016-10-31. Please consider updating to nodejs16.x",
+        "Message": "Deprecated runtime (nodejs) specified. Updating disabled since 2016-10-31. Please consider updating to nodejs20.x",
         "Rule": {
             "Description": "Check if an EOL Lambda Runtime is specified and give an error if used. ",
             "Id": "E2531",
@@ -152,7 +152,7 @@
                 "LineNumber": 159
             }
         },
-        "Message": "Deprecated runtime (nodejs) specified. Updating disabled since 2016-10-31. Please consider updating to nodejs16.x",
+        "Message": "Deprecated runtime (nodejs) specified. Updating disabled since 2016-10-31. Please consider updating to nodejs20.x",
         "Rule": {
             "Description": "Check if an EOL Lambda Runtime is specified and give an error if used. ",
             "Id": "E2531",

--- a/test/integration/test_good_templates.py
+++ b/test/integration/test_good_templates.py
@@ -149,7 +149,7 @@ class TestQuickStartTemplates(BaseCliTestCase):
                         "Path": ["Resources", "myFunction", "Properties", "Runtime"],
                         "Start": {"ColumnNumber": 3, "LineNumber": 10},
                     },
-                    "Message": "Deprecated runtime (nodejs6.10) specified. Updating disabled since 2019-08-12. Please consider updating to nodejs16.x",
+                    "Message": "Deprecated runtime (nodejs6.10) specified. Updating disabled since 2019-08-12. Please consider updating to nodejs20.x",
                     "Rule": {
                         "Description": "Check if an EOL Lambda Runtime is specified and give an error if used. ",
                         "Id": "E2531",


### PR DESCRIPTION
fix https://github.com/aws-cloudformation/cfn-lint/issues/3105
https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html#runtimes-supported
https://github.com/terraform-linters/tflint-ruleset-aws/blob/master/rules/aws_lambda_function_deprecated_runtime.go


updated test results with:
```bash
gsed -i 's/Please consider updating to nodejs16/Please consider updating to nodejs20/' test/integration/*.py
gsed -i 's/Please consider updating to nodejs16/Please consider updating to nodejs20/' test/fixtures/results/*/*.json
```