### PR TITLE
Only include json files as registry schemas

### DIFF
--- a/src/cfnlint/core.py
+++ b/src/cfnlint/core.py
@@ -75,7 +75,7 @@ def run_cli(
                 for f in os.listdir(path):
                     if not f.endswith(".json"):
                         continue
-                    filename = os.path.join(path, f)                    
+                    filename = os.path.join(path, f)
                     if not os.path.isfile(filename):
                         continue
                     with open(filename, encoding="utf-8") as schema:

--- a/src/cfnlint/core.py
+++ b/src/cfnlint/core.py
@@ -73,7 +73,12 @@ def run_cli(
         for path in registry_schemas:
             if path and os.path.isdir(os.path.expanduser(path)):
                 for f in os.listdir(path):
-                    with open(os.path.join(path, f), encoding="utf-8") as schema:
+                    if not f.endswith(".json"):
+                        continue
+                    filename = os.path.join(path, f)                    
+                    if not os.path.isfile(filename):
+                        continue
+                    with open(filename, encoding="utf-8") as schema:
                         REGISTRY_SCHEMAS.append(json.load(schema))
 
     return run_checks(filename, template, rules, regions, mandatory_rules)


### PR DESCRIPTION
This is a drive-by commit:

- I have not tested this
- I'm solving my issue by moving files around

But I ran into this when I had a README.md in my folder with schemas. I added the `isfile` to prevent `.git` folders from being found by `listdir`.

The ` if not f.endswith(".json")` might break people, I think the `isfile` is safe.

To code is trivial, so feel free to close this issue if you plan to implement only part (or none) of it


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
