### PR TITLE
Update I3510 to not fail on resources that start with asterisk

### DIFF
--- a/src/cfnlint/rules/resources/iam/StatementResources.py
+++ b/src/cfnlint/rules/resources/iam/StatementResources.py
@@ -64,7 +64,7 @@ class _Arn:
         ):
             if x == y:
                 continue
-            if x == "*" or y == "" or y == ".*":
+            if x == "*" or x.startswith("*") or y == "" or y == ".*":
                 return True
             if x.startswith(y) and "*" in x:
                 return True

--- a/test/unit/rules/resources/iam/test_statement_resources.py
+++ b/test/unit/rules/resources/iam/test_statement_resources.py
@@ -229,6 +229,13 @@ def template():
         (
             {
                 "Action": ["cloudformation:CreateStack"],
+                "Resource": ["arn:aws:cloudformation:us-east-1:123456789012:*dne*"],
+            },
+            [],
+        ),
+        (
+            {
+                "Action": ["cloudformation:CreateStack"],
                 "Resource": ["arn:aws:logs:us-east-1:123456789012:stack/dne/*"],
             },
             [


### PR DESCRIPTION
*Issue #, if available:*
#1940 

*Description of changes:*
- Update I3510 to not fail on resources that start with asterisk

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
