### PR TITLE
Update HealthCheckType enum for AWS::AutoScaling::AutoScalingGroup

### DIFF
--- a/src/cfnlint/data/schemas/patches/extensions/all/aws_autoscaling_autoscalinggroup/manual.json
+++ b/src/cfnlint/data/schemas/patches/extensions/all/aws_autoscaling_autoscalinggroup/manual.json
@@ -3,8 +3,10 @@
   "op": "add",
   "path": "/properties/HealthCheckType/enum",
   "value": [
+   "EBS",
    "EC2",
-   "ELB"
+   "ELB",
+   "VPC_LATTICE"
   ]
  },
  {

--- a/src/cfnlint/data/schemas/providers/us_east_1/aws-autoscaling-autoscalinggroup.json
+++ b/src/cfnlint/data/schemas/providers/us_east_1/aws-autoscaling-autoscalinggroup.json
@@ -501,8 +501,10 @@
   },
   "HealthCheckType": {
    "enum": [
+    "EBS",
     "EC2",
-    "ELB"
+    "ELB",
+    "VPC_LATTICE"
    ],
    "type": "string"
   },


### PR DESCRIPTION
*Issue #, if available:*
fix #3754 

*Description of changes:*
- Update HealthCheckType enum for AWS::AutoScaling::AutoScalingGroup

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
