### PR TITLE
Allow ICMP to have fromport other than -1 with to port -1

### DIFF
--- a/src/cfnlint/data/schemas/extensions/aws_ec2_securitygroup/all_to_and_from_ports.json
+++ b/src/cfnlint/data/schemas/extensions/aws_ec2_securitygroup/all_to_and_from_ports.json
@@ -1,60 +1,103 @@
 {
- "allOf": [
-  {
-   "if": {
-    "properties": {
-     "ToPort": {
-      "enum": [
-       -1,
-       "-1"
-      ]
-     }
+ "else": {
+  "allOf": [
+   {
+    "if": {
+     "properties": {
+      "ToPort": {
+       "enum": [
+        -1,
+        "-1"
+       ]
+      }
+     },
+     "required": [
+      "ToPort"
+     ]
     },
-    "required": [
-     "ToPort"
-    ]
+    "then": {
+     "properties": {
+      "FromPort": {
+       "enum": [
+        -1,
+        "-1"
+       ]
+      }
+     },
+     "required": [
+      "FromPort"
+     ]
+    }
    },
-   "then": {
-    "properties": {
-     "FromPort": {
-      "enum": [
-       -1,
-       "-1"
-      ]
-     }
+   {
+    "if": {
+     "properties": {
+      "FromPort": {
+       "enum": [
+        -1,
+        "-1"
+       ]
+      }
+     },
+     "required": [
+      "FromPort"
+     ]
     },
-    "required": [
-     "FromPort"
+    "then": {
+     "properties": {
+      "ToPort": {
+       "enum": [
+        -1,
+        "-1"
+       ]
+      }
+     },
+     "required": [
+      "ToPort"
+     ]
+    }
+   }
+  ]
+ },
+ "if": {
+  "properties": {
+   "IpProtocol": {
+    "enum": [
+     "1",
+     "icmp"
     ]
    }
   },
-  {
-   "if": {
-    "properties": {
-     "FromPort": {
-      "enum": [
-       -1,
-       "-1"
-      ]
-     }
-    },
-    "required": [
-     "FromPort"
-    ]
+  "required": [
+   "IpProtocol"
+  ]
+ },
+ "then": {
+  "if": {
+   "properties": {
+    "FromPort": {
+     "enum": [
+      -1,
+      "-1"
+     ]
+    }
    },
-   "then": {
-    "properties": {
-     "ToPort": {
-      "enum": [
-       -1,
-       "-1"
-      ]
-     }
-    },
-    "required": [
-     "ToPort"
-    ]
-   }
+   "required": [
+    "FromPort"
+   ]
+  },
+  "then": {
+   "properties": {
+    "ToPort": {
+     "enum": [
+      -1,
+      "-1"
+     ]
+    }
+   },
+   "required": [
+    "ToPort"
+   ]
   }
- ]
+ }
 }

--- a/test/unit/rules/resources/ec2/test_sg_all_to_and_from_ports.py
+++ b/test/unit/rules/resources/ec2/test_sg_all_to_and_from_ports.py
@@ -42,6 +42,14 @@ def rule():
         ),
         (
             {
+                "IpProtocol": 1,
+                "ToPort": -1,
+                "FromPort": 8,
+            },
+            [],
+        ),
+        (
+            {
                 "ToPort": -1,
             },
             [
@@ -56,7 +64,7 @@ def rule():
                         "properties": {"FromPort": {"enum": [-1, "-1"]}},
                         "required": ["FromPort"],
                     },
-                    schema_path=deque(["allOf", 0, "then", "required"]),
+                    schema_path=deque(["else", "allOf", 0, "then", "required"]),
                 )
             ],
         ),
@@ -76,7 +84,7 @@ def rule():
                         "properties": {"ToPort": {"enum": [-1, "-1"]}},
                         "required": ["ToPort"],
                     },
-                    schema_path=deque(["allOf", 1, "then", "required"]),
+                    schema_path=deque(["else", "allOf", 1, "then", "required"]),
                 )
             ],
         ),
@@ -95,7 +103,7 @@ def rule():
                     instance=5,
                     schema={"enum": [-1, "-1"]},
                     schema_path=deque(
-                        ["allOf", 0, "then", "properties", "FromPort", "enum"]
+                        ["else", "allOf", 0, "then", "properties", "FromPort", "enum"]
                     ),
                 )
             ],
@@ -115,8 +123,27 @@ def rule():
                     instance=5,
                     schema={"enum": [-1, "-1"]},
                     schema_path=deque(
-                        ["allOf", 1, "then", "properties", "ToPort", "enum"]
+                        ["else", "allOf", 1, "then", "properties", "ToPort", "enum"]
                     ),
+                )
+            ],
+        ),
+        (
+            {
+                "IpProtocol": "icmp",
+                "ToPort": 8,
+                "FromPort": -1,
+            },
+            [
+                ValidationError(
+                    ("Both ['FromPort', 'ToPort'] must " "be -1 when one is -1"),
+                    rule=SecurityGroupAllToAndFromPorts(),
+                    path=deque(["ToPort"]),
+                    validator="enum",
+                    validator_value=[-1, "-1"],
+                    instance=5,
+                    schema={"enum": [-1, "-1"]},
+                    schema_path=deque(["then", "then", "properties", "ToPort", "enum"]),
                 )
             ],
         ),


### PR DESCRIPTION
*Issue #, if available:*
#2999 

*Description of changes:*
- Allow ICMP to have fromport other than -1 with to port -1

When picking a certain ICMP protocol the FromPort is that selection and the ToPort are -1.

from the API
```json
"IpPermissions": [
                {
                    "FromPort": 9,
                    "IpProtocol": "icmp",
                    "IpRanges": [
                        {
                            "CidrIp": "0.0.0.0/0"
                        }
                    ],
                    "Ipv6Ranges": [],
                    "PrefixListIds": [],
                    "ToPort": -1,
                    "UserIdGroupPairs": []
                }
            ],
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
