### PR TITLE
Don't scan DefinitionString in rule E3601

### DIFF
--- a/src/cfnlint/rules/resources/stepfunctions/StateMachineDefinition.py
+++ b/src/cfnlint/rules/resources/stepfunctions/StateMachineDefinition.py
@@ -30,7 +30,8 @@ class StateMachineDefinition(CfnLintJsonSchema):
         super().__init__(
             keywords=[
                 "Resources/AWS::StepFunctions::StateMachine/Properties/Definition",
-                "Resources/AWS::StepFunctions::StateMachine/Properties/DefinitionString",
+                # https://github.com/aws-cloudformation/cfn-lint/issues/3518
+                # Resources/AWS::StepFunctions::StateMachine/Properties/DefinitionString
             ],
             schema_details=SchemaDetails(
                 cfnlint.data.schemas.other.step_functions, "statemachine.json"


### PR DESCRIPTION
*Issue #, if available:*
fix #3518 

*Description of changes:*
- Don't scan DefinitionString in rule E3601

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
