### PR TITLE
When using a list param in foreach pass back select statements when no allowed value

### DIFF
--- a/src/cfnlint/decode/node.py
+++ b/src/cfnlint/decode/node.py
@@ -76,7 +76,6 @@ def create_dict_node_class(cls):
         def __init__(
             self, x, start_mark: Mark | None = None, end_mark: Mark | None = None
         ):
-            LOGGER.debug(type(start_mark))
             try:
                 cls.__init__(self, x)
             except TypeError:


### PR DESCRIPTION
fix #3174

*Issue #, if available:*
- When using a list param in foreach pass back select statements when no allowed value
*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
