### PR TITLE
GitHub - move codecov back to 3

### DIFF
--- a/.github/workflows/ci-pr-coverage.yaml
+++ b/.github/workflows/ci-pr-coverage.yaml
@@ -30,12 +30,11 @@ jobs:
           result-encoding: string
       - name: Upload coverage report
         if: '!cancelled()'
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3
         with:
           override_commit: ${{ github.event.workflow_run.head_sha }}
           override_pr: ${{steps.set-pr.outputs.result}}
           token: ${{ secrets.CODECOV_TOKEN }}
-          exclude: ".github"
           files: ".coverage.3.8.xml,.coverage.3.9.xml,.coverage.3.10.xml,.coverage.3.11.xml,.coverage.3.12.xml"
           fail_ci_if_error: true
           verbose: true


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- GitHub - move codecov back to 3

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
