### PR TITLE
Update helpers.py with DocDB snapshot type

### DIFF
--- a/src/cfnlint/helpers.py
+++ b/src/cfnlint/helpers.py
@@ -230,6 +230,7 @@ LIMITS: dict[str, Any] = {
 
 valid_snapshot_types = frozenset(
     [
+        "AWS::DocDB::DBCluster",
         "AWS::EC2::Volume",
         "AWS::ElastiCache::CacheCluster",
         "AWS::ElastiCache::ReplicationGroup",


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

DocumentDB Clusters support DeletionPolicy and UpdateReplacePolicy of type `Snapshot`

https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
