### PR TITLE
Better error message for Ref AWS::NoValue at Properties

### DIFF
--- a/test/unit/rules/resources/properties/test_properties.py
+++ b/test/unit/rules/resources/properties/test_properties.py
@@ -54,15 +54,15 @@ def rule():
             ],
         ),
         (
-            "Valid type but no required fields",
+            "Invalid with Ref AWS::NoValue",
             {"Type": "MyType", "Properties": {"Ref": "AWS::NoValue"}},
-            [(["us-east-1"], Schema({"typeName": "MyType", "required": ["Name"]}))],
+            [],
             [
                 ValidationError(
-                    "'Name' is a required property",
-                    validator="required",
-                    path=deque(["Properties"]),
-                    schema_path=deque(["required"]),
+                    "{'Ref': 'AWS::NoValue'} is not of type object",
+                    validator="type",
+                    path=deque(["Properties", "Ref"]),
+                    rule=None,
                 )
             ],
         ),


### PR DESCRIPTION
*Issue #, if available:*
#3562 

*Description of changes:*
- Better error message for Ref AWS::NoValue at Properties

No matter what `{'Ref': 'AWS::NoValue'}` can't be directly under Properties.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
