### PR TITLE
Add AWS::SSM::Parameter::Value<String> to use AllowedPattern

### DIFF
--- a/src/cfnlint/data/schemas/other/parameters/configuration.json
+++ b/src/cfnlint/data/schemas/other/parameters/configuration.json
@@ -22,6 +22,7 @@
      "properties": {
       "Type": {
        "enum": [
+        "AWS::SSM::Parameter::Value<String>",
         "String",
         "CommaDelimitedList"
        ]


### PR DESCRIPTION
*Issue #, if available:*
fix issue #3328 

*Description of changes:*
- Add AWS::SSM::Parameter::Value<String> to use AllowedPattern

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
