### PR TITLE
Support db2-ae and db2-se RDS engines

### DIFF
--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_rds.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_rds.json
@@ -27,8 +27,8 @@
   "op": "add",
   "path": "/ValueTypes/AWS::RDS::DBInstance.Engine",
   "value": {
-   "AllowedPattern": "Has to be one of [aurora, aurora-mysql, aurora-postgresql, mariadb, mysql, oracle-ee, oracle-ee-cdb, oracle-se2, oracle-se2-cdb, oracle-se1, oracle-se, postgres, sqlserver-ee, sqlserver-se, sqlserver-ex, sqlserver-web]",
-   "AllowedPatternRegex": "(?i)(custom-)?(aurora|aurora-mysql|aurora-postgresql|mariadb|mysql|oracle-ee|oracle-ee-cdb|oracle-se2|oracle-se2-cdb|oracle-se1|oracle-se|postgres|sqlserver-ee|sqlserver-se|sqlserver-ex|sqlserver-web)$"
+   "AllowedPattern": "Has to be one of [aurora, aurora-mysql, aurora-postgresql, db2-ae, db2-se, mariadb, mysql, oracle-ee, oracle-ee-cdb, oracle-se2, oracle-se2-cdb, oracle-se1, oracle-se, postgres, sqlserver-ee, sqlserver-se, sqlserver-ex, sqlserver-web]",
+   "AllowedPatternRegex": "(?i)(custom-)?(aurora|aurora-mysql|aurora-postgresql|db2-ae|db2-se|mariadb|mysql|oracle-ee|oracle-ee-cdb|oracle-se2|oracle-se2-cdb|oracle-se1|oracle-se|postgres|sqlserver-ee|sqlserver-se|sqlserver-ex|sqlserver-web)$"
   }
  },
  {


### PR DESCRIPTION
*Issue #, if available:*
#3138 

*Description of changes:*
Added `db2-ae` and `db2-se` to recognized RDS engine types.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
