### PR TITLE
Default fn validator context will be not strict type checking

### DIFF
--- a/src/cfnlint/helpers.py
+++ b/src/cfnlint/helpers.py
@@ -564,7 +564,9 @@ def _translate_types(types: Sequence[str]) -> list[str]:
 
 
 def is_types_compatible(
-    source_types: str | Sequence[str], destination_types: str | Sequence[str]
+    source_types: str | Sequence[str],
+    destination_types: str | Sequence[str],
+    strict_types: bool = False,
 ) -> bool:
     """
     Validate if desination types are compatible with source types.
@@ -576,7 +578,8 @@ def is_types_compatible(
     Returns:
         bool: If any type of source is compatible with any type in the destination
     """
-    source_types = _translate_types(ensure_list(source_types))
+    if not strict_types:
+        source_types = _translate_types(ensure_list(source_types))
     destination_types = ensure_list(destination_types)
 
     if any(schema_type in source_types for schema_type in destination_types):

--- a/src/cfnlint/jsonschema/_keywords_cfn.py
+++ b/src/cfnlint/jsonschema/_keywords_cfn.py
@@ -59,7 +59,8 @@ class FnItems:
             for (index, item), subschema in zip(enumerate(instance), s):
                 yield from validator.evolve(
                     context=validator.context.evolve(
-                        functions=subschema.get("functions", [])
+                        functions=subschema.get("functions", []),
+                        strict_types=False,
                     ),
                 ).descend(
                     instance=item,
@@ -69,7 +70,10 @@ class FnItems:
         else:
             for index, item in enumerate(instance):
                 yield from validator.evolve(
-                    context=validator.context.evolve(functions=s.get("functions", [])),
+                    context=validator.context.evolve(
+                        functions=s.get("functions", []),
+                        strict_types=False,
+                    ),
                 ).descend(
                     instance=item,
                     schema=s.get("schema", {}),

--- a/src/cfnlint/rules/functions/GetAtt.py
+++ b/src/cfnlint/rules/functions/GetAtt.py
@@ -132,7 +132,9 @@ class GetAtt(BaseFn):
 
                         types = ensure_list(s.get("type"))
 
-                        if is_types_compatible(types, schema_types):
+                        if is_types_compatible(
+                            types, schema_types, validator.context.strict_types
+                        ):
                             continue
 
                         reprs = ", ".join(repr(type) for type in types)

--- a/src/cfnlint/rules/functions/Sub.py
+++ b/src/cfnlint/rules/functions/Sub.py
@@ -90,6 +90,7 @@ class Sub(BaseFn):
                 path=validator.context.path.descend(
                     path=key,
                 ),
+                strict_types=True,
             ),
             function_filter=validator.function_filter.evolve(
                 add_cfn_lint_keyword=False,

--- a/test/unit/module/jsonschema/test_keywords_cfn.py
+++ b/test/unit/module/jsonschema/test_keywords_cfn.py
@@ -8,7 +8,7 @@ from collections import namedtuple
 from typing import List
 
 from cfnlint.context import Context
-from cfnlint.jsonschema._keywords_cfn import cfn_type
+from cfnlint.jsonschema._keywords_cfn import FnItems, cfn_type
 from cfnlint.jsonschema.exceptions import UnknownType
 from cfnlint.jsonschema.validators import CfnTemplateValidator
 
@@ -136,3 +136,18 @@ class TestCfnTypeFailure(Base):
         self.assertIn(
             "Unknown type 'bar' for validator with schema", str(err.exception)
         )
+
+
+class TestFnItems(Base):
+
+    def test_change_type(self):
+        schema = [
+            {
+                "schema": {"type": "string"},
+            },
+        ]
+        validator = CfnTemplateValidator({})
+
+        items = list(FnItems().validate(validator, schema, [1], {}))
+
+        self.assertListEqual(items, [])

--- a/test/unit/rules/functions/test_getatt.py
+++ b/test/unit/rules/functions/test_getatt.py
@@ -158,9 +158,31 @@ class _Fail(CfnLintKeyword):
             "Valid GetAtt with integer to string",
             {"Fn::GetAtt": "MyCodePipeline.Version"},
             {"type": ["integer"]},
-            {},
+            {
+                "strict_types": False,
+            },
             {},
             [],
+        ),
+        (
+            "Invalid GetAtt with integer to string",
+            {"Fn::GetAtt": "MyCodePipeline.Version"},
+            {"type": ["integer"]},
+            {
+                "strict_types": True,
+            },
+            {},
+            [
+                ValidationError(
+                    (
+                        "{'Fn::GetAtt': 'MyCodePipeline.Version'} "
+                        "is not of type 'integer'"
+                    ),
+                    path=deque(["Fn::GetAtt"]),
+                    schema_path=deque(["type"]),
+                    validator="fn_getatt",
+                )
+            ],
         ),
         (
             "Valid GetAtt with one good response type",
@@ -244,4 +266,9 @@ def test_validate(
     rule.child_rules = child_rules
     validator = CfnTemplateValidator({}, context=context, cfn=cfn)
     errs = list(rule.fn_getatt(validator, schema, instance, {}))
+
+    for err in errs:
+        print(err.validator)
+        print(err.path)
+        print(err.schema_path)
     assert errs == expected, f"Test {name!r} got {errs!r}"

--- a/test/unit/rules/functions/test_sub.py
+++ b/test/unit/rules/functions/test_sub.py
@@ -29,6 +29,7 @@ def cfn():
             "Resources": {
                 "MyResource": {"Type": "AWS::S3::Bucket"},
                 "MySimpleAd": {"Type": "AWS::DirectoryService::SimpleAD"},
+                "MyPolicy": {"Type": "AWS::IAM::ManagedPolicy"},
             },
         },
         regions=["us-east-1"],
@@ -95,7 +96,7 @@ def context(cfn):
                 ValidationError(
                     (
                         "'bar' is not one of ["
-                        "'MyResource', 'MySimpleAd', 'AWS::AccountId', "
+                        "'MyResource', 'MySimpleAd', 'MyPolicy', 'AWS::AccountId', "
                         "'AWS::NoValue', 'AWS::NotificationARNs', "
                         "'AWS::Partition', 'AWS::Region', "
                         "'AWS::StackId', 'AWS::StackName', 'AWS::URLSuffix']"
@@ -114,7 +115,7 @@ def context(cfn):
                 ValidationError(
                     (
                         "'foo' is not one of ["
-                        "'MyResource', 'MySimpleAd', 'AWS::AccountId', "
+                        "'MyResource', 'MySimpleAd', 'MyPolicy', 'AWS::AccountId', "
                         "'AWS::NoValue', 'AWS::NotificationARNs', "
                         "'AWS::Partition', 'AWS::Region', "
                         "'AWS::StackId', 'AWS::StackName', 'AWS::URLSuffix']"
@@ -228,7 +229,7 @@ def context(cfn):
             {"type": "string"},
             [
                 ValidationError(
-                    "'Foo' is not one of ['MyResource', 'MySimpleAd']",
+                    "'Foo' is not one of ['MyResource', 'MySimpleAd', 'MyPolicy']",
                     path=deque(["Fn::Sub"]),
                     schema_path=deque([]),
                     validator="fn_sub",
@@ -241,7 +242,21 @@ def context(cfn):
             {"type": "string"},
             [
                 ValidationError(
-                    ("'MySimpleAd.DnsIpAddresses' is not " "of type 'string'"),
+                    ("'MySimpleAd.DnsIpAddresses' is not of type 'string'"),
+                    instance="MySimpleAd.DnsIpAddresses",
+                    path=deque(["Fn::Sub"]),
+                    schema_path=deque([]),
+                    validator="fn_sub",
+                ),
+            ],
+        ),
+        (
+            "Invalid Fn::Sub with a GetAtt to an integer",
+            {"Fn::Sub": "${MyPolicy.AttachmentCount}"},
+            {"type": "string"},
+            [
+                ValidationError(
+                    ("'MyPolicy.AttachmentCount' is not of type 'string'"),
                     instance="MySimpleAd.DnsIpAddresses",
                     path=deque(["Fn::Sub"]),
                     schema_path=deque([]),


### PR DESCRIPTION
*Issue #, if available:*
fix #3383 

*Description of changes:*
- Default fn validator context will be not strict type checking


Sub has strict types because you can't always use a number or boolean value.  When nesting other functions in the Sub that strict type validation should be back to False.  This will make sure the default to functions items is false and will still allow Fn Sub to be strict as needed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
