### PR TITLE
Only escape type checking for pkg params when strict types is false

### DIFF
--- a/src/cfnlint/rules/resources/properties/Type.py
+++ b/src/cfnlint/rules/resources/properties/Type.py
@@ -36,7 +36,10 @@ class Type(CloudFormationLintRule):
     # pylint: disable=unused-argument
     def type(self, validator, types, instance, schema):
         if validator.context.path.cfn_path:
-            if validator.is_type(instance, "string"):
+            if (
+                validator.is_type(instance, "string")
+                and not validator.context.strict_types
+            ):
                 if (
                     "/".join(validator.context.path.cfn_path)
                     in TEMPLATED_PROPERTY_CFN_PATHS

--- a/test/unit/rules/resources/lmbd/test_function_zipfile_runtime_enum.py
+++ b/test/unit/rules/resources/lmbd/test_function_zipfile_runtime_enum.py
@@ -46,6 +46,10 @@ def rule():
                 )
             ],
         ),
+        (
+            {"Code": "../link/to/my/package.zip", "Runtime": "provided.al2023"},
+            [],
+        ),
     ],
 )
 def test_validate(instance, expected, rule, validator):


### PR DESCRIPTION
*Issue #, if available:*
fix #3322 

*Description of changes:*
- Only escape type checking for pkg params when strict types is false

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
