### PR TITLE
AutoMinorVersionUpgrade can be used with Aurora clusters

### DIFF
--- a/src/cfnlint/data/schemas/extensions/aws_rds_dbcluster/aurora.json
+++ b/src/cfnlint/data/schemas/extensions/aws_rds_dbcluster/aurora.json
@@ -16,7 +16,6 @@
  "then": {
   "properties": {
    "AllocatedStorage": false,
-   "AutoMinorVersionUpgrade": false,
    "DBClusterInstanceClass": false,
    "Iops": false,
    "MonitoringInterval": false,


### PR DESCRIPTION
*Issue #, if available:*
fix #3521

*Description of changes:*
- AutoMinorVersionUpgrade can be used with Aurora clusters

[docs](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Aurora.CreateInstance.html#Aurora.CreateInstance.Settings)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
