### PR TITLE
Fix Issue 4207.

### DIFF
--- a/test/fixtures/templates/good/generic.yaml
+++ b/test/fixtures/templates/good/generic.yaml
@@ -171,7 +171,7 @@ Resources:
           NODE_ENV: !Ref pEnvironment
       Handler: index.handler
       Role: "arn:aws:iam::123456789012:role/lambda_basic_execution"
-      Runtime: nodejs18.x
+      Runtime: nodejs22.x
 Outputs:
   ElasticIP:
     Value: !Sub "${ElasticIP}/32"


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-cloudformation/cfn-lint/issues/4207

*Description of changes:*

node18 deprecated, upgraded to node22.

```shell
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <test.integration.test_good_templates.TestQuickStartTemplates testMethod=test_module_integration>
config = {
 "append_rules": [
  "/home/budgeg/build/oss/cfn-lint/src/cfnlint/rules"
 ],
 "config_file": null,
 "configure_rules... "parameters": [],
 "patch_specs": false,
 "regions": [
  "us-east-1"
 ],
 "registry_schemas": [],
 "templates": null
}

    def run_module_integration_scenarios(self, config):
        """Test using cfnlint as a module integrated into another package"""

        configure_logging(None, False)

        for scenario in self.scenarios:
            filename = scenario.get("filename")
            results_filename = scenario.get("results_filename")
            expected_results = scenario.get("results", [])

            if results_filename and not expected_results:
                with open(results_filename, encoding="utf-8") as json_data:
                    expected_results = json.load(json_data)

            for result in expected_results:
                result["Filename"] = str(Path(result.get("Filename")))

            # template = cfn_yaml.load(filename)
            scenario_config = deepcopy(config)
            scenario_config.cli_args.template_alt = [filename]
            scenario_config.cli_args.format = "json"

            runner = Runner(scenario_config)

            with patch("sys.exit") as exit:
                with patch("sys.stdout", new=StringIO()) as out:
                    runner.cli()
                    output = json.loads(out.getvalue())
                    try:
                        exit.assert_called_once_with(scenario.get("exit_code", 0))
                    except AssertionError:
>                       raise AssertionError(
                            f"Expected exit code {scenario.get('exit_code', 0)!r} "
                            f"for {filename}: {output}"
                        )
E                       AssertionError: Expected exit code 0 for test/fixtures/templates/good/generic.yaml: [{'Filename': 'test/fixtures/templates/good/generic.yaml', 'Id': 'a4a887d0-e62b-902b-492b-421ff3068315', 'Level': 'Warning', 'Location': {'End': {'ColumnNumber': 14, 'LineNumber': 174}, 'Path': ['Resources', 'LambdaFunction', 'Properties', 'Runtime'], 'Start': {'ColumnNumber': 7, 'LineNumber': 174}}, 'Message': "Runtime 'nodejs18.x' was deprecated on '2025-07-31'. Creation was disabled on '2025-10-01' and update on '2025-11-01'. Please consider updating to 'nodejs22.x'", 'ParentId': None, 'Rule': {'Description': 'Check if an EOL Lambda Runtime is specified and give a warning if used. ', 'Id': 'W2531', 'ShortDescription': 'Check if EOL Lambda Function Runtimes are used', 'Source': 'https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html'}}]

test/integration/__init__.py:123: AssertionError
_____________________________________________ TestQuickStartTemplates.test_templates _____________________________________________

self = <test.integration.test_good_templates.TestQuickStartTemplates testMethod=test_templates>, extra_params = []

    def run_scenarios(self, extra_params=None):
        """Success test"""
        extra_params = extra_params or []
        for scenario in self.scenarios:
            filename = scenario.get("filename")
            results_filename = scenario.get("results_filename")
            expected_results = scenario.get("results", [])
            exit_code = scenario.get("exit_code")

            if results_filename and not expected_results:
                with open(results_filename, encoding="utf-8") as json_data:
                    expected_results = json.load(json_data)

            for result in expected_results:
                result["Filename"] = str(Path(result.get("Filename")))

            try:
>               result = subprocess.check_output(
                    ["cfn-lint"] + extra_params + ["--format", "json", "--", filename]
                )

test/integration/__init__.py:47:
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
