### PR TITLE
walk FindInMap to pass mapping in resolution failure

### DIFF
--- a/src/cfnlint/template/transforms/_language_extensions.py
+++ b/src/cfnlint/template/transforms/_language_extensions.py
@@ -156,7 +156,7 @@ class _Transform:
                 elif k == "Fn::FindInMap":
                     try:
                         mapping = _ForEachValueFnFindInMap(get_hash(v), v)
-                        map_value = mapping.value(cfn, params, True)
+                        map_value = mapping.value(cfn, params, True, False)
                         # if we get None this means its all strings but couldn't be resolved
                         # we will pass this forward
                         if map_value is None:
@@ -298,6 +298,7 @@ class _ForEachValueFnFindInMap(_ForEachValue):
         cfn: Any,
         params: Optional[Mapping[str, Any]] = None,
         only_params: bool = False,
+        default_on_resolver_failure: bool = True,
     ) -> Any:
         if params is None:
             params = {}
@@ -361,11 +362,11 @@ class _ForEachValueFnFindInMap(_ForEachValue):
                     t_map[2].value(cfn, params, only_params)
                 )
             except _ResolveError as e:
-                if len(self._map) == 4:
+                if len(self._map) == 4 and default_on_resolver_failure:
                     return self._map[3].value(cfn, params, only_params)
                 raise _ResolveError("Can't resolve Fn::FindInMap", self._obj) from e
 
-        if len(self._map) == 4:
+        if len(self._map) == 4 and default_on_resolver_failure:
             return self._map[3].value(cfn, params, only_params)
         raise _ResolveError("Can't resolve Fn::FindInMap", self._obj)
 

--- a/test/unit/module/template/transforms/test_language_extensions.py
+++ b/test/unit/module/template/transforms/test_language_extensions.py
@@ -182,6 +182,32 @@ class TestFindInMap(TestCase):
         with self.assertRaises(_ValueError):
             _ForEachValueFnFindInMap("", ["foo"])
 
+    def test_find_in_map_values_with_default(self):
+        map = _ForEachValueFnFindInMap(
+            "a", ["Bucket", {"Ref": "Foo"}, "Key", {"DefaultValue": "bar"}]
+        )
+
+        self.assertEqual(map.value(self.cfn, None, False, True), "bar")
+        with self.assertRaises(_ResolveError):
+            map.value(self.cfn, None, False, False)
+
+    def test_find_in_map_values_without_default(self):
+        map = _ForEachValueFnFindInMap("a", ["Bucket", {"Ref": "Foo"}, "Key"])
+
+        with self.assertRaises(_ResolveError):
+            self.assertEqual(map.value(self.cfn, None, False, True), "bar")
+        with self.assertRaises(_ResolveError):
+            map.value(self.cfn, None, False, False)
+
+    def test_mapping_not_found(self):
+        map = _ForEachValueFnFindInMap(
+            "a", ["Foo", {"Ref": "Foo"}, "Key", {"DefaultValue": "bar"}]
+        )
+
+        self.assertEqual(map.value(self.cfn, None, False, True), "bar")
+        with self.assertRaises(_ResolveError):
+            map.value(self.cfn, None, False, False)
+
     def test_two_mappings(self):
         template_obj = deepcopy(self.template_obj)
         template_obj["Mappings"]["Foo"] = {"Bar": {"Key": ["a", "b"]}}


### PR DESCRIPTION
*Issue #, if available:*
fix #1300 

*Description of changes:*
- When doing a transform walk we want to pass through the entire FindInMap function when there is a resolution failure.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
