### PR TITLE
Remove AWS::RDS::DBCluster from exclusive checks

### DIFF
--- a/src/cfnlint/data/AdditionalSpecs/Exclusive.json
+++ b/src/cfnlint/data/AdditionalSpecs/Exclusive.json
@@ -98,11 +98,6 @@
     "SourceSecurityGroupName"
    ]
   },
-  "AWS::RDS::DBCluster": {
-   "SnapshotIdentifier": [
-    "MasterUsername"
-   ]
-  },
   "AWS::RDS::DBInstance": {
    "DBClusterIdentifier": [
     "StorageEncrypted"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Remove AWS::RDS::DBCluster from exclusive checks

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
