### PR TITLE
Switch type comparison in BaseFn to use is_types_compatible

### DIFF
--- a/src/cfnlint/rules/functions/_BaseFn.py
+++ b/src/cfnlint/rules/functions/_BaseFn.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from collections import namedtuple
 from typing import Any, Tuple
 
-from cfnlint.helpers import ToPy, ensure_list
+from cfnlint.helpers import ToPy, ensure_list, is_types_compatible
 from cfnlint.jsonschema import ValidationError, ValidationResult, Validator
 from cfnlint.rules import CloudFormationLintRule
 
@@ -118,7 +118,7 @@ class BaseFn(CloudFormationLintRule):
     ) -> ValidationResult:
         tS = self.resolve_type(validator, s)
         if tS:
-            if not any(t in self.types for t in tS):
+            if not is_types_compatible(self.types, tS):
                 reprs = ", ".join(repr(type) for type in tS)
                 yield ValidationError(f"{instance!r} is not of type {reprs}")
 

--- a/test/unit/rules/functions/test_length.py
+++ b/test/unit/rules/functions/test_length.py
@@ -113,6 +113,13 @@ def context(cfn):
             {"transforms": Transforms(["AWS::LanguageExtensions"])},
             [],
         ),
+        (
+            "Fn::Length output while a number can be a string",
+            {"Fn::Length": []},
+            {"type": "string"},
+            {"transforms": Transforms(["AWS::LanguageExtensions"])},
+            [],
+        ),
     ],
 )
 def test_validate(name, instance, schema, context_evolve, expected, rule, context, cfn):


### PR DESCRIPTION
*Issue #, if available:*
fix #3458 

*Description of changes:*
- Switch type comparison in BaseFn to use is_types_compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
