### PR TITLE
Update resolution validation to only return an error if there are no valid values

### DIFF
--- a/test/unit/module/cfn_yaml/test_yaml.py
+++ b/test/unit/module/cfn_yaml/test_yaml.py
@@ -27,7 +27,7 @@ class TestYamlParse(BaseTestCase):
             },
             "generic_bad": {
                 "filename": "test/fixtures/templates/bad/generic.yaml",
-                "failures": 33,
+                "failures": 28,
             },
         }
 

--- a/test/unit/module/test_rules_collections.py
+++ b/test/unit/module/test_rules_collections.py
@@ -69,7 +69,7 @@ class TestRulesCollection(BaseTestCase):
         filename = "test/fixtures/templates/bad/generic.yaml"
         template = cfnlint.decode.cfn_yaml.load(filename)
         cfn = Template(filename, template, ["us-east-1"])
-        expected_err_count = 36
+        expected_err_count = 31
         matches = []
         matches.extend(self.rules.run(filename, cfn))
         assert (

--- a/test/unit/rules/functions/test_sub.py
+++ b/test/unit/rules/functions/test_sub.py
@@ -26,6 +26,15 @@ def cfn():
     return Template(
         "",
         {
+            "Parameters": {
+                "MyParameter": {
+                    "Type": "String",
+                    "AllowedValues": [
+                        "one",
+                        "two",
+                    ],
+                }
+            },
             "Resources": {
                 "MyResource": {"Type": "AWS::S3::Bucket"},
                 "MySimpleAd": {"Type": "AWS::DirectoryService::SimpleAD"},
@@ -96,8 +105,8 @@ def context(cfn):
                 ValidationError(
                     (
                         "'bar' is not one of ["
-                        "'MyResource', 'MySimpleAd', 'MyPolicy', 'AWS::AccountId', "
-                        "'AWS::NoValue', 'AWS::NotificationARNs', "
+                        "'MyParameter', 'MyResource', 'MySimpleAd', 'MyPolicy', "
+                        "'AWS::AccountId', 'AWS::NoValue', 'AWS::NotificationARNs', "
                         "'AWS::Partition', 'AWS::Region', "
                         "'AWS::StackId', 'AWS::StackName', 'AWS::URLSuffix']"
                     ),
@@ -115,8 +124,8 @@ def context(cfn):
                 ValidationError(
                     (
                         "'foo' is not one of ["
-                        "'MyResource', 'MySimpleAd', 'MyPolicy', 'AWS::AccountId', "
-                        "'AWS::NoValue', 'AWS::NotificationARNs', "
+                        "'MyParameter', 'MyResource', 'MySimpleAd', 'MyPolicy', "
+                        "'AWS::AccountId', 'AWS::NoValue', 'AWS::NotificationARNs', "
                         "'AWS::Partition', 'AWS::Region', "
                         "'AWS::StackId', 'AWS::StackName', 'AWS::URLSuffix']"
                     ),
@@ -260,6 +269,25 @@ def context(cfn):
                     instance="MySimpleAd.DnsIpAddresses",
                     path=deque(["Fn::Sub"]),
                     schema_path=deque([]),
+                    validator="fn_sub",
+                ),
+            ],
+        ),
+        (
+            "One valid resolution",
+            {"Fn::Sub": "${MyParameter}"},
+            {"type": "string", "const": "two"},
+            [],
+        ),
+        (
+            "No valid resolution",
+            {"Fn::Sub": "${MyParameter}"},
+            {"type": "string", "const": "three"},
+            [
+                ValidationError(
+                    ("'three' was expected when 'Fn::Sub' is resolved"),
+                    path=deque(["Fn::Sub"]),
+                    schema_path=deque(["const"]),
                     validator="fn_sub",
                 ),
             ],


### PR DESCRIPTION
*Issue #, if available:*
fix #3380 

*Description of changes:*
- Update resolution validation to only return an error if there are no valid resolution values.
- Update sub resolver to return multiple times when just using a string

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
