### PR TITLE
Ipv6Address count for NetworkInterface

### DIFF
--- a/scripts/update_schemas_manually.py
+++ b/scripts/update_schemas_manually.py
@@ -728,6 +728,20 @@ patches.extend(
             ],
         ),
         ResourcePatch(
+            resource_type="AWS::EC2::NetworkInterface",
+            patches=[
+                Patch(
+                    values={
+                        "dependentExcluded": {
+                            "Ipv6AddressCount": ["Ipv6Addresses"],
+                            "Ipv6Addresses": ["Ipv6AddressCount"],
+                        },
+                    },
+                    path="/",
+                ),
+            ],
+        ),
+        ResourcePatch(
             resource_type="AWS::EC2::SecurityGroup",
             patches=[
                 Patch(

--- a/scripts/update_snapshot_results.sh
+++ b/scripts/update_snapshot_results.sh
@@ -5,6 +5,7 @@ cfn-lint test/fixtures/templates/integration/dynamic-references.yaml -e -c I --f
 cfn-lint test/fixtures/templates/integration/resources-cloudformation-init.yaml -e -c I --format json > test/fixtures/results/integration/resources-cloudformation-init.json
 cfn-lint test/fixtures/templates/integration/ref-no-value.yaml -e -c I --format json > test/fixtures/results/integration/ref-no-value.json
 cfn-lint test/fixtures/templates/integration/availability-zones.yaml -e -c I --format json > test/fixtures/results/integration/availability-zones.json
+cfn-lint test/fixtures/templates/integration/aws-ec2-networkinterface.yaml -e -c I --format json > test/fixtures/results/integration/aws-ec2-networkinterface.json
 
 # public/
 cfn-lint test/fixtures/templates/public/lambda-poller.yaml -e -c I --format json > test/fixtures/results/public/lambda-poller.json

--- a/src/cfnlint/data/schemas/patches/extensions/all/aws_ec2_networkinterface/manual.json
+++ b/src/cfnlint/data/schemas/patches/extensions/all/aws_ec2_networkinterface/manual.json
@@ -1,0 +1,14 @@
+[
+ {
+  "op": "add",
+  "path": "/dependentExcluded",
+  "value": {
+   "Ipv6AddressCount": [
+    "Ipv6Addresses"
+   ],
+   "Ipv6Addresses": [
+    "Ipv6AddressCount"
+   ]
+  }
+ }
+]

--- a/src/cfnlint/data/schemas/providers/us_east_1/aws-ec2-networkinterface.json
+++ b/src/cfnlint/data/schemas/providers/us_east_1/aws-ec2-networkinterface.json
@@ -96,6 +96,14 @@
    "type": "object"
   }
  },
+ "dependentExcluded": {
+  "Ipv6AddressCount": [
+   "Ipv6Addresses"
+  ],
+  "Ipv6Addresses": [
+   "Ipv6AddressCount"
+  ]
+ },
  "primaryIdentifier": [
   "/properties/Id"
  ],

--- a/test/fixtures/results/integration/aws-ec2-networkinterface.json
+++ b/test/fixtures/results/integration/aws-ec2-networkinterface.json
@@ -1,0 +1,60 @@
+[
+    {
+        "Filename": "test/fixtures/templates/integration/aws-ec2-networkinterface.yaml",
+        "Id": "9d40fd01-0117-1816-b924-0b0c89ee7a5e",
+        "Level": "Error",
+        "Location": {
+            "End": {
+                "ColumnNumber": 20,
+                "LineNumber": 15
+            },
+            "Path": [
+                "Resources",
+                "NetworkInterface",
+                "Properties",
+                "Ipv6Addresses"
+            ],
+            "Start": {
+                "ColumnNumber": 7,
+                "LineNumber": 15
+            }
+        },
+        "Message": "'Ipv6Addresses' should not be included with 'Ipv6AddressCount'",
+        "ParentId": null,
+        "Rule": {
+            "Description": "When certain properties are specified other properties should not be included",
+            "Id": "E3020",
+            "ShortDescription": "Validate that when a property is specified another property should be excluded",
+            "Source": "https://github.com/aws-cloudformation/cfn-lint/blob/main/docs/cfn-schema-specification.md#dependentexcluded"
+        }
+    },
+    {
+        "Filename": "test/fixtures/templates/integration/aws-ec2-networkinterface.yaml",
+        "Id": "e26370d1-ed25-a14c-9a48-7cabc88945ec",
+        "Level": "Error",
+        "Location": {
+            "End": {
+                "ColumnNumber": 23,
+                "LineNumber": 17
+            },
+            "Path": [
+                "Resources",
+                "NetworkInterface",
+                "Properties",
+                "Ipv6AddressCount"
+            ],
+            "Start": {
+                "ColumnNumber": 7,
+                "LineNumber": 17
+            }
+        },
+        "Message": "'Ipv6AddressCount' should not be included with 'Ipv6Addresses'",
+        "ParentId": null,
+        "Rule": {
+            "Description": "When certain properties are specified other properties should not be included",
+            "Id": "E3020",
+            "ShortDescription": "Validate that when a property is specified another property should be excluded",
+            "Source": "https://github.com/aws-cloudformation/cfn-lint/blob/main/docs/cfn-schema-specification.md#dependentexcluded"
+        }
+    }
+]

--- a/test/fixtures/templates/integration/aws-ec2-networkinterface.yaml
+++ b/test/fixtures/templates/integration/aws-ec2-networkinterface.yaml
@@ -1,0 +1,17 @@
+Parameters:
+  SubnetId:
+    Type: AWS::EC2::Subnet::Id
+  SecurityGroupId:
+    Type: AWS::EC2::SecurityGroup::Id
+Resources:
+  NetworkInterface:
+    Type: AWS::EC2::NetworkInterface
+    Properties:
+      Description: "a network interface"
+      GroupSet:
+        - !Ref SecurityGroupId
+      SourceDestCheck: false
+      SubnetId: !Ref SubnetId
+      Ipv6Addresses:
+        - Ipv6Address: abc
+      Ipv6AddressCount: 1

--- a/test/integration/test_integration_templates.py
+++ b/test/integration/test_integration_templates.py
@@ -47,6 +47,15 @@ class TestQuickStartTemplates(BaseCliTestCase):
             ),
             "exit_code": 2,
         },
+        {
+            "filename": (
+                "test/fixtures/templates/integration/aws-ec2-networkinterface.yaml"
+            ),
+            "results_filename": (
+                "test/fixtures/results/integration/aws-ec2-networkinterface.json"
+            ),
+            "exit_code": 2,
+        },
     ]
 
     def test_templates(self):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Ipv6Address count for NetworkInterface


Steps:
1. Update `scripts/update_schemas_manuall.py`
2. Run `scripts/update_schemas_manually.py`
3. Run `cfn-lint --patch-specs` 
4. Create your test template in `test/fixtures/results/integration`
5. Add template to `scripts/update_snapshot_results.sh` and then execute `scripts/update_snapshot_results.sh` to create your test results.  Validate things look good
6. Update `test/integration/test_integration_templates.py` with your test template information

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
