### PR TITLE
Switch back to raising bad path errors

### DIFF
--- a/src/cfnlint/config.py
+++ b/src/cfnlint/config.py
@@ -796,10 +796,10 @@ class ConfigMixIn(TemplateArgs, CliArgs, ConfigFileArgs):
         for filename in filenames:
             add_filenames = glob.glob(filename, recursive=True)
 
-            if isinstance(add_filenames, list):
+            if add_filenames:
                 all_filenames.extend(add_filenames)
             else:
-                LOGGER.error(f"{filename} could not be processed by glob.glob")
+                raise ValueError(f"{filename} could not be processed by glob.glob")
 
         return sorted(list(map(str, map(Path, all_filenames))))
 

--- a/src/cfnlint/config.py
+++ b/src/cfnlint/config.py
@@ -796,10 +796,10 @@ class ConfigMixIn(TemplateArgs, CliArgs, ConfigFileArgs):
         for filename in filenames:
             add_filenames = glob.glob(filename, recursive=True)
 
-            if add_filenames:
-                all_filenames.extend(add_filenames)
-            else:
+            if not add_filenames and not self.ignore_bad_template:
                 raise ValueError(f"{filename} could not be processed by glob.glob")
+
+            all_filenames.extend(add_filenames)
 
         return sorted(list(map(str, map(Path, all_filenames))))
 

--- a/src/cfnlint/data/CfnLintCli/config/schema.json
+++ b/src/cfnlint/data/CfnLintCli/config/schema.json
@@ -58,16 +58,16 @@
    "description": "custom rule file to use",
    "type": "string"
   },
+  "ignore_bad_template": {
+   "description": "Ignore bad templates",
+   "type": "boolean"
+  },
   "ignore_checks": {
    "description": "List of checks to ignore",
    "items": {
     "type": "string"
    },
    "type": "array"
-  },
-  "ignore_bad_template": {
-   "description": "Ignore bad templates",
-   "type": "boolean"
   },
   "ignore_templates": {
    "description": "Templates to ignore",

--- a/src/cfnlint/data/CfnLintCli/config/schema.json
+++ b/src/cfnlint/data/CfnLintCli/config/schema.json
@@ -65,6 +65,10 @@
    },
    "type": "array"
   },
+  "ignore_bad_template": {
+   "description": "Ignore bad templates",
+   "type": "boolean"
+  },
   "ignore_templates": {
    "description": "Templates to ignore",
    "items": {

--- a/src/cfnlint/rules/errors/__init__.py
+++ b/src/cfnlint/rules/errors/__init__.py
@@ -3,6 +3,7 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 
+from cfnlint.rules.errors.config import ConfigError
 from cfnlint.rules.errors.parse import ParseError
 from cfnlint.rules.errors.rule import RuleError
 from cfnlint.rules.errors.transform import TransformError

--- a/src/cfnlint/rules/errors/config.py
+++ b/src/cfnlint/rules/errors/config.py
@@ -1,0 +1,15 @@
+"""
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+"""
+
+from cfnlint.rules._rule import CloudFormationLintRule
+
+
+class ConfigError(CloudFormationLintRule):
+
+    id = "E0003"
+    shortdesc = "Error with cfn-lint configuration"
+    description = "Error as a result of the cfn-lint configuration"
+    source_url = "https://github.com/aws-cloudformation/cfn-lint"
+    tags = ["base", "rule"]

--- a/src/cfnlint/runner.py
+++ b/src/cfnlint/runner.py
@@ -230,7 +230,6 @@ class Runner:
             self.config.templates
         except ValueError as e:
             self._cli_output([Match(str(e), ConfigError(), None)])
-            sys.exit(1)
         # load registry schemas before patching
         if self.config.registry_schemas:
             for path in self.config.registry_schemas:

--- a/src/cfnlint/runner.py
+++ b/src/cfnlint/runner.py
@@ -17,7 +17,7 @@ from cfnlint.config import ConfigMixIn, configure_logging
 from cfnlint.decode.decode import decode
 from cfnlint.helpers import REGIONS
 from cfnlint.rules import Match, Rules
-from cfnlint.rules.errors import ParseError, TransformError
+from cfnlint.rules.errors import ConfigError, ParseError, TransformError
 from cfnlint.schema import PROVIDER_SCHEMA_MANAGER
 from cfnlint.template.template import Template
 
@@ -223,10 +223,14 @@ class Runner:
                 settings for the template scan.
         """
         self.config = config
-        self.config.templates
         self.formatter = get_formatter(self.config)
         self.rules: Rules = Rules()
         self._get_rules()
+        try:
+            self.config.templates
+        except ValueError as e:
+            self._cli_output([Match(str(e), ConfigError(), None)])
+            sys.exit(1)
         # load registry schemas before patching
         if self.config.registry_schemas:
             for path in self.config.registry_schemas:

--- a/test/unit/module/config/test_config_mixin.py
+++ b/test/unit/module/config/test_config_mixin.py
@@ -208,6 +208,20 @@ class TestConfigMixIn(BaseTestCase):
         ]
         config = cfnlint.config.ConfigMixIn([])
 
+        with self.assertRaises(ValueError):
+            self.assertEqual(len(config.templates), 1)
+
+    @patch("cfnlint.config.ConfigFileArgs._read_config", create=True)
+    def test_config_expand_paths_nomatch_ignore_bad_template(self, yaml_mock):
+        """Test precedence in"""
+
+        filename = "test/fixtures/templates/nonexistant/*.yaml"
+        yaml_mock.side_effect = [
+            {"templates": [filename], "ignore_bad_template": True},
+            {},
+        ]
+        config = cfnlint.config.ConfigMixIn([])
+
         # test defaults
         self.assertEqual(config.templates, [])
 

--- a/test/unit/module/maintenance/test_update_documentation.py
+++ b/test/unit/module/maintenance/test_update_documentation.py
@@ -77,6 +77,14 @@ Regular Text
                     " [Source](https://github.com/aws-cloudformation/cfn-lint) |"
                     " `base`,`rule` |\n"
                 ),
+                call(
+                    '| [E0003<a name="E0003"></a>]'
+                    "(../src/cfnlint/rules/errors/config.py) | "
+                    "Error with cfn-lint configuration | "
+                    "Error as a result of the cfn-lint configuration |  | "
+                    "[Source](https://github.com/aws-cloudformation/cfn-lint) "
+                    "| `base`,`rule` |\n"
+                ),
                 call("\n\\* experimental rules\n"),
             ]
             mock_builtin_open.return_value.write.assert_has_calls(expected_calls)

--- a/test/unit/module/runner/test_runner.py
+++ b/test/unit/module/runner/test_runner.py
@@ -3,6 +3,7 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 
+from io import StringIO
 from unittest.mock import patch
 
 import pytest
@@ -93,3 +94,18 @@ def test_init_schemas(name, registry_path, patch_path, expected):
 
     PROVIDER_SCHEMA_MANAGER._registry_schemas = {}
     PROVIDER_SCHEMA_MANAGER.reset()
+
+
+def test_no_templates():
+    params = ["--template", "does-not-exist.yaml"]
+
+    config = ConfigMixIn(params)
+    with patch("sys.exit") as exit:
+        with patch("sys.stdout", new=StringIO()) as out:
+            exit.assert_not_called()
+            Runner(config)
+            assert out.getvalue().strip() == (
+                "E0003 does-not-exist.yaml could not "
+                "be processed by glob.glob\nNone:1:1"
+            )
+            exit.assert_called_once_with(2)


### PR DESCRIPTION
*Issue #, if available:*
fix #3827 

*Description of changes:*
- Switch back to raising bad bath errors
- in pr #3603 we stopped failing if a template file was not found. This brings back that functionality but additionally allows a person to use the parameter `ignore_bad_templates` that will ignore if the path is bad.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
