### PR TITLE
Fix validating min/maxLength with array types

### DIFF
--- a/src/cfnlint/rules/resources/properties/StringLength.py
+++ b/src/cfnlint/rules/resources/properties/StringLength.py
@@ -9,7 +9,7 @@ from typing import Any
 
 import regex as re
 
-from cfnlint.helpers import FUNCTIONS
+from cfnlint.helpers import FUNCTIONS, ensure_list, is_function
 from cfnlint.jsonschema import ValidationError
 from cfnlint.rules import CloudFormationLintRule
 
@@ -80,8 +80,8 @@ class StringLength(CloudFormationLintRule):
             return
         # there are scenarios where Fn::Sub may not predictable so use
         # best judgement
-        if validator.is_type(instance, "object") and len(instance) == 1:
-            key = list(instance.keys())[0]
+        key, value = is_function(instance)
+        if key is not None:
             if key == "Fn::Sub":
                 value = instance[key]
                 if isinstance(value, str):
@@ -93,7 +93,7 @@ class StringLength(CloudFormationLintRule):
                         validator, mL, self._fix_sub_string(value[0]), schema
                     )
                 return
-        if schema.get("type") == "object":
+        if "object" in ensure_list(schema.get("type")):
             yield from self._non_string_max_length(instance, mL)
 
     # pylint: disable=unused-argument, arguments-renamed
@@ -105,8 +105,8 @@ class StringLength(CloudFormationLintRule):
 
         # there are scenarios where Fn::Sub may not predictable so use
         # best judgement
-        if validator.is_type(instance, "object") and len(instance) == 1:
-            key = list(instance.keys())[0]
+        key, value = is_function(instance)
+        if key is not None:
             if key == "Fn::Sub":
                 value = instance[key]
                 if isinstance(value, str):
@@ -118,5 +118,6 @@ class StringLength(CloudFormationLintRule):
                         validator, mL, self._fix_sub_string(value[0]), schema
                     )
                 return
-        if schema.get("type") == "object":
+
+        if "object" in ensure_list(schema.get("type")):
             yield from self._non_string_min_length(instance, mL)

--- a/test/unit/rules/resources/properties/test_string_length.py
+++ b/test/unit/rules/resources/properties/test_string_length.py
@@ -37,6 +37,12 @@ def rule():
         ({"foo": 1, "bar": {"Fn::Sub": "2"}}, 20, {"type": "object"}, 1),
         ({"foo": 1, "bar": {"Fn::Sub": ["2", {}]}}, 10, {"type": "object"}, 0),
         ({"foo": 1, "bar": {"Fn::Sub": ["2", {}]}}, 20, {"type": "object"}, 1),
+        (
+            {"foo": 1, "bar": {"Fn::Sub": ["2", {}]}},
+            20,
+            {"type": ["string", "object"]},
+            1,
+        ),
     ],
 )
 def test_min_length(instance, mL, expected, rule, schema, validator):
@@ -65,6 +71,12 @@ def test_min_length(instance, mL, expected, rule, schema, validator):
         ({"foo": 1, "bar": {"Fn::Sub": "2"}}, 4, {"type": "object"}, 1),
         ({"foo": 1, "bar": {"Fn::Sub": ["2", {}]}}, 20, {"type": "object"}, 0),
         ({"foo": 1, "bar": {"Fn::Sub": ["2", {}]}}, 4, {"type": "object"}, 1),
+        (
+            {"foo": 1, "bar": {"Fn::Sub": ["2", {}]}},
+            4,
+            {"type": ["string", "object"]},
+            1,
+        ),
     ],
 )
 def test_max_length(instance, mL, expected, rule, schema, validator):


### PR DESCRIPTION
*Issue #, if available:*
fix #3804 
*Description of changes:*
- Fix validating min/maxLength with array types

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
