### PR TITLE
Skip state machine validation when using a function

### DIFF
--- a/src/cfnlint/rules/resources/stepfunctions/StateMachineDefinition.py
+++ b/src/cfnlint/rules/resources/stepfunctions/StateMachineDefinition.py
@@ -11,6 +11,7 @@ from typing import Any
 import cfnlint.data.schemas.other.resources
 import cfnlint.data.schemas.other.step_functions
 import cfnlint.helpers
+from cfnlint.helpers import is_function
 from cfnlint.jsonschema import ValidationError, ValidationResult, Validator
 from cfnlint.rules.jsonschema.CfnLintJsonSchema import CfnLintJsonSchema, SchemaDetails
 from cfnlint.schema.resolver import RefResolver
@@ -64,6 +65,9 @@ class StateMachineDefinition(CfnLintJsonSchema):
         # so we can run this now
         for k in definition_keys:
             value = instance.get(k)
+            fn_name, _ = is_function(value)
+            if fn_name:
+                continue
             if not value:
                 continue
 

--- a/test/unit/rules/resources/stepfunctions/test_state_machine_definition.py
+++ b/test/unit/rules/resources/stepfunctions/test_state_machine_definition.py
@@ -689,6 +689,11 @@ def rule():
                 ),
             ],
         ),
+        (
+            "Using a function",
+            {"Definition": {"Fn::Join": ["\n", []]}},
+            [],
+        ),
     ],
 )
 def test_validate(


### PR DESCRIPTION
*Issue #, if available:*
fix #3769 
*Description of changes:*
- skip validation of E3601 when using a function for the definition

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
