### PR TITLE
Allow * for resource partition

### DIFF
--- a/src/cfnlint/data/schemas/other/iam/policy.json
+++ b/src/cfnlint/data/schemas/other/iam/policy.json
@@ -16,7 +16,7 @@
    ]
   },
   "AwsArn": {
-   "pattern": "^(arn:aws[A-Za-z\\-]*?:[^:]+:[^:]*(:(?:\\d{12}|\\*|aws)?:.+|)|\\*)$"
+   "pattern": "^(arn:(aws[A-Za-z\\-]*?|\\*):[^:]+:[^:]*(:(?:\\d{12}|\\*|aws)?:.+|)|\\*)$"
   },
   "AwsPrincipalArn": {
    "anyOf": [

--- a/test/fixtures/results/quickstart/nist_application.json
+++ b/test/fixtures/results/quickstart/nist_application.json
@@ -89,7 +89,7 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/nist_application.yaml",
-        "Id": "c855ed21-761f-b3a3-1fac-92578c95872d",
+        "Id": "c95357ae-6a84-2a52-5a04-fa9d9d6c2e4f",
         "Level": "Warning",
         "Location": {
             "End": {
@@ -106,7 +106,7 @@
                 "LineNumber": 198
             }
         },
-        "Message": "{'Ref': 'pSecurityAlarmTopic'} does not match '^(arn:aws[A-Za-z\\\\-]*?:[^:]+:[^:]*(:(?:\\\\d{12}|\\\\*|aws)?:.+|)|\\\\*)$' when 'Ref' is resolved",
+        "Message": "{'Ref': 'pSecurityAlarmTopic'} does not match '^(arn:(aws[A-Za-z\\\\-]*?|\\\\*):[^:]+:[^:]*(:(?:\\\\d{12}|\\\\*|aws)?:.+|)|\\\\*)$' when 'Ref' is resolved",
         "ParentId": null,
         "Rule": {
             "Description": "Resolve the Ref and then validate the values against the schema",

--- a/test/fixtures/results/quickstart/non_strict/nist_application.json
+++ b/test/fixtures/results/quickstart/non_strict/nist_application.json
@@ -89,7 +89,7 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/nist_application.yaml",
-        "Id": "c855ed21-761f-b3a3-1fac-92578c95872d",
+        "Id": "c95357ae-6a84-2a52-5a04-fa9d9d6c2e4f",
         "Level": "Warning",
         "Location": {
             "End": {
@@ -106,7 +106,7 @@
                 "LineNumber": 198
             }
         },
-        "Message": "{'Ref': 'pSecurityAlarmTopic'} does not match '^(arn:aws[A-Za-z\\\\-]*?:[^:]+:[^:]*(:(?:\\\\d{12}|\\\\*|aws)?:.+|)|\\\\*)$' when 'Ref' is resolved",
+        "Message": "{'Ref': 'pSecurityAlarmTopic'} does not match '^(arn:(aws[A-Za-z\\\\-]*?|\\\\*):[^:]+:[^:]*(:(?:\\\\d{12}|\\\\*|aws)?:.+|)|\\\\*)$' when 'Ref' is resolved",
         "ParentId": null,
         "Rule": {
             "Description": "Resolve the Ref and then validate the values against the schema",


### PR DESCRIPTION
*Issue #, if available:*
fix #4167 
*Description of changes:*
- Update rule E3510 schema definition to allow `*` for resource partition

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
