### PR TITLE
Add CloudFormationProvisionedProduct to exceptions

### DIFF
--- a/src/cfnlint/rules/functions/GetAttFormat.py
+++ b/src/cfnlint/rules/functions/GetAttFormat.py
@@ -30,6 +30,7 @@ class GetAttFormat(CfnLintKeyword):
         self._resource_type_exceptions = [
             "AWS::CloudFormation::CustomResource",
             "AWS::CloudFormation::Stack",
+            "AWS::ServiceCatalog::CloudFormationProvisionedProduct",
         ]
 
     def validate(


### PR DESCRIPTION
*Issue #, if available:*
fix #3480 

*Description of changes:*
* Skip getatt format validation on AWS::ServiceCatalog::CloudFormationProvisionedProduct


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
