### PR TITLE
Add in awslogs-create-group to ECS task logging

### DIFF
--- a/src/cfnlint/data/schemas/extensions/aws_ecs_taskdefinition/logging_configuration.json
+++ b/src/cfnlint/data/schemas/extensions/aws_ecs_taskdefinition/logging_configuration.json
@@ -16,6 +16,7 @@
    "Options": {
     "propertyNames": {
      "enum": [
+      "awslogs-create-group",
       "awslogs-datetime-format",
       "awslogs-group",
       "awslogs-multiline-pattern",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Add in awslogs-create-group to ECS task logging

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
