### PR TITLE
Update equals is useful for always false

### DIFF
--- a/src/cfnlint/rules/conditions/EqualsIsUseful.py
+++ b/src/cfnlint/rules/conditions/EqualsIsUseful.py
@@ -50,8 +50,16 @@ class EqualsIsUseful(CloudFormationLintRule):
                 first = "true" if first else "false"
             if str(first) == str(second):
                 yield ValidationError(
-                    f"{instance!r} will always return {True!r} or {False!r}",
+                    f"{instance!r} will always return {True!r}",
                     rule=self,
                 )
+            if isinstance(instance[0], (str, float, int, bool)) and isinstance(
+                instance[1], (str, float, int, bool)
+            ):
+                if str(first) != str(second):
+                    yield ValidationError(
+                        f"{instance!r} will always return {False!r}",
+                        rule=self,
+                    )
         except:  # noqa: E722
             pass

--- a/test/unit/rules/conditions/test_equals_is_useful.py
+++ b/test/unit/rules/conditions/test_equals_is_useful.py
@@ -15,10 +15,12 @@ from cfnlint.rules.conditions.EqualsIsUseful import EqualsIsUseful
         ("Equal string and integer", [1, "1"], 1),
         ("Equal string and boolean", [True, "true"], 1),
         ("Equal string and number", [1.0, "1.0"], 1),
-        ("Not equal string and integer", [1, "1.1"], 0),
-        ("Not equal string and boolean", [True, "True"], 0),
+        ("Not equal string and integer", [1, "1.1"], 1),
+        ("Not equal string and boolean", [True, "True"], 1),
         ("No error on bad type", {"true": True}, 0),
         ("No error on bad length", ["a", "a", "a"], 0),
+        ("No with string and account id", ["A", {"Ref": "AWS::AccountId"}], 0),
+        ("No with string and account id", [{"Ref": "AWS::AccountId"}, "A"], 0),
     ],
 )
 def test_names(name, instance, num_of_errors):
@@ -26,4 +28,4 @@ def test_names(name, instance, num_of_errors):
     validator = CfnTemplateValidator({})
     assert (
         len(list(rule.equals_is_useful(validator, {}, instance, {}))) == num_of_errors
-    ), f"Expected {num_of_errors} errors for {name}"
+    ), f"Expected {num_of_errors} errors for {name} and {instance}"


### PR DESCRIPTION
*Issue #, if available:*
fix #3846 
*Description of changes:*
- Update equals is useful for always false

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
