### PR TITLE
StorageEncrypted can be used on aurora AWS::RDS::DBInstance

### DIFF
--- a/src/cfnlint/data/schemas/extensions/aws_rds_dbinstance/aurora_exclusive.json
+++ b/src/cfnlint/data/schemas/extensions/aws_rds_dbinstance/aurora_exclusive.json
@@ -45,11 +45,6 @@
      "required": [
       "MasterUserPassword"
      ]
-    },
-    {
-     "required": [
-      "StorageEncrypted"
-     ]
     }
    ],
    "properties": {
@@ -58,8 +53,7 @@
     "CopyTagsToSnapshot": true,
     "DeletionProtection": true,
     "EnableIAMDatabaseAuthentication": true,
-    "MasterUserPassword": true,
-    "StorageEncrypted": true
+    "MasterUserPassword": true
    }
   }
  }


### PR DESCRIPTION
*Issue #, if available:*
fix #4068 
*Description of changes:*
- `StorageEncrypted` can be used on aurora `AWS::RDS::DBInstance`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
