### PR TITLE
Add W3693 for aurora cluster properties

### DIFF
--- a/src/cfnlint/data/schemas/extensions/aws_rds_dbcluster/aurora.json
+++ b/src/cfnlint/data/schemas/extensions/aws_rds_dbcluster/aurora.json
@@ -20,9 +20,6 @@
    "Iops": false,
    "MonitoringInterval": false,
    "MonitoringRoleArn": false,
-   "PerformanceInsightsEnabled": false,
-   "PerformanceInsightsKmsKeyId": false,
-   "PerformanceInsightsRetentionPeriod": false,
    "PubliclyAccessible": false,
    "StorageType": {
     "if": {

--- a/src/cfnlint/data/schemas/extensions/aws_rds_dbcluster/aurora_warning.json
+++ b/src/cfnlint/data/schemas/extensions/aws_rds_dbcluster/aurora_warning.json
@@ -7,10 +7,17 @@
         "aurora-postgresql"
        ],
        "type": "string"
-      }
+      },
+      "EngineMode": {
+        "enum": [
+         "serverless"
+        ],
+        "type": "string"
+       }
      },
      "required": [
-      "Engine"
+      "Engine",
+      "EngineMode"
      ]
     },
     "then": {

--- a/src/cfnlint/data/schemas/extensions/aws_rds_dbcluster/aurora_warning.json
+++ b/src/cfnlint/data/schemas/extensions/aws_rds_dbcluster/aurora_warning.json
@@ -1,0 +1,23 @@
+{
+    "if": {
+     "properties": {
+      "Engine": {
+       "enum": [
+        "aurora-mysql",
+        "aurora-postgresql"
+       ],
+       "type": "string"
+      }
+     },
+     "required": [
+      "Engine"
+     ]
+    },
+    "then": {
+     "properties": {
+      "PerformanceInsightsEnabled": false,
+      "PerformanceInsightsKmsKeyId": false,
+      "PerformanceInsightsRetentionPeriod": false
+     }
+    }
+   }

--- a/src/cfnlint/data/schemas/extensions/aws_rds_dbcluster/aurora_warning.json
+++ b/src/cfnlint/data/schemas/extensions/aws_rds_dbcluster/aurora_warning.json
@@ -1,30 +1,30 @@
 {
-    "if": {
-     "properties": {
-      "Engine": {
-       "enum": [
-        "aurora-mysql",
-        "aurora-postgresql"
-       ],
-       "type": "string"
-      },
-      "EngineMode": {
-        "enum": [
-         "serverless"
-        ],
-        "type": "string"
-       }
-     },
-     "required": [
-      "Engine",
-      "EngineMode"
-     ]
-    },
-    "then": {
-     "properties": {
-      "PerformanceInsightsEnabled": false,
-      "PerformanceInsightsKmsKeyId": false,
-      "PerformanceInsightsRetentionPeriod": false
-     }
-    }
+ "if": {
+  "properties": {
+   "Engine": {
+    "enum": [
+     "aurora-mysql",
+     "aurora-postgresql"
+    ],
+    "type": "string"
+   },
+   "EngineMode": {
+    "enum": [
+     "serverless"
+    ],
+    "type": "string"
    }
+  },
+  "required": [
+   "Engine",
+   "EngineMode"
+  ]
+ },
+ "then": {
+  "properties": {
+   "PerformanceInsightsEnabled": false,
+   "PerformanceInsightsKmsKeyId": false,
+   "PerformanceInsightsRetentionPeriod": false
+  }
+ }
+}

--- a/src/cfnlint/rules/resources/rds/DbClusterAuroraWarning.py
+++ b/src/cfnlint/rules/resources/rds/DbClusterAuroraWarning.py
@@ -14,7 +14,7 @@ from cfnlint.rules.jsonschema.CfnLintJsonSchema import CfnLintJsonSchema, Schema
 
 class DbClusterAuroraWarning(CfnLintJsonSchema):
     id = "W3693"
-    shortdesc = "Validate Aurora DB cluster configuration"
+    shortdesc = "Validate Aurora DB cluster configuration for ignored properties"
     description = (
         "When creating an Aurora DB Cluster there are fields that "
         "will allow for successful deployment but are ignored"
@@ -32,9 +32,6 @@ class DbClusterAuroraWarning(CfnLintJsonSchema):
             all_matches=True,
         )
 
-    # DBClusterInstanceClass is required
-    # AllocatedStorage is required
-    # Iops is required
     def validate(
         self, validator: Validator, keywords: Any, instance: Any, schema: dict[str, Any]
     ) -> ValidationResult:

--- a/src/cfnlint/rules/resources/rds/DbClusterAuroraWarning.py
+++ b/src/cfnlint/rules/resources/rds/DbClusterAuroraWarning.py
@@ -1,0 +1,48 @@
+"""
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import cfnlint.data.schemas.extensions.aws_rds_dbcluster
+from cfnlint.jsonschema import ValidationResult, Validator
+from cfnlint.rules.jsonschema.CfnLintJsonSchema import CfnLintJsonSchema, SchemaDetails
+
+
+class DbClusterAuroraWarning(CfnLintJsonSchema):
+    id = "W3693"
+    shortdesc = "Validate Aurora DB cluster configuration"
+    description = (
+        "When creating an Aurora DB Cluster there are fields that "
+        "will allow for successful deployment but are ignored"
+    )
+    tags = ["resources"]
+    source_url = "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-dbcluster.html#cfn-rds-dbcluster-engineversion"
+
+    def __init__(self) -> None:
+        super().__init__(
+            keywords=["Resources/AWS::RDS::DBCluster/Properties"],
+            schema_details=SchemaDetails(
+                module=cfnlint.data.schemas.extensions.aws_rds_dbcluster,
+                filename="aurora_warning.json",
+            ),
+            all_matches=True,
+        )
+
+    # DBClusterInstanceClass is required
+    # AllocatedStorage is required
+    # Iops is required
+    def validate(
+        self, validator: Validator, keywords: Any, instance: Any, schema: dict[str, Any]
+    ) -> ValidationResult:
+        for err in super().validate(validator, keywords, instance, schema):
+            if err.schema is False:
+                err.message = (
+                    "Additional properties are not allowed "
+                    f"{err.path[0]!r} when creating Aurora cluster"
+                )
+
+            yield err

--- a/test/unit/rules/resources/rds/test_db_cluster_aurora_warning.py
+++ b/test/unit/rules/resources/rds/test_db_cluster_aurora_warning.py
@@ -21,14 +21,28 @@ def rule():
     "instance,expected",
     [
         (
+            {"Engine": "aurora-mysql", "EngineMode": "serverless"},
+            [],
+        ),
+        (
             {
                 "Engine": "aurora-mysql",
+                "EngineMode": "provisioned",
+                "PerformanceInsightsEnabled": True,
             },
             [],
         ),
         (
             {
                 "Engine": "aurora-mysql",
+                "PerformanceInsightsEnabled": True,
+            },
+            [],
+        ),
+        (
+            {
+                "Engine": "aurora-mysql",
+                "EngineMode": "serverless",
                 "PerformanceInsightsEnabled": True,
             },
             [

--- a/test/unit/rules/resources/rds/test_db_cluster_aurora_warning.py
+++ b/test/unit/rules/resources/rds/test_db_cluster_aurora_warning.py
@@ -1,0 +1,53 @@
+"""
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+"""
+
+from collections import deque
+
+import pytest
+
+from cfnlint.jsonschema import ValidationError
+from cfnlint.rules.resources.rds.DbClusterAuroraWarning import DbClusterAuroraWarning
+
+
+@pytest.fixture(scope="module")
+def rule():
+    rule = DbClusterAuroraWarning()
+    yield rule
+
+
+@pytest.mark.parametrize(
+    "instance,expected",
+    [
+        (
+            {
+                "Engine": "aurora-mysql",
+            },
+            [],
+        ),
+        (
+            {
+                "Engine": "aurora-mysql",
+                "PerformanceInsightsEnabled": True,
+            },
+            [
+                ValidationError(
+                    (
+                        "Additional properties are not allowed "
+                        "'PerformanceInsightsEnabled' when creating Aurora cluster"
+                    ),
+                    rule=DbClusterAuroraWarning(),
+                    path=deque(["PerformanceInsightsEnabled"]),
+                    validator=None,
+                    schema_path=deque(
+                        ["then", "properties", "PerformanceInsightsEnabled"]
+                    ),
+                ),
+            ],
+        ),
+    ],
+)
+def test_validate(instance, expected, rule, validator):
+    errs = list(rule.validate(validator, "", instance, {}))
+    assert errs == expected, f"Expected {expected} got {errs}"


### PR DESCRIPTION
*Issue #, if available:*
fix #3693 
*Description of changes:*
- Add W3693 for aurora serverless v1 cluster properties
- Move `PerformanceInsightsEnabled`, `PerformanceInsightsKmsKeyId`, `PerformanceInsightsRetentionPeriod` from `E3693` to `W3693`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
