### PR TITLE
Don't fail when ignore templates is empty or not findable

### DIFF
--- a/src/cfnlint/config.py
+++ b/src/cfnlint/config.py
@@ -785,9 +785,11 @@ class ConfigMixIn(TemplateArgs, CliArgs, ConfigFileArgs):
         if isinstance(filenames, str):
             filenames = [filenames]
 
-        return self._glob_filenames(filenames)
+        return self._glob_filenames(filenames, False)
 
-    def _glob_filenames(self, filenames: Sequence[str]) -> list[str]:
+    def _glob_filenames(
+        self, filenames: Sequence[str], raise_exception: bool = True
+    ) -> list[str]:
         # handle different shells and Config files
         # some shells don't expand * and configparser won't expand wildcards
         all_filenames = []
@@ -796,7 +798,8 @@ class ConfigMixIn(TemplateArgs, CliArgs, ConfigFileArgs):
             add_filenames = glob.glob(filename, recursive=True)
 
             if not add_filenames and not self.ignore_bad_template:
-                raise ValueError(f"{filename} could not be processed by glob.glob")
+                if raise_exception:
+                    raise ValueError(f"{filename} could not be processed by glob.glob")
 
             all_filenames.extend(add_filenames)
 

--- a/test/unit/module/config/test_config_mixin.py
+++ b/test/unit/module/config/test_config_mixin.py
@@ -248,6 +248,28 @@ class TestConfigMixIn(BaseTestCase):
         self.assertEqual(len(config.templates), 3)
 
     @patch("cfnlint.config.ConfigFileArgs._read_config", create=True)
+    def test_config_expand_and_ignore_templates_with_bad_path(self, yaml_mock):
+        """Test ignore templates"""
+
+        yaml_mock.side_effect = [
+            {
+                "templates": ["test/fixtures/templates/bad/resources/iam/*.yaml"],
+                "ignore_templates": [
+                    "dne/fixtures/templates/bad/resources/iam/resource_*.yaml"
+                ],
+            },
+            {},
+        ]
+        config = cfnlint.config.ConfigMixIn([])
+
+        # test defaults
+        self.assertIn(
+            str(Path("test/fixtures/templates/bad/resources/iam/resource_policy.yaml")),
+            config.templates,
+        )
+        self.assertEqual(len(config.templates), 4)
+
+    @patch("cfnlint.config.ConfigFileArgs._read_config", create=True)
     def test_config_merge(self, yaml_mock):
         """Test merging lists"""
 


### PR DESCRIPTION
*Issue #, if available:*
fix #3881 

*Description of changes:*
- Don't fail when ignore templates is empty or not findable

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
