### PR TITLE
Add OnDemandThroughput to AWS::DynamoDB::Table patching

### DIFF
--- a/src/cfnlint/data/schemas/patches/providers/all/aws_dynamodb_table/ondemandthroughput.json
+++ b/src/cfnlint/data/schemas/patches/providers/all/aws_dynamodb_table/ondemandthroughput.json
@@ -1,0 +1,34 @@
+[
+ {
+  "op": "add",
+  "path": "/definitions/OnDemandThroughput",
+  "value": {
+   "additionalProperties": false,
+   "properties": {
+    "MaxReadRequestUnits": {
+     "minimum": 1,
+     "type": "integer"
+    },
+    "MaxWriteRequestUnits": {
+     "minimum": 1,
+     "type": "integer"
+    }
+   },
+   "type": "object"
+  }
+ },
+ {
+  "op": "add",
+  "path": "/properties/OnDemandThroughput",
+  "value": {
+   "$ref": "#/definitions/OnDemandThroughput"
+  }
+ },
+ {
+  "op": "add",
+  "path": "/definitions/GlobalSecondaryIndex/properties/OnDemandThroughput",
+  "value": {
+   "$ref": "#/definitions/OnDemandThroughput"
+  }
+ }
+]


### PR DESCRIPTION
*Issue #, if available:*
#3238 

*Description of changes:*
- Add OnDemandThroughput to AWS::DynamoDB::Table patching

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
