### PR TITLE
Add uniqueKeys for Sid in IAM policies

### DIFF
--- a/src/cfnlint/data/schemas/other/iam/policy_identity.json
+++ b/src/cfnlint/data/schemas/other/iam/policy_identity.json
@@ -61,6 +61,9 @@
    "type": [
     "object",
     "array"
+   ],
+   "uniqueKeys": [
+    "Sid"
    ]
   },
   "Version": {

--- a/src/cfnlint/data/schemas/other/iam/policy_resource.json
+++ b/src/cfnlint/data/schemas/other/iam/policy_resource.json
@@ -73,6 +73,9 @@
    "type": [
     "object",
     "array"
+   ],
+   "uniqueKeys": [
+    "Sid"
    ]
   },
   "Version": {

--- a/test/unit/rules/resources/iam/test_identity_policy.py
+++ b/test/unit/rules/resources/iam/test_identity_policy.py
@@ -208,3 +208,33 @@ class TestIdentityPolicies(TestCase):
         self.assertListEqual(
             list(errs[0].path), ["Statement", 0, "Condition", "iam:PassedToService"]
         )
+
+    def test_duplicate_sid(self):
+        validator = CfnTemplateValidator()
+
+        policy = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Sid": "All",
+                    "Effect": "Allow",
+                    "Action": "*",
+                    "Resource": "*",
+                },
+                {
+                    "Sid": "All",
+                    "Effect": "Allow",
+                    "Action": "*",
+                    "Resource": "*",
+                },
+            ],
+        }
+
+        errs = list(
+            self.rule.validate(
+                validator=validator, policy=policy, schema={}, policy_type=None
+            )
+        )
+        self.assertEqual(len(errs), 1, errs)
+        self.assertEqual(errs[0].message, "array items are not unique for keys ['Sid']")
+        self.assertListEqual(list(errs[0].path), ["Statement"])


### PR DESCRIPTION
*Issue #, if available:*
fix #3973 
*Description of changes:*
- Add uniqueKeys for Sid in IAM policies

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
