### PR TITLE
GetAtts to array returns a string

### DIFF
--- a/src/cfnlint/rules/functions/GetAtt.py
+++ b/src/cfnlint/rules/functions/GetAtt.py
@@ -12,7 +12,7 @@ import regex as re
 
 from cfnlint.helpers import ensure_list, is_types_compatible
 from cfnlint.jsonschema import ValidationError, ValidationResult, Validator
-from cfnlint.rules.functions._BaseFn import BaseFn, all_types
+from cfnlint.rules.functions._BaseFn import BaseFn
 from cfnlint.schema import PROVIDER_SCHEMA_MANAGER
 
 
@@ -29,7 +29,7 @@ class GetAtt(BaseFn):
     tags = ["functions", "getatt"]
 
     def __init__(self) -> None:
-        super().__init__("Fn::GetAtt", all_types)
+        super().__init__("Fn::GetAtt", ("string", "boolean", "integer", "number"))
 
     def schema(self, validator, instance) -> dict[str, Any]:
         resource_functions = []
@@ -127,6 +127,9 @@ class GetAtt(BaseFn):
                             continue
 
                         schema_types = ensure_list(getatt_schema.get("type"))
+                        if "array" in schema_types:
+                            schema_types.remove("array")
+                            schema_types.append("string")
 
                         types = ensure_list(s.get("type"))
 

--- a/test/unit/rules/functions/test_getatt.py
+++ b/test/unit/rules/functions/test_getatt.py
@@ -134,8 +134,8 @@ class _Fail(CfnLintKeyword):
             [
                 ValidationError(
                     "{'Fn::GetAtt': 'MyBucket.Arn'} is not of type 'array'",
-                    path=deque(["Fn::GetAtt"]),
-                    schema_path=deque(["type"]),
+                    path=deque([]),
+                    schema_path=deque([]),
                     validator="fn_getatt",
                 ),
             ],
@@ -149,8 +149,8 @@ class _Fail(CfnLintKeyword):
             [
                 ValidationError(
                     "{'Fn::GetAtt': 'MyBucket.Arn'} is not of type 'array', 'object'",
-                    path=deque(["Fn::GetAtt"]),
-                    schema_path=deque(["type"]),
+                    path=deque([]),
+                    schema_path=deque([]),
                     validator="fn_getatt",
                 ),
             ],

--- a/test/unit/rules/functions/test_sub.py
+++ b/test/unit/rules/functions/test_sub.py
@@ -274,15 +274,7 @@ def context(cfn):
             "Invalid Fn::Sub with a GetAtt to an array of attributes",
             {"Fn::Sub": "${MySimpleAd.DnsIpAddresses}"},
             {"type": "string"},
-            [
-                ValidationError(
-                    ("'MySimpleAd.DnsIpAddresses' is not of type 'string'"),
-                    instance="MySimpleAd.DnsIpAddresses",
-                    path=deque(["Fn::Sub"]),
-                    schema_path=deque([]),
-                    validator="fn_sub",
-                ),
-            ],
+            [],
         ),
         (
             "Invalid Fn::Sub with a GetAtt to an integer",


### PR DESCRIPTION
*Issue #, if available:*
fix #3635 
*Description of changes:*
- GetAtts to array returns a string

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
