### PR TITLE
Fix tagging examples

### DIFF
--- a/examples/rules/PropertiesTagsRequired.py
+++ b/examples/rules/PropertiesTagsRequired.py
@@ -3,6 +3,7 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 
+from cfnlint.decode.node import dict_node, list_node
 from cfnlint.rules import CloudFormationLintRule, RuleMatch
 
 
@@ -24,7 +25,12 @@ class PropertiesTagsRequired(CloudFormationLintRule):
         all_tags = cfn.search_deep_keys("Tags")
         all_tags = [x for x in all_tags if x[0] == "Resources"]
         for all_tag in all_tags:
-            all_keys = [d.get("Key") for d in all_tag[-1]]
+            if isinstance(all_tag[-1], list_node):
+                all_keys = [d.get("Key") for d in all_tag[-1]]
+            elif isinstance(all_tag[-1], dict_node):
+                all_keys = all_tag[-1].keys()
+            else:
+                continue
             for required_tag in required_tags:
                 if required_tag not in all_keys:
                     message = "Missing Tag {0} at {1}"


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*  The examples no longer worked with cfn-lint v1.  The `PropertiesTagsRequired` probably didn't work with v0 either, because it didn't account for resources that use objects as tags, eg. [AWS::SSM::Parameter](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ssm-parameter.html#cfn-ssm-parameter-tags).

Instead of `"Tags" in schema.schema["properties"]` I wanted to use `(schema.schema.get("tagging") or {}).get("taggable")`, but that doesn't work with `AWS::ApiGatewayV2::Stage` (`"tagging" not in schema.schema`, but the resource supports tags).  Happend to have that resource in our test suite, there might be more where this doesn't work.  (See also this [message at discord](https://discord.com/channels/981586120448020580/1009534248778211448/1256319419374899454).)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
