### PR TITLE
Add rule E3061 to validate Bucket tiering configurations

### DIFF
--- a/src/cfnlint/rules/resources/s3/BucketTieringConfiguration.py
+++ b/src/cfnlint/rules/resources/s3/BucketTieringConfiguration.py
@@ -1,0 +1,72 @@
+"""
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from typing import Any
+
+from cfnlint.jsonschema import ValidationResult, Validator
+from cfnlint.rules.helpers import get_value_from_path
+from cfnlint.rules.jsonschema.CfnLintKeyword import CfnLintKeyword
+
+
+class BucketTieringConfiguration(CfnLintKeyword):
+    id = "E3061"
+    shortdesc = "Validate the days for tierings in IntelligentTieringConfigurations"
+    description = (
+        "When using AWS::S3::Bucket to configure IntelligentTieringConfigurations "
+        "the Tierings have minimum and maximum values"
+    )
+    source_url = "https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html"
+    tags = ["resources", "s3"]
+
+    def __init__(self):
+        super().__init__(
+            [
+                "Resources/AWS::S3::Bucket/Properties/IntelligentTieringConfigurations/*/Tierings/*"
+            ]
+        )
+
+        self._tierings = {
+            "ARCHIVE_ACCESS": {
+                "minimum": 90,
+                "maximum": 730,
+            },
+            "DEEP_ARCHIVE_ACCESS": {
+                "minimum": 180,
+                "maximum": 730,
+            },
+        }
+
+    def validate(
+        self, validator: Validator, _, instance: Any, schema: dict[str, Any]
+    ) -> ValidationResult:
+
+        for archive_access, archive_access_validator in get_value_from_path(
+            validator, instance, deque(["AccessTier"])
+        ):
+            if not validator.is_type(archive_access, "string"):
+                continue
+            for days, days_validator in get_value_from_path(
+                archive_access_validator, instance, deque(["Days"])
+            ):
+                if validator.is_type(days, "string"):
+                    try:
+                        days = int(days)
+                    except Exception:
+                        return
+
+                if not validator.is_type(days, "integer"):
+                    continue
+
+                days_validator = validator.evolve(
+                    schema=self._tierings.get(archive_access, {})
+                )
+
+                for err in days_validator.iter_errors(days):
+                    err.path = deque(["Days"])
+                    err.rule = self
+                    yield err

--- a/test/unit/rules/resources/ec2/test_vpc_subnet_overlap.py
+++ b/test/unit/rules/resources/ec2/test_vpc_subnet_overlap.py
@@ -175,8 +175,6 @@ def test_validate(name, instance, starting_subnets, expected, rule, validator):
     rule._subnets = starting_subnets
     errs = list(rule.validate(validator, "", instance, {}))
 
-    for err in errs:
-        print(err.path)
     assert (
         errs == expected
     ), f"Expected test {name!r} to have {expected!r} but got {errs!r}"

--- a/test/unit/rules/resources/s3/test_bucket_tiering_configuration.py
+++ b/test/unit/rules/resources/s3/test_bucket_tiering_configuration.py
@@ -1,0 +1,81 @@
+"""
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+"""
+
+from collections import deque
+
+import pytest
+
+from cfnlint.jsonschema import ValidationError
+from cfnlint.rules.resources.s3.BucketTieringConfiguration import (
+    BucketTieringConfiguration,
+)
+
+
+@pytest.fixture(scope="module")
+def rule():
+    rule = BucketTieringConfiguration()
+    yield rule
+
+
+@pytest.mark.parametrize(
+    "instance,expected",
+    [
+        (
+            {},
+            [],
+        ),
+        (
+            {"AccessTier": "ARCHIVE_ACCESS"},
+            [],
+        ),
+        (
+            {
+                "AccessTier": "ARCHIVE_ACCESS",
+                "Days": "90",
+            },
+            [],
+        ),
+        (
+            {
+                "AccessTier": "ARCHIVE_ACCESS",
+                "Days": "a",
+            },
+            [],
+        ),
+        (
+            {
+                "AccessTier": "ARCHIVE_ACCESS",
+                "Days": 1,
+            },
+            [
+                ValidationError(
+                    ("1 is less than the minimum of 90"),
+                    path=deque(["Days"]),
+                    validator="minimum",
+                    schema_path=deque(["minimum"]),
+                    rule=BucketTieringConfiguration(),
+                )
+            ],
+        ),
+        (
+            {
+                "AccessTier": "ARCHIVE_ACCESS",
+                "Days": 99999,
+            },
+            [
+                ValidationError(
+                    ("99999 is greater than the maximum of 730"),
+                    path=deque(["Days"]),
+                    validator="maximum",
+                    schema_path=deque(["maximum"]),
+                    rule=BucketTieringConfiguration(),
+                )
+            ],
+        ),
+    ],
+)
+def test_validate(instance, expected, rule, validator):
+    errs = list(rule.validate(validator, "", instance, {}))
+    assert errs == expected, f"Expected {expected} got {errs}"


### PR DESCRIPTION
*Issue #, if available:*
fix #3992 

*Description of changes:*
- Add rule E3061 to validate Bucket tiering configurations

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
