### PR TITLE
Allow cloudfront to be used in ARNs for accountId

### DIFF
--- a/src/cfnlint/rules/resources/HardCodedArnProperties.py
+++ b/src/cfnlint/rules/resources/HardCodedArnProperties.py
@@ -125,10 +125,11 @@ class HardCodedArnProperties(CloudFormationLintRule):
             if self.config["accountId"] and not re.match(
                 r"^\$\{\w+}|\$\{AWS::AccountId}|aws|lambda|$", candidate[2]
             ):
-                message = (
-                    "ARN in Resource {0} contains hardcoded AccountId in ARN or"
-                    " incorrectly placed Pseudo Parameters"
-                )
-                matches.append(RuleMatch(path, message.format(path[1])))
+                if candidate[2] not in ["cloudfront"]:
+                    message = (
+                        "ARN in Resource {0} contains hardcoded AccountId in ARN or"
+                        " incorrectly placed Pseudo Parameters"
+                    )
+                    matches.append(RuleMatch(path, message.format(path[1])))
 
         return matches

--- a/test/fixtures/templates/good/resources/properties/hard_coded_arn_properties.yaml
+++ b/test/fixtures/templates/good/resources/properties/hard_coded_arn_properties.yaml
@@ -14,3 +14,15 @@ Resources:
       TemplateURL: !Sub https://s3_bucket_name.s3.${AWS::Region}.amazonaws.com/template.yaml
       Parameters:
         AuthorizerUri: !Sub arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:FunctionName/invocations
+  Bucket:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: bucket
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !Sub arn:${AWS::Partition}:iam::cloudfront:user/CloudFront Origin Access Identity E15MNIMTCFKK4C
+            Action: s3:GetObject
+            Resource: arn:aws:s3:::bucket/*

--- a/test/unit/rules/resources/test_hardcodedarnproperties.py
+++ b/test/unit/rules/resources/test_hardcodedarnproperties.py
@@ -28,6 +28,26 @@ class TestHardCodedArnProperties(BaseRuleTestCase):
         # By default, a set of "correct" templates are checked
         self.helper_file_positive()
 
+    def test_file_positive_with_config(self):
+        self.helper_file_negative(
+            "test/fixtures/templates/good/resources/properties/hard_coded_arn_properties.yaml",
+            0,
+            ConfigMixIn(
+                [],
+                include_experimental=True,
+                include_checks=[
+                    "I",
+                ],
+                configure_rules={
+                    "I3042": {
+                        "partition": True,
+                        "region": True,
+                        "accountId": True,
+                    }
+                },
+            ),
+        )
+
     def test_file_negative_partition(self):
         self.helper_file_negative(
             "test/fixtures/templates/bad/hard_coded_arn_properties.yaml",


### PR DESCRIPTION
*Issue #, if available:*
fix #3819 
*Description of changes:*
- Allow cloudfront to be used in ARNs for accountId

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
