### PR TITLE
Dont guess at mappings when values are static

### DIFF
--- a/src/cfnlint/template/transforms/_language_extensions.py
+++ b/src/cfnlint/template/transforms/_language_extensions.py
@@ -403,11 +403,14 @@ class _ForEachValueFnFindInMap(_ForEachValue):
                     return self._map[3].value(cfn, params, only_params)
                 # no default value and map 1 exists
                 try:
-                    for _, v in mapping.get(
-                        t_map[1].value(cfn, params, only_params), {}
-                    ).items():
-                        if isinstance(v, list):
-                            return v
+                    if isinstance(
+                        t_map[2], (_ForEachValueRef, _ForEachValueFnFindInMap)
+                    ):
+                        for _, v in mapping.get(
+                            t_map[1].value(cfn, params, only_params), {}
+                        ).items():
+                            if isinstance(v, list):
+                                return v
                 except _ResolveError:
                     pass
                 raise _ResolveError("Can't resolve Fn::FindInMap", self._obj) from e

--- a/test/unit/module/template/transforms/test_language_extensions.py
+++ b/test/unit/module/template/transforms/test_language_extensions.py
@@ -305,7 +305,14 @@ class TestFindInMap(TestCase):
         )
 
         self.assertEqual(map.value(self.cfn, None, False, True), "bar")
-        self.assertEqual(map.value(self.cfn, None, False, False), ["foo", "bar"])
+        with self.assertRaises(_ResolveError):
+            map.value(self.cfn, None, False, False)
+
+    def test_find_in_map_values_strings_without_default(self):
+        map = _ForEachValueFnFindInMap("a", ["Bucket", "Production", "DNE"])
+
+        with self.assertRaises(_ResolveError):
+            map.value(self.cfn, None, False, True)
 
     def test_find_in_map_values_without_default(self):
         map = _ForEachValueFnFindInMap("a", ["Bucket", {"Ref": "Foo"}, "Key"])


### PR DESCRIPTION
*Issue #, if available:*
fix #3873 
*Description of changes:*
- When doing language extension transform don't guess at a mapping value when the FindInMap values are static

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
