### PR TITLE
Use get to safely pull readOnlyProperties.

### DIFF
--- a/src/cfnlint/template/template.py
+++ b/src/cfnlint/template/template.py
@@ -423,7 +423,7 @@ class Template:  # pylint: disable=R0904,too-many-lines,too-many-instance-attrib
                         for schema in cfnlint.helpers.REGISTRY_SCHEMAS:
                             if value["Type"] == schema["typeName"]:
                                 results[name] = {}
-                                for ro_property in schema["readOnlyProperties"]:
+                                for ro_property in schema.get("readOnlyProperties", []):
                                     try:
                                         item = resolve_pointer(schema, ro_property)
                                     except KeyError:


### PR DESCRIPTION
*Issue #, if available:*
#3140 
*Description of changes:*

Use `get` to safely access `readOnlyProperties` returning an empty list if not present. Since this isn't a [required field](https://github.com/aws-cloudformation/cloudformation-cli/blob/09d60db16ff5af0e5284b196d54548ec3866b3f2/src/rpdk/core/data/schema/provider.definition.schema.v1.json#L321-L327) cannot assume will be in template we're validating.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
