### PR TITLE
Return Symbol instead of None on Fn::Equals logic

### DIFF
--- a/src/cfnlint/conditions/_equals.py
+++ b/src/cfnlint/conditions/_equals.py
@@ -158,7 +158,10 @@ class Equal:
                 return BooleanTrue()
             return BooleanFalse()
 
-        return params.get(self.hash)
+        if self.hash in params:
+            return params.get(self.hash)
+
+        return Symbol(self.hash)
 
     def test(self, scenarios: Mapping[str, str]) -> bool:
         """Do an equals based on the provided scenario"""

--- a/src/cfnlint/conditions/_rule.py
+++ b/src/cfnlint/conditions/_rule.py
@@ -91,7 +91,11 @@ class _Assertions:
         for assertion in self._assertions:
             assertions.append(assertion.build_cnf(params))
 
-        return And(*assertions)
+        try:
+            return And(*assertions)
+        except Exception as e:
+            LOGGER.debug(f"Error building conditions: {e}")
+            return BooleanTrue()
 
     @property
     def equals(self) -> list[Equal]:

--- a/test/unit/module/conditions/test_rules.py
+++ b/test/unit/module/conditions/test_rules.py
@@ -333,6 +333,39 @@ class TestConditionsWithRules(TestCase):
             )
         )
 
+    def test_fn_equals_assertions_ref_never_satisfiable(self):
+        template = decode_str(
+            """
+        Parameters:
+            AccountId:
+                Type: String
+        Rules:
+          Rule1:
+            Assertions:
+            - Assert: !Equals [!Ref AccountId, !Ref AWS::AccountId]
+            - Assert: !Not [!Equals [!Ref AccountId, !Ref AWS::AccountId]]
+        """
+        )[0]
+
+        cfn = Template("", template)
+        self.assertEqual(len(cfn.conditions._conditions), 0)
+        self.assertEqual(len(cfn.conditions._rules), 1)
+
+        self.assertListEqual(
+            [equal.hash for equal in cfn.conditions._rules[0].equals],
+            [
+                "f36e61f3d5bf6cdc6ea2e7f01487af728094a439",
+                "f36e61f3d5bf6cdc6ea2e7f01487af728094a439",
+            ],
+        )
+
+        self.assertFalse(
+            cfn.conditions.satisfiable(
+                {},
+                {},
+            )
+        )
+
 
 class TestAssertion(TestCase):
     def test_assertion_errors(self):

--- a/test/unit/module/conditions/test_rules.py
+++ b/test/unit/module/conditions/test_rules.py
@@ -302,6 +302,37 @@ class TestConditionsWithRules(TestCase):
             )
         )
 
+    def test_fn_equals_assertions_ref_no_data(self):
+        template = decode_str(
+            """
+        Parameters:
+            AccountId:
+                Type: String
+        Rules:
+          Rule1:
+            Assertions:
+            - Assert: !Equals [!Ref AccountId, !Ref AWS::AccountId]
+        """
+        )[0]
+
+        cfn = Template("", template)
+        self.assertEqual(len(cfn.conditions._conditions), 0)
+        self.assertEqual(len(cfn.conditions._rules), 1)
+
+        self.assertListEqual(
+            [equal.hash for equal in cfn.conditions._rules[0].equals],
+            [
+                "f36e61f3d5bf6cdc6ea2e7f01487af728094a439",
+            ],
+        )
+
+        self.assertTrue(
+            cfn.conditions.satisfiable(
+                {},
+                {},
+            )
+        )
+
 
 class TestAssertion(TestCase):
     def test_assertion_errors(self):


### PR DESCRIPTION
*Issue #, if available:*
fix #3662 

*Description of changes:*
- Return Symbol instead of None on Fn::Equals logic
- Try and except on building all assertions

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
