### PR TITLE
update logic in rule E3686

### DIFF
--- a/src/cfnlint/data/schemas/extensions/aws_rds_dbcluster/serverless_exclusive.json
+++ b/src/cfnlint/data/schemas/extensions/aws_rds_dbcluster/serverless_exclusive.json
@@ -1,21 +1,56 @@
 {
  "additionalProperties": true,
- "description": "When creating a serverless 'EngineMode' don't specify 'ScalingConfiguration'",
- "else": {},
- "if": {
-  "properties": {
-   "EngineMode": {
-    "const": "serverless"
+ "allOf": [
+  {
+   "if": {
+    "properties": {
+     "EngineMode": {
+      "const": "provisioned"
+     }
+    },
+    "required": [
+     "EngineMode"
+    ],
+    "type": "object"
+   },
+   "then": {
+    "properties": {
+     "ScalingConfiguration": false
+    }
    }
   },
-  "required": [
-   "EngineMode"
-  ],
-  "type": "object"
- },
- "then": {
-  "properties": {
-   "ScalingConfiguration": false
+  {
+   "if": {
+    "properties": {
+     "EngineMode": {
+      "const": "serverless"
+     }
+    },
+    "required": [
+     "EngineMode"
+    ],
+    "type": "object"
+   },
+   "then": {
+    "properties": {
+     "ServerlessV2ScalingConfiguration": false
+    }
+   }
+  },
+  {
+   "if": {
+    "properties": {
+     "EngineMode": false
+    },
+    "type": "object"
+   },
+   "then": {
+    "properties": {
+     "ScalingConfiguration": false,
+     "ServerlessV2ScalingConfiguration": false
+    }
+   }
   }
- }
+ ],
+ "description": "When creating a serverless 'EngineMode' don't specify 'ServerlessV2ScalingConfiguration'"
 }

--- a/test/unit/rules/resources/rds/test_db_cluster_serverless_exclusive.py
+++ b/test/unit/rules/resources/rds/test_db_cluster_serverless_exclusive.py
@@ -35,14 +35,82 @@ def rule():
             [],
         ),
         (
-            {"EngineMode": "serverless", "ScalingConfiguration": "foo"},
+            {"EngineMode": "serverless", "ServerlessV2ScalingConfiguration": "foo"},
             [
                 ValidationError(
-                    "Additional properties are not allowed ('ScalingConfiguration')",
+                    (
+                        "EngineMode 'serverless'  doesn't allow additional "
+                        "properties 'ServerlessV2ScalingConfiguration'"
+                    ),
+                    rule=DbClusterServerlessExclusive(),
+                    path=deque(["ServerlessV2ScalingConfiguration"]),
+                    validator=None,
+                    schema_path=deque(
+                        [
+                            "allOf",
+                            1,
+                            "then",
+                            "properties",
+                            "ServerlessV2ScalingConfiguration",
+                        ]
+                    ),
+                )
+            ],
+        ),
+        (
+            {"EngineMode": "provisioned", "ScalingConfiguration": "foo"},
+            [
+                ValidationError(
+                    (
+                        "EngineMode 'provisioned'  doesn't allow "
+                        "additional properties 'ScalingConfiguration'"
+                    ),
                     rule=DbClusterServerlessExclusive(),
                     path=deque(["ScalingConfiguration"]),
                     validator=None,
-                    schema_path=deque(["then", "properties", "ScalingConfiguration"]),
+                    schema_path=deque(
+                        ["allOf", 0, "then", "properties", "ScalingConfiguration"]
+                    ),
+                )
+            ],
+        ),
+        (
+            {"ServerlessV2ScalingConfiguration": "foo"},
+            [
+                ValidationError(
+                    (
+                        "Additional properties are not allowed "
+                        "('ServerlessV2ScalingConfiguration')"
+                    ),
+                    rule=DbClusterServerlessExclusive(),
+                    path=deque(["ServerlessV2ScalingConfiguration"]),
+                    validator=None,
+                    schema_path=deque(
+                        [
+                            "allOf",
+                            2,
+                            "then",
+                            "properties",
+                            "ServerlessV2ScalingConfiguration",
+                        ]
+                    ),
+                )
+            ],
+        ),
+        (
+            {"ScalingConfiguration": "foo"},
+            [
+                ValidationError(
+                    (
+                        "Additional properties are not allowed "
+                        "('ScalingConfiguration')"
+                    ),
+                    rule=DbClusterServerlessExclusive(),
+                    path=deque(["ScalingConfiguration"]),
+                    validator=None,
+                    schema_path=deque(
+                        ["allOf", 2, "then", "properties", "ScalingConfiguration"]
+                    ),
                 )
             ],
         ),
@@ -50,5 +118,4 @@ def rule():
 )
 def test_validate(instance, expected, rule, validator):
     errs = list(rule.validate(validator, "", instance, {}))
-
     assert errs == expected, f"Expected {expected} got {errs}"


### PR DESCRIPTION
*Issue #, if available:*
fix #3366 

*Description of changes:*
- update logic in rule E3686

- Serverless v1 and v2 validation of allowed properties
- If not using serverless then validate that we aren't providing any of v1/v2 scaling configurations.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
