### PR TITLE
Update logging configuration to not when used by a library

### DIFF
--- a/src/cfnlint/api.py
+++ b/src/cfnlint/api.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from typing import List
 
-from cfnlint.config import ConfigMixIn, ManualArgs, configure_logging
+from cfnlint.config import ConfigMixIn, ManualArgs
 from cfnlint.decode.decode import decode_str
 from cfnlint.helpers import REGION_PRIMARY, REGIONS
 from cfnlint.rules import Match, RulesCollection
@@ -38,7 +38,6 @@ def lint(
     list
         a list of errors if any were found, else an empty list
     """
-    configure_logging(None, None)
     template, errors = decode_str(s)
     if errors:
         return errors

--- a/src/cfnlint/config.py
+++ b/src/cfnlint/config.py
@@ -30,14 +30,13 @@ _DEFAULT_RULESDIR = os.path.join(os.path.dirname(__file__), "rules")
 
 def configure_logging(debug_logging, info_logging):
     ch = logging.StreamHandler()
-    ch.setLevel(logging.DEBUG)
 
     if debug_logging:
         LOGGER.setLevel(logging.DEBUG)
     elif info_logging:
         LOGGER.setLevel(logging.INFO)
     else:
-        LOGGER.setLevel(logging.NOTSET)
+        LOGGER.setLevel(logging.WARNING)
     log_formatter = logging.Formatter(
         "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
     )
@@ -621,7 +620,6 @@ class ConfigMixIn(TemplateArgs, CliArgs, ConfigFileArgs):
         self._manual_args = kwargs or ManualArgs()
         CliArgs.__init__(self, cli_args)
         # configure debug as soon as we can
-        configure_logging(self.cli_args.debug, self.cli_args.info)  # type: ignore
         TemplateArgs.__init__(self, {})
         ConfigFileArgs.__init__(
             self, config_file=self._get_argument_value("config_file", False, False)
@@ -638,6 +636,7 @@ class ConfigMixIn(TemplateArgs, CliArgs, ConfigFileArgs):
                 "regions": self.regions,
                 "ignore_bad_template": self.ignore_bad_template,
                 "debug": self.debug,
+                "info": self.info,
                 "format": self.format,
                 "templates": self.templates,
                 "append_rules": self.append_rules,
@@ -716,6 +715,10 @@ class ConfigMixIn(TemplateArgs, CliArgs, ConfigFileArgs):
     @property
     def debug(self):
         return self._get_argument_value("debug", False, False)
+
+    @property
+    def info(self):
+        return self._get_argument_value("info", False, False)
 
     @property
     def format(self):

--- a/src/cfnlint/runner.py
+++ b/src/cfnlint/runner.py
@@ -13,7 +13,7 @@ from typing import Any, Iterator, Sequence
 
 import cfnlint.formatters
 import cfnlint.maintenance
-from cfnlint.config import ConfigMixIn
+from cfnlint.config import ConfigMixIn, configure_logging
 from cfnlint.decode.decode import decode
 from cfnlint.rules import Match, Rules
 from cfnlint.rules.errors import ParseError, TransformError
@@ -398,6 +398,9 @@ class Runner:
         Raises:
             None: This function does not raise any exceptions.
         """
+        # Add our logging configuration when running CLI
+        configure_logging(self.config.debug, self.config.info)
+
         if self.config.update_specs:
             cfnlint.maintenance.update_resource_specs(self.config.force)
             sys.exit(0)

--- a/test/unit/module/config/test_logging.py
+++ b/test/unit/module/config/test_logging.py
@@ -37,5 +37,5 @@ class TestLogging(BaseTestCase):
         """Test no logging level"""
 
         cfnlint.config.configure_logging(False, False)
-        self.assertEqual(logging.NOTSET, LOGGER.level)
+        self.assertEqual(logging.WARNING, LOGGER.level)
         self.assertEqual(len(LOGGER.handlers), 1)

--- a/test/unit/module/runner/test_cli.py
+++ b/test/unit/module/runner/test_cli.py
@@ -3,15 +3,23 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 
+import logging
 from test.testlib.testcase import BaseTestCase
 from unittest.mock import patch
 
 from cfnlint import ConfigMixIn
 from cfnlint.runner import Runner
 
+LOGGER = logging.getLogger("cfnlint")
+
 
 class TestCli(BaseTestCase):
     """Test CLI with config"""
+
+    def tearDown(self):
+        """Setup"""
+        for handler in LOGGER.handlers:
+            LOGGER.removeHandler(handler)
 
     @patch("cfnlint.maintenance.update_documentation")
     def test_update_documentation(self, mock_maintenance):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Only configure logging when running via the CLI

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
