### PR TITLE
Associate[CarrierIpAddress|PublicIpAddress] not with NetworkInterfaceId

### DIFF
--- a/scripts/update_schemas_manually.py
+++ b/scripts/update_schemas_manually.py
@@ -701,6 +701,19 @@ patches.extend(
                     },
                     path="/",
                 ),
+                Patch(
+                    values={
+                        "dependentExcluded": {
+                            "AssociateCarrierIpAddress": ["NetworkInterfaceId"],
+                            "AssociatePublicIpAddress": ["NetworkInterfaceId"],
+                            "NetworkInterfaceId": [
+                                "AssociateCarrierIpAddress",
+                                "AssociatePublicIpAddress",
+                            ],
+                        }
+                    },
+                    path="/definitions/NetworkInterface",
+                ),
             ],
         ),
         ResourcePatch(
@@ -713,6 +726,19 @@ patches.extend(
                 Patch(
                     values={"pattern": "^ephemeral([0-9]|[1][0-9]|[2][0-3])$"},
                     path="/definitions/BlockDeviceMapping/properties/VirtualName",
+                ),
+                Patch(
+                    values={
+                        "dependentExcluded": {
+                            "AssociateCarrierIpAddress": ["NetworkInterfaceId"],
+                            "AssociatePublicIpAddress": ["NetworkInterfaceId"],
+                            "NetworkInterfaceId": [
+                                "AssociateCarrierIpAddress",
+                                "AssociatePublicIpAddress",
+                            ],
+                        }
+                    },
+                    path="/definitions/NetworkInterface",
                 ),
             ],
         ),

--- a/scripts/update_snapshot_results.sh
+++ b/scripts/update_snapshot_results.sh
@@ -6,6 +6,8 @@ cfn-lint test/fixtures/templates/integration/resources-cloudformation-init.yaml 
 cfn-lint test/fixtures/templates/integration/ref-no-value.yaml -e -c I --format json > test/fixtures/results/integration/ref-no-value.json
 cfn-lint test/fixtures/templates/integration/availability-zones.yaml -e -c I --format json > test/fixtures/results/integration/availability-zones.json
 cfn-lint test/fixtures/templates/integration/aws-ec2-networkinterface.yaml -e -c I --format json > test/fixtures/results/integration/aws-ec2-networkinterface.json
+cfn-lint test/fixtures/templates/integration/aws-ec2-instance.yaml -e -c I --format json > test/fixtures/results/integration/aws-ec2-instance.json
+cfn-lint test/fixtures/templates/integration/aws-ec2-launchtemplate.yaml -e -c I --format json > test/fixtures/results/integration/aws-ec2-launchtemplate.json
 
 # public/
 cfn-lint test/fixtures/templates/public/lambda-poller.yaml -e -c I --format json > test/fixtures/results/public/lambda-poller.json

--- a/src/cfnlint/data/schemas/patches/extensions/all/aws_ec2_instance/manual.json
+++ b/src/cfnlint/data/schemas/patches/extensions/all/aws_ec2_instance/manual.json
@@ -24,5 +24,21 @@
     "NetworkInterfaces"
    ]
   }
+ },
+ {
+  "op": "add",
+  "path": "/definitions/NetworkInterface/dependentExcluded",
+  "value": {
+   "AssociateCarrierIpAddress": [
+    "NetworkInterfaceId"
+   ],
+   "AssociatePublicIpAddress": [
+    "NetworkInterfaceId"
+   ],
+   "NetworkInterfaceId": [
+    "AssociateCarrierIpAddress",
+    "AssociatePublicIpAddress"
+   ]
+  }
  }
 ]

--- a/src/cfnlint/data/schemas/patches/extensions/all/aws_ec2_launchtemplate/manual.json
+++ b/src/cfnlint/data/schemas/patches/extensions/all/aws_ec2_launchtemplate/manual.json
@@ -12,5 +12,21 @@
   "op": "add",
   "path": "/definitions/BlockDeviceMapping/properties/VirtualName/pattern",
   "value": "^ephemeral([0-9]|[1][0-9]|[2][0-3])$"
+ },
+ {
+  "op": "add",
+  "path": "/definitions/NetworkInterface/dependentExcluded",
+  "value": {
+   "AssociateCarrierIpAddress": [
+    "NetworkInterfaceId"
+   ],
+   "AssociatePublicIpAddress": [
+    "NetworkInterfaceId"
+   ],
+   "NetworkInterfaceId": [
+    "AssociateCarrierIpAddress",
+    "AssociatePublicIpAddress"
+   ]
+  }
  }
 ]

--- a/src/cfnlint/data/schemas/providers/ap_southeast_5/aws-ec2-instance.json
+++ b/src/cfnlint/data/schemas/providers/ap_southeast_5/aws-ec2-instance.json
@@ -205,6 +205,18 @@
   },
   "NetworkInterface": {
    "additionalProperties": false,
+   "dependentExcluded": {
+    "AssociateCarrierIpAddress": [
+     "NetworkInterfaceId"
+    ],
+    "AssociatePublicIpAddress": [
+     "NetworkInterfaceId"
+    ],
+    "NetworkInterfaceId": [
+     "AssociateCarrierIpAddress",
+     "AssociatePublicIpAddress"
+    ]
+   },
    "properties": {
     "AssociateCarrierIpAddress": {
      "type": "boolean"

--- a/src/cfnlint/data/schemas/providers/us_east_1/aws-ec2-instance.json
+++ b/src/cfnlint/data/schemas/providers/us_east_1/aws-ec2-instance.json
@@ -195,6 +195,18 @@
   },
   "NetworkInterface": {
    "additionalProperties": false,
+   "dependentExcluded": {
+    "AssociateCarrierIpAddress": [
+     "NetworkInterfaceId"
+    ],
+    "AssociatePublicIpAddress": [
+     "NetworkInterfaceId"
+    ],
+    "NetworkInterfaceId": [
+     "AssociateCarrierIpAddress",
+     "AssociatePublicIpAddress"
+    ]
+   },
    "properties": {
     "AssociateCarrierIpAddress": {
      "type": "boolean"

--- a/src/cfnlint/data/schemas/providers/us_east_1/aws-ec2-launchtemplate.json
+++ b/src/cfnlint/data/schemas/providers/us_east_1/aws-ec2-launchtemplate.json
@@ -637,6 +637,18 @@
   },
   "NetworkInterface": {
    "additionalProperties": false,
+   "dependentExcluded": {
+    "AssociateCarrierIpAddress": [
+     "NetworkInterfaceId"
+    ],
+    "AssociatePublicIpAddress": [
+     "NetworkInterfaceId"
+    ],
+    "NetworkInterfaceId": [
+     "AssociateCarrierIpAddress",
+     "AssociatePublicIpAddress"
+    ]
+   },
    "properties": {
     "AssociateCarrierIpAddress": {
      "type": "boolean"

--- a/test/fixtures/results/integration/aws-ec2-instance.json
+++ b/test/fixtures/results/integration/aws-ec2-instance.json
@@ -1,0 +1,126 @@
+[
+    {
+        "Filename": "test/fixtures/templates/integration/aws-ec2-instance.yaml",
+        "Id": "1a19d9d5-cf14-50d0-d2f5-9ebd5b73a7d4",
+        "Level": "Error",
+        "Location": {
+            "End": {
+                "ColumnNumber": 36,
+                "LineNumber": 14
+            },
+            "Path": [
+                "Resources",
+                "Instance",
+                "Properties",
+                "NetworkInterfaces",
+                0,
+                "AssociateCarrierIpAddress"
+            ],
+            "Start": {
+                "ColumnNumber": 11,
+                "LineNumber": 14
+            }
+        },
+        "Message": "'AssociateCarrierIpAddress' should not be included with 'NetworkInterfaceId'",
+        "ParentId": null,
+        "Rule": {
+            "Description": "When certain properties are specified other properties should not be included",
+            "Id": "E3020",
+            "ShortDescription": "Validate that when a property is specified another property should be excluded",
+            "Source": "https://github.com/aws-cloudformation/cfn-lint/blob/main/docs/cfn-schema-specification.md#dependentexcluded"
+        }
+    },
+    {
+        "Filename": "test/fixtures/templates/integration/aws-ec2-instance.yaml",
+        "Id": "62b86da6-4603-37c5-3087-299f72acc9a2",
+        "Level": "Error",
+        "Location": {
+            "End": {
+                "ColumnNumber": 35,
+                "LineNumber": 15
+            },
+            "Path": [
+                "Resources",
+                "Instance",
+                "Properties",
+                "NetworkInterfaces",
+                0,
+                "AssociatePublicIpAddress"
+            ],
+            "Start": {
+                "ColumnNumber": 11,
+                "LineNumber": 15
+            }
+        },
+        "Message": "'AssociatePublicIpAddress' should not be included with 'NetworkInterfaceId'",
+        "ParentId": null,
+        "Rule": {
+            "Description": "When certain properties are specified other properties should not be included",
+            "Id": "E3020",
+            "ShortDescription": "Validate that when a property is specified another property should be excluded",
+            "Source": "https://github.com/aws-cloudformation/cfn-lint/blob/main/docs/cfn-schema-specification.md#dependentexcluded"
+        }
+    },
+    {
+        "Filename": "test/fixtures/templates/integration/aws-ec2-instance.yaml",
+        "Id": "6cf986c0-5afe-2cdd-5da0-2a411f486e56",
+        "Level": "Error",
+        "Location": {
+            "End": {
+                "ColumnNumber": 29,
+                "LineNumber": 17
+            },
+            "Path": [
+                "Resources",
+                "Instance",
+                "Properties",
+                "NetworkInterfaces",
+                0,
+                "NetworkInterfaceId"
+            ],
+            "Start": {
+                "ColumnNumber": 11,
+                "LineNumber": 17
+            }
+        },
+        "Message": "'NetworkInterfaceId' should not be included with 'AssociateCarrierIpAddress'",
+        "ParentId": null,
+        "Rule": {
+            "Description": "When certain properties are specified other properties should not be included",
+            "Id": "E3020",
+            "ShortDescription": "Validate that when a property is specified another property should be excluded",
+            "Source": "https://github.com/aws-cloudformation/cfn-lint/blob/main/docs/cfn-schema-specification.md#dependentexcluded"
+        }
+    },
+    {
+        "Filename": "test/fixtures/templates/integration/aws-ec2-instance.yaml",
+        "Id": "697ee9aa-160c-152b-5d46-e708ed04b425",
+        "Level": "Error",
+        "Location": {
+            "End": {
+                "ColumnNumber": 29,
+                "LineNumber": 17
+            },
+            "Path": [
+                "Resources",
+                "Instance",
+                "Properties",
+                "NetworkInterfaces",
+                0,
+                "NetworkInterfaceId"
+            ],
+            "Start": {
+                "ColumnNumber": 11,
+                "LineNumber": 17
+            }
+        },
+        "Message": "'NetworkInterfaceId' should not be included with 'AssociatePublicIpAddress'",
+        "ParentId": null,
+        "Rule": {
+            "Description": "When certain properties are specified other properties should not be included",
+            "Id": "E3020",
+            "ShortDescription": "Validate that when a property is specified another property should be excluded",
+            "Source": "https://github.com/aws-cloudformation/cfn-lint/blob/main/docs/cfn-schema-specification.md#dependentexcluded"
+        }
+    }
+]

--- a/test/fixtures/results/integration/aws-ec2-launchtemplate.json
+++ b/test/fixtures/results/integration/aws-ec2-launchtemplate.json
@@ -1,0 +1,163 @@
+[
+    {
+        "Filename": "test/fixtures/templates/integration/aws-ec2-launchtemplate.yaml",
+        "Id": "ea35e0bf-e4b1-de91-1d1e-10315702c6cb",
+        "Level": "Error",
+        "Location": {
+            "End": {
+                "ColumnNumber": 38,
+                "LineNumber": 10
+            },
+            "Path": [
+                "Resources",
+                "LaunchTemplate",
+                "Properties",
+                "LaunchTemplateData",
+                "NetworkInterfaces",
+                0,
+                "AssociateCarrierIpAddress"
+            ],
+            "Start": {
+                "ColumnNumber": 13,
+                "LineNumber": 10
+            }
+        },
+        "Message": "'AssociateCarrierIpAddress' should not be included with 'NetworkInterfaceId'",
+        "ParentId": null,
+        "Rule": {
+            "Description": "When certain properties are specified other properties should not be included",
+            "Id": "E3020",
+            "ShortDescription": "Validate that when a property is specified another property should be excluded",
+            "Source": "https://github.com/aws-cloudformation/cfn-lint/blob/main/docs/cfn-schema-specification.md#dependentexcluded"
+        }
+    },
+    {
+        "Filename": "test/fixtures/templates/integration/aws-ec2-launchtemplate.yaml",
+        "Id": "92bf2a0f-7c2d-e253-dd4a-5ba7f1873b26",
+        "Level": "Error",
+        "Location": {
+            "End": {
+                "ColumnNumber": 37,
+                "LineNumber": 11
+            },
+            "Path": [
+                "Resources",
+                "LaunchTemplate",
+                "Properties",
+                "LaunchTemplateData",
+                "NetworkInterfaces",
+                0,
+                "AssociatePublicIpAddress"
+            ],
+            "Start": {
+                "ColumnNumber": 13,
+                "LineNumber": 11
+            }
+        },
+        "Message": "'AssociatePublicIpAddress' should not be included with 'NetworkInterfaceId'",
+        "ParentId": null,
+        "Rule": {
+            "Description": "When certain properties are specified other properties should not be included",
+            "Id": "E3020",
+            "ShortDescription": "Validate that when a property is specified another property should be excluded",
+            "Source": "https://github.com/aws-cloudformation/cfn-lint/blob/main/docs/cfn-schema-specification.md#dependentexcluded"
+        }
+    },
+    {
+        "Filename": "test/fixtures/templates/integration/aws-ec2-launchtemplate.yaml",
+        "Id": "0dd53a64-75a2-3a75-f805-f2874cb77810",
+        "Level": "Error",
+        "Location": {
+            "End": {
+                "ColumnNumber": 31,
+                "LineNumber": 13
+            },
+            "Path": [
+                "Resources",
+                "LaunchTemplate",
+                "Properties",
+                "LaunchTemplateData",
+                "NetworkInterfaces",
+                0,
+                "NetworkInterfaceId",
+                "Ref"
+            ],
+            "Start": {
+                "ColumnNumber": 13,
+                "LineNumber": 13
+            }
+        },
+        "Message": "'NetworkInterface' is not one of ['LaunchTemplate', 'AWS::AccountId', 'AWS::NoValue', 'AWS::NotificationARNs', 'AWS::Partition', 'AWS::Region', 'AWS::StackId', 'AWS::StackName', 'AWS::URLSuffix']",
+        "ParentId": null,
+        "Rule": {
+            "Description": "Making sure the Ref has a String value (no other functions are supported)",
+            "Id": "E1020",
+            "ShortDescription": "Ref validation of value",
+            "Source": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-ref.html"
+        }
+    },
+    {
+        "Filename": "test/fixtures/templates/integration/aws-ec2-launchtemplate.yaml",
+        "Id": "a658c2f8-dc70-5d71-00fc-8a7cd4d3d753",
+        "Level": "Error",
+        "Location": {
+            "End": {
+                "ColumnNumber": 31,
+                "LineNumber": 13
+            },
+            "Path": [
+                "Resources",
+                "LaunchTemplate",
+                "Properties",
+                "LaunchTemplateData",
+                "NetworkInterfaces",
+                0,
+                "NetworkInterfaceId"
+            ],
+            "Start": {
+                "ColumnNumber": 13,
+                "LineNumber": 13
+            }
+        },
+        "Message": "'NetworkInterfaceId' should not be included with 'AssociateCarrierIpAddress'",
+        "ParentId": null,
+        "Rule": {
+            "Description": "When certain properties are specified other properties should not be included",
+            "Id": "E3020",
+            "ShortDescription": "Validate that when a property is specified another property should be excluded",
+            "Source": "https://github.com/aws-cloudformation/cfn-lint/blob/main/docs/cfn-schema-specification.md#dependentexcluded"
+        }
+    },
+    {
+        "Filename": "test/fixtures/templates/integration/aws-ec2-launchtemplate.yaml",
+        "Id": "d423e594-1cdb-52a2-53f0-ff58e28c36e8",
+        "Level": "Error",
+        "Location": {
+            "End": {
+                "ColumnNumber": 31,
+                "LineNumber": 13
+            },
+            "Path": [
+                "Resources",
+                "LaunchTemplate",
+                "Properties",
+                "LaunchTemplateData",
+                "NetworkInterfaces",
+                0,
+                "NetworkInterfaceId"
+            ],
+            "Start": {
+                "ColumnNumber": 13,
+                "LineNumber": 13
+            }
+        },
+        "Message": "'NetworkInterfaceId' should not be included with 'AssociatePublicIpAddress'",
+        "ParentId": null,
+        "Rule": {
+            "Description": "When certain properties are specified other properties should not be included",
+            "Id": "E3020",
+            "ShortDescription": "Validate that when a property is specified another property should be excluded",
+            "Source": "https://github.com/aws-cloudformation/cfn-lint/blob/main/docs/cfn-schema-specification.md#dependentexcluded"
+        }
+    }
+]

--- a/test/fixtures/templates/integration/aws-ec2-instance.yaml
+++ b/test/fixtures/templates/integration/aws-ec2-instance.yaml
@@ -1,0 +1,20 @@
+Resources:
+  NetworkInterface:
+    Type: AWS::EC2::NetworkInterface
+    Properties:
+      Description: foobar
+      SourceDestCheck: false
+      SubnetId: subnet-abcdefgh
+  Instance:
+    Type: AWS::EC2::Instance
+    Properties:
+      ImageId: ami-abcdefgh
+      InstanceType: t2.micro
+      NetworkInterfaces:
+        - AssociateCarrierIpAddress: true
+          AssociatePublicIpAddress: true
+          DeviceIndex: "0"
+          NetworkInterfaceId: !Ref NetworkInterface
+      Tags:
+        - Key: foo
+          Value: bar

--- a/test/fixtures/templates/integration/aws-ec2-launchtemplate.yaml
+++ b/test/fixtures/templates/integration/aws-ec2-launchtemplate.yaml
@@ -1,0 +1,14 @@
+Resources:
+  LaunchTemplate:
+    Type: AWS::EC2::LaunchTemplate
+    Properties:
+      LaunchTemplateData:
+        ImageId: ami-abcdefgh
+        InstanceType: t2.micro
+        UserData: !Base64 "#!/bin/bash\necho 'Hello World' > /var/www/html/index.html"
+        NetworkInterfaces:
+          - AssociateCarrierIpAddress: true
+            AssociatePublicIpAddress: true
+            DeviceIndex: 0
+            NetworkInterfaceId: !Ref NetworkInterface
+      LaunchTemplateName: MyLaunchTemplate

--- a/test/integration/test_integration_templates.py
+++ b/test/integration/test_integration_templates.py
@@ -56,6 +56,22 @@ class TestQuickStartTemplates(BaseCliTestCase):
             ),
             "exit_code": 2,
         },
+        {
+            "filename": ("test/fixtures/templates/integration/aws-ec2-instance.yaml"),
+            "results_filename": (
+                "test/fixtures/results/integration/aws-ec2-instance.json"
+            ),
+            "exit_code": 2,
+        },
+        {
+            "filename": (
+                "test/fixtures/templates/integration/aws-ec2-launchtemplate.yaml"
+            ),
+            "results_filename": (
+                "test/fixtures/results/integration/aws-ec2-launchtemplate.json"
+            ),
+            "exit_code": 2,
+        },
     ]
 
     def test_templates(self):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Associate[CarrierIpAddress|PublicIpAddress] not with NetworkInterfaceId

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
