### PR TITLE
Move requireXor to SpotFleetRequestConfigData

### DIFF
--- a/scripts/update_schemas_manually.py
+++ b/scripts/update_schemas_manually.py
@@ -884,7 +884,7 @@ patches.extend(
                     path="/definitions/BlockDeviceMapping/properties/VirtualName",
                 ),
                 Patch(
-                    path="/",
+                    path="/definitions/SpotFleetRequestConfigData",
                     values={
                         "requiredXor": ["LaunchSpecifications", "LaunchTemplateConfigs"]
                     },

--- a/src/cfnlint/data/schemas/patches/extensions/all/aws_ec2_spotfleet/manual.json
+++ b/src/cfnlint/data/schemas/patches/extensions/all/aws_ec2_spotfleet/manual.json
@@ -15,7 +15,7 @@
  },
  {
   "op": "add",
-  "path": "/requiredXor",
+  "path": "/definitions/SpotFleetRequestConfigData/requiredXor",
   "value": [
    "LaunchSpecifications",
    "LaunchTemplateConfigs"

--- a/src/cfnlint/data/schemas/providers/ap_south_2/aws-ec2-spotfleet.json
+++ b/src/cfnlint/data/schemas/providers/ap_south_2/aws-ec2-spotfleet.json
@@ -345,10 +345,6 @@
     "ImageId",
     "InstanceType"
    ],
-   "requiredXor": [
-    "LaunchSpecifications",
-    "LaunchTemplateConfigs"
-   ],
    "type": "object"
   },
   "SpotFleetMonitoring": {

--- a/src/cfnlint/data/schemas/providers/ap_south_2/aws-ec2-spotfleet.json
+++ b/src/cfnlint/data/schemas/providers/ap_south_2/aws-ec2-spotfleet.json
@@ -436,6 +436,10 @@
     "IamFleetRole",
     "TargetCapacity"
    ],
+   "requiredXor": [
+    "LaunchSpecifications",
+    "LaunchTemplateConfigs"
+   ],
    "type": "object"
   },
   "SpotFleetTagSpecification": {

--- a/src/cfnlint/data/schemas/providers/ap_south_2/aws-ec2-spotfleet.json
+++ b/src/cfnlint/data/schemas/providers/ap_south_2/aws-ec2-spotfleet.json
@@ -345,6 +345,10 @@
     "ImageId",
     "InstanceType"
    ],
+   "requiredXor": [
+    "LaunchSpecifications",
+    "LaunchTemplateConfigs"
+   ],
    "type": "object"
   },
   "SpotFleetMonitoring": {
@@ -535,10 +539,6 @@
  ],
  "required": [
   "SpotFleetRequestConfigData"
- ],
- "requiredXor": [
-  "LaunchSpecifications",
-  "LaunchTemplateConfigs"
  ],
  "typeName": "AWS::EC2::SpotFleet"
 }

--- a/src/cfnlint/data/schemas/providers/ap_southeast_4/aws-ec2-spotfleet.json
+++ b/src/cfnlint/data/schemas/providers/ap_southeast_4/aws-ec2-spotfleet.json
@@ -428,6 +428,10 @@
      "type": "string"
     }
    },
+   "requiredXor": [
+    "LaunchSpecifications",
+    "LaunchTemplateConfigs"
+   ],
    "required": [
     "IamFleetRole",
     "TargetCapacity"
@@ -535,10 +539,6 @@
  ],
  "required": [
   "SpotFleetRequestConfigData"
- ],
- "requiredXor": [
-  "LaunchSpecifications",
-  "LaunchTemplateConfigs"
  ],
  "typeName": "AWS::EC2::SpotFleet"
 }

--- a/src/cfnlint/data/schemas/providers/ap_southeast_4/aws-ec2-spotfleet.json
+++ b/src/cfnlint/data/schemas/providers/ap_southeast_4/aws-ec2-spotfleet.json
@@ -428,13 +428,13 @@
      "type": "string"
     }
    },
-   "requiredXor": [
-    "LaunchSpecifications",
-    "LaunchTemplateConfigs"
-   ],
    "required": [
     "IamFleetRole",
     "TargetCapacity"
+   ],
+   "requiredXor": [
+    "LaunchSpecifications",
+    "LaunchTemplateConfigs"
    ],
    "type": "object"
   },

--- a/src/cfnlint/data/schemas/providers/il_central_1/aws-ec2-spotfleet.json
+++ b/src/cfnlint/data/schemas/providers/il_central_1/aws-ec2-spotfleet.json
@@ -345,10 +345,6 @@
     "ImageId",
     "InstanceType"
    ],
-   "requiredXor": [
-    "LaunchSpecifications",
-    "LaunchTemplateConfigs"
-   ],
    "type": "object"
   },
   "SpotFleetMonitoring": {

--- a/src/cfnlint/data/schemas/providers/il_central_1/aws-ec2-spotfleet.json
+++ b/src/cfnlint/data/schemas/providers/il_central_1/aws-ec2-spotfleet.json
@@ -436,6 +436,10 @@
     "IamFleetRole",
     "TargetCapacity"
    ],
+   "requiredXor": [
+    "LaunchSpecifications",
+    "LaunchTemplateConfigs"
+   ],
    "type": "object"
   },
   "SpotFleetTagSpecification": {

--- a/src/cfnlint/data/schemas/providers/il_central_1/aws-ec2-spotfleet.json
+++ b/src/cfnlint/data/schemas/providers/il_central_1/aws-ec2-spotfleet.json
@@ -345,6 +345,10 @@
     "ImageId",
     "InstanceType"
    ],
+   "requiredXor": [
+    "LaunchSpecifications",
+    "LaunchTemplateConfigs"
+   ],
    "type": "object"
   },
   "SpotFleetMonitoring": {
@@ -535,10 +539,6 @@
  ],
  "required": [
   "SpotFleetRequestConfigData"
- ],
- "requiredXor": [
-  "LaunchSpecifications",
-  "LaunchTemplateConfigs"
  ],
  "typeName": "AWS::EC2::SpotFleet"
 }

--- a/src/cfnlint/data/schemas/providers/us_east_1/aws-ec2-spotfleet.json
+++ b/src/cfnlint/data/schemas/providers/us_east_1/aws-ec2-spotfleet.json
@@ -764,6 +764,10 @@
     "IamFleetRole",
     "TargetCapacity"
    ],
+   "requiredXor": [
+    "LaunchSpecifications",
+    "LaunchTemplateConfigs"
+   ],
    "type": "object"
   },
   "SpotFleetTagSpecification": {
@@ -945,10 +949,6 @@
  ],
  "required": [
   "SpotFleetRequestConfigData"
- ],
- "requiredXor": [
-  "LaunchSpecifications",
-  "LaunchTemplateConfigs"
  ],
  "typeName": "AWS::EC2::SpotFleet",
  "writeOnlyProperties": [


### PR DESCRIPTION
Fixes an issue with E3014 when checking `AWS::EC2:SpotFleet` resources. The original requireXor field had the correct fields but was placed at the root level of the resource instead of on the relevant definition.

*Issue #, if available:*

*Description of changes:*
- Moves the `requireXor` field to the correct place, resolving an issue where E3014 was looking for fields at the wrong layer of the resource definition.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
