### PR TITLE
Allow Fn::GetAtt to an array in Join

### DIFF
--- a/src/cfnlint/rules/functions/Join.py
+++ b/src/cfnlint/rules/functions/Join.py
@@ -41,6 +41,7 @@ class Join(BaseFn):
                 {
                     "functions": [
                         "Fn::FindInMap",
+                        "Fn::GetAtt",
                         "Fn::If",
                         "Fn::Split",
                         "Ref",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Allow Fn::GetAtt to an array in Join

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
