### PR TITLE
Allow Ref AWS::NoValue in FindInMap parameters

### DIFF
--- a/src/cfnlint/jsonschema/_filter.py
+++ b/src/cfnlint/jsonschema/_filter.py
@@ -36,18 +36,18 @@ class FunctionFilter:
         init=False,
         default_factory=lambda: [
             "dependencies",
-            "if",
-            "then",
-            "else",
-            "required",
-            "requiredXor",
-            "requiredAtLeastOne",
             "dependentExcluded",
             "dependentRequired",
-            "minItems",
-            "minProperties",
+            "else",
+            "if",
             "maxItems",
             "maxProperties",
+            "minItems",
+            "minProperties",
+            "required",
+            "requiredAtLeastOne",
+            "requiredXor",
+            "then",
             "uniqueItems",
         ],
     )
@@ -115,6 +115,12 @@ class FunctionFilter:
                     yield (instance, {"dynamicReference": schema})
                     return
                 return
+
+        # if there are no functions then we don't need to worry
+        # about ref AWS::NoValue or If conditions
+        if not validator.context.functions:
+            yield instance, schema
+            return
 
         # dependencies, required, minProperties, maxProperties
         # need to have filtered properties to validate

--- a/test/unit/rules/resources/ecs/test_task_definition_essentials.py
+++ b/test/unit/rules/resources/ecs/test_task_definition_essentials.py
@@ -57,8 +57,8 @@ def rule():
                     "At least one essential container is required",
                     rule=TaskDefinitionEssentialContainer(),
                     path=deque([]),
-                    validator="minItems",
-                    schema_path=deque(["minItems"]),
+                    validator="contains",
+                    schema_path=deque(["contains"]),
                 )
             ],
         ),

--- a/test/unit/rules/resources/route53/test_recordsets.py
+++ b/test/unit/rules/resources/route53/test_recordsets.py
@@ -342,22 +342,6 @@ def rule():
             },
             [
                 ValidationError(
-                    "['cname1.example.com', 'foo√bar'] is too long (1)",
-                    rule=RecordSet(),
-                    path=deque(["ResourceRecords"]),
-                    validator="maxItems",
-                    schema_path=deque(
-                        [
-                            "allOf",
-                            3,
-                            "then",
-                            "properties",
-                            "ResourceRecords",
-                            "maxItems",
-                        ]
-                    ),
-                ),
-                ValidationError(
                     "'foo√bar' is not valid under any of the given schemas",
                     rule=RecordSet(),
                     path=deque(["ResourceRecords", 1]),
@@ -395,6 +379,22 @@ def rule():
                             "ResourceRecords",
                             "items",
                             "anyOf",
+                        ]
+                    ),
+                ),
+                ValidationError(
+                    "['cname1.example.com', 'foo√bar'] is too long (1)",
+                    rule=RecordSet(),
+                    path=deque(["ResourceRecords"]),
+                    validator="maxItems",
+                    schema_path=deque(
+                        [
+                            "allOf",
+                            3,
+                            "then",
+                            "properties",
+                            "ResourceRecords",
+                            "maxItems",
                         ]
                     ),
                 ),


### PR DESCRIPTION
*Issue #, if available:*
fix #3396 
*Description of changes:*
- Allow Ref AWS::NoValue in FindInMap parameters

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
