### PR TITLE
Allow Fn::GetAtt to an object when using short form

### DIFF
--- a/src/cfnlint/decode/decode.py
+++ b/src/cfnlint/decode/decode.py
@@ -130,7 +130,7 @@ def _decode(
                 )
         else:
             matches = [create_match_yaml_parser_error(err, filename)]
-    except YAMLError as err:
+    except (YAMLError, Exception) as err:
         matches = [create_match_file_error(filename, str(err))]
 
     if not isinstance(template, dict) and not matches:

--- a/src/cfnlint/template/transforms/_language_extensions.py
+++ b/src/cfnlint/template/transforms/_language_extensions.py
@@ -141,6 +141,9 @@ class _Transform:
                 elif k == "Fn::ToJsonString":
                     # extra special handing for this as {} could be a valid value
                     return obj
+                elif k == "Fn::GetAtt":
+                    if isinstance(v, (list, str)):
+                        obj[k] = self._walk(v, params, cfn)
                 elif k == "Fn::Sub":
                     if isinstance(v, str):
                         only_string, obj[k] = self._replace_string_params(v, params)

--- a/test/unit/module/template/transforms/test_language_extensions.py
+++ b/test/unit/module/template/transforms/test_language_extensions.py
@@ -735,6 +735,31 @@ class TestTransform(TestCase):
             [{"Key": "Foo", "Value": {"Fn::FindInMap": ["Bucket", "Tags", "Key"]}}],
         )
 
+    def test_getatt_not_a_list(self):
+        template_obj = deepcopy(self.template_obj)
+        nested_set(
+            template_obj,
+            [
+                "Outputs",
+                "Fn::ForEach::BucketOutputs",
+                2,
+                "Fn::ForEach::Attribute",
+                2,
+                "S3Bucket${Identifier}${Property}",
+                "Value",
+            ],
+            {"Fn::GetAtt": {"Fn::FindInMap": ["Bucket", "Outputs", "Attributes"]}},
+        )
+        cfn = Template(filename="", template=template_obj, regions=["us-east-1"])
+
+        matches, template = language_extension(cfn)
+        self.assertListEqual(matches, [])
+        print(template["Outputs"]["S3BucketAArn"]["Value"])
+        self.assertDictEqual(
+            template["Outputs"]["S3BucketAArn"]["Value"],
+            {"Fn::GetAtt": {"Fn::FindInMap": ["Bucket", "Outputs", "Attributes"]}},
+        )
+
 
 class TestTransformValues(TestCase):
     def setUp(self) -> None:


### PR DESCRIPTION
*Issue #, if available:*
#4099 
*Description of changes:*
- Allow Fn::GetAtt to an object when using short form

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
