### PR TITLE
Condition satisfaction checks to raise error when unknown

### DIFF
--- a/src/cfnlint/conditions/__init__.py
+++ b/src/cfnlint/conditions/__init__.py
@@ -5,4 +5,5 @@ SPDX-License-Identifier: MIT-0
 
 __all__ = ["Conditions"]
 
+from cfnlint.conditions._errors import UnknownSatisfisfaction
 from cfnlint.conditions.conditions import Conditions

--- a/src/cfnlint/conditions/_equals.py
+++ b/src/cfnlint/conditions/_equals.py
@@ -10,7 +10,7 @@ import logging
 from typing import Any, Mapping, Tuple
 
 from cfnlint.conditions._utils import get_hash
-from cfnlint.helpers import FUNCTIONS, is_function
+from cfnlint.helpers import is_function
 
 LOGGER = logging.getLogger(__name__)
 REF_REGION = get_hash({"Ref": "AWS::Region"})
@@ -22,8 +22,13 @@ class EqualParameter:
     def __init__(self, value: dict):
         self._value = value
         k, _ = is_function(value)
-        if k in FUNCTIONS:
+
+        # we can only do satisfaction validation
+        # on Refs currently
+        if k not in ["Ref"]:
             self._satisfiable = False
+        else:
+            self._satisfiable = True
 
         self.hash: str = get_hash(value)
 
@@ -31,6 +36,17 @@ class EqualParameter:
         if isinstance(__o, str):
             return self.hash == __o
         return self.hash == __o.hash
+
+    @property
+    def satisfiable(self) -> bool:
+        """Returns a boolean value if the parameter can be True or False
+
+        Args: None
+
+        Returns:
+            bool: True if the parameter can be True or False, False otherwise
+        """
+        return self._satisfiable
 
 
 class Equal:

--- a/src/cfnlint/conditions/_equals.py
+++ b/src/cfnlint/conditions/_equals.py
@@ -10,6 +10,7 @@ import logging
 from typing import Any, Mapping, Tuple
 
 from cfnlint.conditions._utils import get_hash
+from cfnlint.helpers import FUNCTIONS, is_function
 
 LOGGER = logging.getLogger(__name__)
 REF_REGION = get_hash({"Ref": "AWS::Region"})
@@ -20,6 +21,10 @@ class EqualParameter:
 
     def __init__(self, value: dict):
         self._value = value
+        k, _ = is_function(value)
+        if k in FUNCTIONS:
+            self._satisfiable = False
+
         self.hash: str = get_hash(value)
 
     def __eq__(self, __o: Any):

--- a/src/cfnlint/conditions/_errors.py
+++ b/src/cfnlint/conditions/_errors.py
@@ -1,0 +1,13 @@
+"""
+Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+"""
+
+from typing import Any
+
+
+class UnknownSatisfisfaction(Exception):
+    """Unknown Satisfisfaction Exception"""
+
+    def __init__(self, message: str, **kwargs: Any):
+        super().__init__(message, **kwargs)

--- a/src/cfnlint/conditions/conditions.py
+++ b/src/cfnlint/conditions/conditions.py
@@ -16,7 +16,8 @@ from sympy.logic.boolalg import BooleanFalse, BooleanTrue
 from sympy.logic.inference import satisfiable
 
 from cfnlint.conditions._condition import ConditionNamed
-from cfnlint.conditions._equals import Equal
+from cfnlint.conditions._equals import Equal, EqualParameter
+from cfnlint.conditions._errors import UnknownSatisfisfaction
 from cfnlint.conditions._utils import get_hash
 from cfnlint.helpers import PSEUDOPARAMS
 
@@ -361,6 +362,9 @@ class Conditions:
 
         Returns:
             bool: True if the conditions are satisfied
+
+        Raises:
+            UnknownSatisfisfaction: If we don't know how to satisfy a condition
         """
         if not conditions:
             return True
@@ -375,6 +379,12 @@ class Conditions:
                         continue
 
                     ref_hash = get_hash({"Ref": param})
+                    for c_equal_param in c_equals.parameters:
+                        if isinstance(c_equal_param, EqualParameter):
+                            if c_equal_param._satisfiable is False:
+                                raise UnknownSatisfisfaction(
+                                    f"Can't resolve satisfaction for {condition_name!r}"
+                                )
                     if ref_hash in c_equals.parameters:
                         found_params = {ref_hash: value}
 

--- a/src/cfnlint/conditions/conditions.py
+++ b/src/cfnlint/conditions/conditions.py
@@ -381,7 +381,7 @@ class Conditions:
                     ref_hash = get_hash({"Ref": param})
                     for c_equal_param in c_equals.parameters:
                         if isinstance(c_equal_param, EqualParameter):
-                            if c_equal_param._satisfiable is False:
+                            if c_equal_param.satisfiable is False:
                                 raise UnknownSatisfisfaction(
                                     f"Can't resolve satisfaction for {condition_name!r}"
                                 )


### PR DESCRIPTION
*Issue #, if available:*
fix #3325 
fix #3348

*Description of changes:*
- Condition satisfaction checks to raise error when unknown

We currently do not have proper logic for handling complex functions in conditions and testing for satisfaction.  As a result we are going to raise an error so we don't validate those values. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
