### PR TITLE
Add rule to validate mixing API body definitions

### DIFF
--- a/src/cfnlint/rules/resources/apigateway/RestApiMixingDefinitions.py
+++ b/src/cfnlint/rules/resources/apigateway/RestApiMixingDefinitions.py
@@ -1,0 +1,66 @@
+"""
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from cfnlint.jsonschema import ValidationError, ValidationResult, Validator
+from cfnlint.rules.jsonschema.CfnLintKeyword import CfnLintKeyword
+
+
+class RestApiMixingDefinitions(CfnLintKeyword):
+    id = "W3660"
+    shortdesc = "Validate if multiple resources are modifying a Rest API definition"
+    description = (
+        "When using AWS::ApiGateway::RestApi with 'Body' or 'BodyS3Location' "
+        "the resource handler will use PutRestApi with mode overwrite. "
+        "Depending on how resources are updated the IaC template will "
+        "drift and create orphaned resources."
+    )
+    tags = ["resources", "apigateway"]
+
+    def __init__(self) -> None:
+        super().__init__(
+            keywords=[
+                "Resources/AWS::ApiGateway::RestApi/Properties/Body",
+                "Resources/AWS::ApiGateway::RestApi/Properties/BodyS3Location",
+            ],
+        )
+        self._mix_types = [
+            "AWS::ApiGateway::Method",
+            "AWS::ApiGateway::Model",
+            "AWS::ApiGateway::Resource",
+            "AWS::ApiGateway::GatewayResponse",
+            "AWS::ApiGateway::RequestValidator",
+            "AWS::ApiGateway::Authorizer",
+        ]
+
+    def validate(
+        self, validator: Validator, keywords: Any, instance: Any, schema: dict[str, Any]
+    ) -> ValidationResult:
+
+        if validator.cfn.graph is None:
+            return
+
+        if not len(validator.context.path.path) > 3:
+            return
+
+        resource_name = validator.context.path.path[1]
+        key = validator.context.path.path[3]
+
+        unique_sources: set[str] = set()
+        for source, _ in validator.cfn.graph.graph.in_edges(resource_name):
+            if validator.context.resources[source].type in self._mix_types:
+                if source not in unique_sources:
+                    yield ValidationError(
+                        message=(
+                            f"Defining {key!r} with a relation to resource {source!r} "
+                            f"of type {validator.context.resources[source].type!r} "
+                            "may result in drift and orphaned resources"
+                        ),
+                        rule=self,
+                    )
+                    unique_sources.add(source)

--- a/src/cfnlint/rules/resources/apigateway/RestApiMixingDefinitions.py
+++ b/src/cfnlint/rules/resources/apigateway/RestApiMixingDefinitions.py
@@ -42,8 +42,8 @@ class RestApiMixingDefinitions(CfnLintKeyword):
         self, validator: Validator, keywords: Any, instance: Any, schema: dict[str, Any]
     ) -> ValidationResult:
 
-        if validator.cfn.graph is None:
-            return
+        if validator.cfn.graph is None:  # pragma: no cover
+            return  # pragma: no cover
 
         if not len(validator.context.path.path) > 3:
             return
@@ -53,6 +53,8 @@ class RestApiMixingDefinitions(CfnLintKeyword):
 
         unique_sources: set[str] = set()
         for source, _ in validator.cfn.graph.graph.in_edges(resource_name):
+            if source not in validator.context.resources:
+                continue
             if validator.context.resources[source].type in self._mix_types:
                 if source not in unique_sources:
                     yield ValidationError(

--- a/test/unit/rules/resources/apigateway/test_rest_api_mixing_definition.py
+++ b/test/unit/rules/resources/apigateway/test_rest_api_mixing_definition.py
@@ -1,0 +1,135 @@
+"""
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+"""
+
+from collections import deque
+
+import pytest
+
+from cfnlint.context import Path
+from cfnlint.jsonschema import ValidationError
+from cfnlint.rules.resources.apigateway.RestApiMixingDefinitions import (
+    RestApiMixingDefinitions,
+)
+
+
+@pytest.fixture(scope="module")
+def rule():
+    rule = RestApiMixingDefinitions()
+    yield rule
+
+
+@pytest.fixture
+def path():
+    return Path(
+        path=deque(["Resources", "RestApi", "Properties", "Body"]),
+        cfn_path=deque(["Resources", "AWS::ApiGateway::RestApi", "Properties", "Body"]),
+    )
+
+
+_rest_api = {
+    "Type": "AWS::ApiGateway::RestApi",
+    "Properties": {},
+}
+
+_api_resource = {
+    "Type": "AWS::ApiGateway::Resource",
+    "Properties": {
+        "RestApiId": {"Ref": "RestApi"},
+        "ParentId": {"Fn::GetAtt": "RestApi.RootResourceId"},
+        "PathPart": "test",
+    },
+}
+
+_api_model = {
+    "Type": "AWS::ApiGateway::Model",
+    "Properties": {
+        "RestApiId": {"Ref": "RestApi"},
+        "ContentType": "application/json",
+        "Description": "Schema for Pets example",
+        "Name": "PetsModelNoFlatten",
+        "Schema": {
+            "$schema": "http://json-schema.org/draft-04/schema#",
+            "title": "PetsModelNoFlatten",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "number": {"type": "integer"},
+                    "class": {"type": "string"},
+                    "salesPrice": {"type": "number"},
+                },
+            },
+        },
+    },
+}
+
+
+@pytest.mark.parametrize(
+    "template,expected",
+    [
+        (
+            {
+                "Resources": {
+                    "RestApi": _rest_api,
+                }
+            },
+            [],
+        ),
+        (
+            {
+                "Resources": {
+                    "RestApi": _rest_api,
+                    "RootResource": _api_resource,
+                }
+            },
+            [
+                ValidationError(
+                    (
+                        "Defining 'Body' with a relation to "
+                        "resource 'RootResource' of type "
+                        "'AWS::ApiGateway::Resource' may result "
+                        "in drift and orphaned resources"
+                    ),
+                    rule=RestApiMixingDefinitions(),
+                    path=deque([]),
+                )
+            ],
+        ),
+        (
+            {
+                "Resources": {
+                    "RestApi": _rest_api,
+                    "RootResource": _api_resource,
+                    "Model": _api_model,
+                }
+            },
+            [
+                ValidationError(
+                    (
+                        "Defining 'Body' with a relation to "
+                        "resource 'RootResource' of type "
+                        "'AWS::ApiGateway::Resource' may result "
+                        "in drift and orphaned resources"
+                    ),
+                    rule=RestApiMixingDefinitions(),
+                ),
+                ValidationError(
+                    (
+                        "Defining 'Body' with a relation to "
+                        "resource 'Model' of type "
+                        "'AWS::ApiGateway::Model' may result "
+                        "in drift and orphaned resources"
+                    ),
+                    rule=RestApiMixingDefinitions(),
+                ),
+            ],
+        ),
+    ],
+    indirect=["template"],
+)
+def test_validate(template, expected, rule, validator):
+    errs = list(rule.validate(validator, "", "", {}))
+
+    assert errs == expected, f"Expected {expected} got {errs}"


### PR DESCRIPTION
*Issue #, if available:*
fix #3919
*Description of changes:*
- Add rule W3660 to validate mixing API body definitions

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
