### PR TITLE
Cloud9 ImageIds can be an alias

### DIFF
--- a/src/cfnlint/data/schemas/patches/extensions/all/aws_cloud9_environmentec2/format.json
+++ b/src/cfnlint/data/schemas/patches/extensions/all/aws_cloud9_environmentec2/format.json
@@ -1,7 +1,0 @@
-[
- {
-  "op": "add",
-  "path": "/properties/ImageId/format",
-  "value": "AWS::EC2::Image.Id"
- }
-]

--- a/src/cfnlint/data/schemas/providers/cn_north_1/aws-cloud9-environmentec2.json
+++ b/src/cfnlint/data/schemas/providers/cn_north_1/aws-cloud9-environmentec2.json
@@ -63,7 +63,6 @@
    "type": "string"
   },
   "ImageId": {
-   "format": "AWS::EC2::Image.Id",
    "type": "string"
   },
   "InstanceType": {

--- a/src/cfnlint/data/schemas/providers/cn_northwest_1/aws-cloud9-environmentec2.json
+++ b/src/cfnlint/data/schemas/providers/cn_northwest_1/aws-cloud9-environmentec2.json
@@ -63,7 +63,6 @@
    "type": "string"
   },
   "ImageId": {
-   "format": "AWS::EC2::Image.Id",
    "type": "string"
   },
   "InstanceType": {

--- a/src/cfnlint/data/schemas/providers/us_east_1/aws-cloud9-environmentec2.json
+++ b/src/cfnlint/data/schemas/providers/us_east_1/aws-cloud9-environmentec2.json
@@ -63,7 +63,6 @@
    "type": "string"
   },
   "ImageId": {
-   "format": "AWS::EC2::Image.Id",
    "type": "string"
   },
   "InstanceType": {


### PR DESCRIPTION
*Issue #, if available:*
fix #3678 

*Description of changes:*
- Cloud9 ImageIds can be an alias

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
