### PR TITLE
move data validation to its own action

### DIFF
--- a/.github/workflows/ci-pr-data.yaml
+++ b/.github/workflows/ci-pr-data.yaml
@@ -1,0 +1,21 @@
+name: "[CI] Test PR Data"
+
+on:
+  pull_request:
+    paths:
+    - "src/cfnlint/data/**"
+
+jobs:
+  data:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install Tox and any other packages
+        run: pip install tox
+      - name: Run Tox
+        run: |
+          tox -e py -- -m "data"

--- a/.github/workflows/ci-pr.yaml
+++ b/.github/workflows/ci-pr.yaml
@@ -40,19 +40,6 @@ jobs:
         with:
           name: pr
           path: pr/
-  data:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-      - name: Install Tox and any other packages
-        run: pip install tox
-      - name: Run Tox
-        run: |
-          tox -e py -- -m "data"
   integration:
     runs-on: ${{ matrix.os }}
     strategy:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Move data validation to its own action
- Only run data validation if a file inside `src/cfnlint/data/**`

The data job can take around 20 minutes to execute.  This separates that job into its own task and runs it as needed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
