### PR TITLE
Keep resource names to the resource name

### DIFF
--- a/test/unit/rules/resources/codepipeline/test_pipeline_artifact_names.py
+++ b/test/unit/rules/resources/codepipeline/test_pipeline_artifact_names.py
@@ -111,6 +111,66 @@ def _append_queues(queue1: Iterable, queue2: Iterable) -> deque:
                 ),
                 (
                     "Foo",
+                    deque(
+                        [
+                            "Resources",
+                            1,
+                            "Properties",
+                            "Stages",
+                            0,
+                            "Actions",
+                            0,
+                            "OutputArtifacts",
+                            0,
+                            "Name",
+                        ]
+                    ),
+                    {},
+                ),
+            ],
+            [],
+        ),
+        (
+            [
+                (
+                    "Foo",
+                    _append_queues(
+                        _standard_path, [0, "Actions", 0, "OutputArtifacts", 0, "Name"]
+                    ),
+                    {},
+                ),
+                (
+                    "Foo",
+                    deque(
+                        [
+                            "Resources",
+                            "AnotherPipeline",
+                            "Properties",
+                            "Stages",
+                            0,
+                            "Actions",
+                            0,
+                            "OutputArtifacts",
+                            0,
+                            "Name",
+                        ]
+                    ),
+                    {},
+                ),
+            ],
+            [],
+        ),
+        (
+            [
+                (
+                    "Foo",
+                    _append_queues(
+                        _standard_path, [0, "Actions", 0, "OutputArtifacts", 0, "Name"]
+                    ),
+                    {},
+                ),
+                (
+                    "Foo",
                     _append_queues(
                         _standard_path, [0, "Actions", 0, "OutputArtifacts", 1, "Name"]
                     ),


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Update rule E3701 to keep resource names to the resource name

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
