### PR TITLE
Dynamically determine Account ID during transform

### DIFF
--- a/src/cfnlint/template/transforms/_language_extensions.py
+++ b/src/cfnlint/template/transforms/_language_extensions.py
@@ -373,10 +373,11 @@ class _ForEachValueFnFindInMap(_ForEachValue):
                     for k, v in mapping.items():
                         if isinstance(v, dict):
                             if t_map[2].value(cfn, params, only_params) in v:
+                                if isinstance(t_map[1], _ForEachValueRef):
+                                    if t_map[1]._ref._value == "AWS::AccountId":
+                                        global _ACCOUNT_ID
+                                        _ACCOUNT_ID = k
                                 t_map[1] = _ForEachValue.create(k)
-                                if t_map[1].value == {"Ref": "AWS::AccountId"}:
-                                    global _ACCOUNT_ID
-                                    _ACCOUNT_ID = k
                                 break
                 except _ResolveError:
                     pass

--- a/src/cfnlint/template/transforms/_language_extensions.py
+++ b/src/cfnlint/template/transforms/_language_extensions.py
@@ -28,6 +28,8 @@ _N = 7
 
 _SCALAR_TYPES = (str, int, float, bool)
 
+_ACCOUNT_ID = None
+
 
 class _ResolveError(Exception):
     def __init__(self, message: str, key: Any) -> None:
@@ -372,6 +374,10 @@ class _ForEachValueFnFindInMap(_ForEachValue):
                         if isinstance(v, dict):
                             if t_map[2].value(cfn, params, only_params) in v:
                                 t_map[1] = _ForEachValue.create(k)
+                                if t_map[1].value == {"Ref": "AWS::AccountId"}:
+                                    global _ACCOUNT_ID
+                                    _ACCOUNT_ID = k
+                                break
                 except _ResolveError:
                     pass
 
@@ -439,7 +445,9 @@ class _ForEachValueRef(_ForEachValue):
             return region
 
         if v == "AWS::AccountId":
-            return account_id
+            if _ACCOUNT_ID is None:
+                raise _ResolveError("Can't resolve Fn::Ref", self._obj)
+            return _ACCOUNT_ID
 
         if v == "AWS::NotificationARNs":
             return [f"arn:{partition}:sns:{region}:{account_id}:notification"]

--- a/test/unit/module/template/transforms/test_language_extensions.py
+++ b/test/unit/module/template/transforms/test_language_extensions.py
@@ -6,6 +6,7 @@ SPDX-License-Identifier: MIT-0
 from copy import deepcopy
 from unittest import TestCase, mock
 
+import cfnlint.template.transforms._language_extensions
 from cfnlint.decode import convert_dict
 from cfnlint.template import Template
 from cfnlint.template.transforms._language_extensions import (
@@ -364,6 +365,31 @@ class TestFindInMap(TestCase):
         )
         with self.assertRaises(_ResolveError):
             fe.value(self.cfn)
+
+    def test_account_id(self):
+
+        cfnlint.template.transforms._language_extensions._ACCOUNT_ID = None
+
+        with mock.patch(
+            "cfnlint.template.transforms._language_extensions._ACCOUNT_ID", None
+        ):
+            self.assertIsNone(
+                cfnlint.template.transforms._language_extensions._ACCOUNT_ID
+            )
+            fe = _ForEachValueFnFindInMap(
+                "a",
+                [
+                    "Bucket",
+                    {"Ref": "AWS::AccountId"},
+                    "Names",
+                ],
+            )
+            self.assertListEqual(fe.value(self.cfn), ["foo", "bar"])
+
+            self.assertEqual(
+                cfnlint.template.transforms._language_extensions._ACCOUNT_ID,
+                "Production",
+            )
 
 
 class TestTransform(TestCase):

--- a/test/unit/module/template/transforms/test_language_extensions.py
+++ b/test/unit/module/template/transforms/test_language_extensions.py
@@ -4,7 +4,7 @@ SPDX-License-Identifier: MIT-0
 """
 
 from copy import deepcopy
-from unittest import TestCase
+from unittest import TestCase, mock
 
 from cfnlint.decode import convert_dict
 from cfnlint.template import Template
@@ -124,6 +124,13 @@ class TestRef(TestCase):
         fe = _ForEachValue.create({"Ref": "AWS::AccountId"})
         with self.assertRaises(_ResolveError):
             fe.value(self.cfn)
+
+        with mock.patch(
+            "cfnlint.template.transforms._language_extensions._ACCOUNT_ID",
+            "123456789012",
+        ):
+            fe = _ForEachValue.create({"Ref": "AWS::AccountId"})
+            self.assertEqual(fe.value(self.cfn), "123456789012")
 
         fe = _ForEachValue.create({"Ref": "AWS::NotificationARNs"})
         self.assertListEqual(


### PR DESCRIPTION
*Issue #, if available:*
fix #3747 
*Description of changes:*
- Dynamically determine Account ID during transform

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
