### PR TITLE
Allow for secretsmanager dynamic refs in Parameter defaults

### DIFF
--- a/src/cfnlint/rules/functions/DynamicReferenceSecretsManagerPath.py
+++ b/src/cfnlint/rules/functions/DynamicReferenceSecretsManagerPath.py
@@ -29,6 +29,12 @@ class DynamicReferenceSecretsManagerPath(CloudFormationLintRule):
             ):
                 return
 
+            if (
+                validator.context.path.path[0] == "Parameters"
+                and validator.context.path.path[2] == "Default"
+            ):
+                return
+
         yield ValidationError(
             (
                 f"Dynamic reference {instance!r} to secrets manager can only be "

--- a/test/unit/rules/functions/test_dynamic_reference_secrets_manager_path.py
+++ b/test/unit/rules/functions/test_dynamic_reference_secrets_manager_path.py
@@ -43,6 +43,12 @@ def context(cfn):
             [],
         ),
         (
+            "Valid secrets manager",
+            "{{resolve:secretsmanager:Parameter}}",
+            ["Parameters", "MyParameter", "Default"],
+            [],
+        ),
+        (
             "Short list",
             "{{resolve:secretsmanager:Parameter}}",
             ["Parameters", "MyParameter"],


### PR DESCRIPTION
*Issue #, if available:*
fix #3706 
*Description of changes:*
- Allow for secretsmanager dynamic refs in Parameter defaults

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
