### PR TITLE
Return all errors from resolution

### DIFF
--- a/src/cfnlint/context/context.py
+++ b/src/cfnlint/context/context.py
@@ -153,6 +153,9 @@ class Context:
 
     transforms: Transforms = field(init=True, default_factory=lambda: Transforms([]))
 
+    # is the value a resolved value
+    is_resolved_value: bool = field(init=True, default=False)
+
     def evolve(self, **kwargs) -> "Context":
         """
         Create a new context without merging together attributes

--- a/src/cfnlint/jsonschema/validators.py
+++ b/src/cfnlint/jsonschema/validators.py
@@ -176,6 +176,11 @@ def create(
                                 r_validator.context.conditions.status,
                                 r_validator.context.ref_values,
                             ):
+                                r_validator = r_validator.evolve(
+                                    context=r_validator.context.evolve(
+                                        is_resolved_value=True,
+                                    )
+                                )
                                 yield r_value, r_validator, r_errs
                         except UnknownSatisfisfaction as err:
                             LOGGER.debug(err)

--- a/src/cfnlint/rules/resources/properties/Type.py
+++ b/src/cfnlint/rules/resources/properties/Type.py
@@ -46,7 +46,9 @@ class Type(CloudFormationLintRule):
                 ):
                     return
 
-        if self.config.get("strict") or validator.context.strict_types:
+        if (
+            self.config.get("strict") or validator.context.strict_types
+        ) and not validator.context.is_resolved_value:
             validator = validator.evolve(
                 context=validator.context.evolve(strict_types=True)
             )

--- a/test/fixtures/results/public/watchmaker.json
+++ b/test/fixtures/results/public/watchmaker.json
@@ -931,41 +931,6 @@
     },
     {
         "Filename": "test/fixtures/templates/public/watchmaker.json",
-        "Id": "c686663b-d84c-9054-d89b-e04373ffff7a",
-        "Level": "Error",
-        "Location": {
-            "End": {
-                "ColumnNumber": 46,
-                "LineNumber": 1374
-            },
-            "Path": [
-                "Resources",
-                "WatchmakerInstance",
-                "Properties",
-                "BlockDeviceMappings",
-                1,
-                "Fn::If",
-                1,
-                "Ebs",
-                "VolumeSize",
-                "Ref"
-            ],
-            "Start": {
-                "ColumnNumber": 41,
-                "LineNumber": 1374
-            }
-        },
-        "Message": "{'Ref': 'AppVolumeSize'} is not of type 'integer' when 'Ref' is resolved",
-        "ParentId": null,
-        "Rule": {
-            "Description": "Making sure the Ref has a String value (no other functions are supported)",
-            "Id": "E1020",
-            "ShortDescription": "Ref validation of value",
-            "Source": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-ref.html"
-        }
-    },
-    {
-        "Filename": "test/fixtures/templates/public/watchmaker.json",
         "Id": "913a07a4-0962-ced6-de7c-a1e4b678ecc9",
         "Level": "Informational",
         "Location": {

--- a/test/unit/module/cfn_yaml/test_yaml.py
+++ b/test/unit/module/cfn_yaml/test_yaml.py
@@ -27,7 +27,7 @@ class TestYamlParse(BaseTestCase):
             },
             "generic_bad": {
                 "filename": "test/fixtures/templates/bad/generic.yaml",
-                "failures": 27,
+                "failures": 32,
             },
         }
 

--- a/test/unit/module/test_rules_collections.py
+++ b/test/unit/module/test_rules_collections.py
@@ -69,7 +69,7 @@ class TestRulesCollection(BaseTestCase):
         filename = "test/fixtures/templates/bad/generic.yaml"
         template = cfnlint.decode.cfn_yaml.load(filename)
         cfn = Template(filename, template, ["us-east-1"])
-        expected_err_count = 30
+        expected_err_count = 35
         matches = []
         matches.extend(self.rules.run(filename, cfn))
         assert (

--- a/test/unit/rules/functions/test_sub.py
+++ b/test/unit/rules/functions/test_sub.py
@@ -290,6 +290,12 @@ def context(cfn):
                     schema_path=deque(["const"]),
                     validator="fn_sub",
                 ),
+                ValidationError(
+                    ("'three' was expected when 'Fn::Sub' is resolved"),
+                    path=deque(["Fn::Sub"]),
+                    schema_path=deque(["const"]),
+                    validator="fn_sub",
+                ),
             ],
         ),
     ],


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Return all errors from resolution
- Add `is_resolved_value` to context to define that the value has been resolved
- Update Type checking to not use strict type validation on resolved values

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
