### PR TITLE
SnapStart is okay with new python dotnet

### DIFF
--- a/src/cfnlint/rules/resources/lmbd/SnapStartSupported.py
+++ b/src/cfnlint/rules/resources/lmbd/SnapStartSupported.py
@@ -51,6 +51,26 @@ class SnapStartSupported(CfnLintKeyword):
             "sa-east-1",
         ]
 
+    def _is_runtime_valid(self, runtime: str) -> bool:
+        if not any(runtime.startswith(r) for r in ["python", "java", "dotnet"]):
+            return False
+
+        if runtime.startswith("dotnetcore"):
+            return False
+
+        return runtime not in [
+            "dotnet5.0",
+            "dotnet6",
+            "dotnet7",
+            "java8.al2",
+            "java8",
+            "python3.10",
+            "python3.11",
+            "python3.7",
+            "python3.8",
+            "python3.9",
+        ]
+
     def validate(
         self, validator: Validator, _, instance: Any, schema: dict[str, Any]
     ) -> ValidationResult:
@@ -94,11 +114,7 @@ class SnapStartSupported(CfnLintKeyword):
             if not isinstance(runtime, str):
                 continue
 
-            if (
-                runtime
-                and (not runtime.startswith("java"))
-                and runtime not in ["java8.al2", "java8"]
-            ):
+            if not self._is_runtime_valid(runtime):
                 yield ValidationError(
                     f"{runtime!r} is not supported for 'SnapStart' enabled functions",
                     path=deque(["SnapStart", "ApplyOn"]),

--- a/test/unit/rules/resources/lmbd/test_snapstart_supported.py
+++ b/test/unit/rules/resources/lmbd/test_snapstart_supported.py
@@ -66,7 +66,72 @@ def rule():
             ],
         ),
         (
-            "SnapStart not enabled on non java runtime",
+            "SnapStart enabled for python3.12 error",
+            {
+                "Runtime": "python3.12",
+                "SnapStart": {
+                    "ApplyOn": "PublishedVersions",
+                },
+            },
+            ["us-east-1"],
+            True,
+            False,
+            [],
+        ),
+        (
+            "SnapStart enabled for dotnet",
+            {
+                "Runtime": "dotnet8",
+                "SnapStart": {
+                    "ApplyOn": "PublishedVersions",
+                },
+            },
+            ["us-east-1"],
+            True,
+            False,
+            [],
+        ),
+        (
+            "SnapStart enabled for dotnet version that isn't supported",
+            {
+                "Runtime": "dotnet5.0",
+                "SnapStart": {
+                    "ApplyOn": "PublishedVersions",
+                },
+            },
+            ["us-east-1"],
+            True,
+            False,
+            [
+                ValidationError(
+                    "'dotnet5.0' is not supported for 'SnapStart' enabled functions",
+                    path=deque(["SnapStart", "ApplyOn"]),
+                )
+            ],
+        ),
+        (
+            "SnapStart enabled for dotnetcore version that isn't supported",
+            {
+                "Runtime": "dotnetcore2.1",
+                "SnapStart": {
+                    "ApplyOn": "PublishedVersions",
+                },
+            },
+            ["us-east-1"],
+            True,
+            False,
+            [
+                ValidationError(
+                    (
+                        "'dotnetcore2.1' is not supported for "
+                        "'SnapStart' enabled functions"
+                    ),
+                    path=deque(["SnapStart", "ApplyOn"]),
+                )
+            ],
+        ),
+        (
+            "SnapStart not enabled on python non supported runtime",
             {
                 "Runtime": "python3.11",
             },
@@ -76,7 +141,7 @@ def rule():
             [],
         ),
         (
-            "SnapStart not enabled on java runtime in a bad region",
+            "SnapStart not enabled on python runtime in a bad region",
             {
                 "Runtime": "python3.11",
             },

--- a/test/unit/rules/resources/lmbd/test_snapstart_supported.py
+++ b/test/unit/rules/resources/lmbd/test_snapstart_supported.py
@@ -92,6 +92,24 @@ def rule():
             [],
         ),
         (
+            "SnapStart enabled for go that isn't supported",
+            {
+                "Runtime": "go1.x",
+                "SnapStart": {
+                    "ApplyOn": "PublishedVersions",
+                },
+            },
+            ["us-east-1"],
+            True,
+            False,
+            [
+                ValidationError(
+                    "'go1.x' is not supported for 'SnapStart' enabled functions",
+                    path=deque(["SnapStart", "ApplyOn"]),
+                )
+            ],
+        ),
+        (
             "SnapStart enabled for dotnet version that isn't supported",
             {
                 "Runtime": "dotnet5.0",


### PR DESCRIPTION
*Issue #, if available:*
fix #3887 
*Description of changes:*
- SnapStart is okay with new python dotnet runtimes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
