### PR TITLE
Remove AmazonGuardDutyFullAccess from ManagedPolicies

### DIFF
--- a/src/cfnlint/data/Serverless/ManagedPolicies.json
+++ b/src/cfnlint/data/Serverless/ManagedPolicies.json
@@ -871,7 +871,6 @@
  "AmazonGrafanaCloudWatchAccess": "arn:aws:iam::aws:policy/service-role/AmazonGrafanaCloudWatchAccess",
  "AmazonGrafanaRedshiftAccess": "arn:aws:iam::aws:policy/service-role/AmazonGrafanaRedshiftAccess",
  "AmazonGrafanaServiceLinkedRolePolicy": "arn:aws:iam::aws:policy/aws-service-role/AmazonGrafanaServiceLinkedRolePolicy",
- "AmazonGuardDutyFullAccess": "arn:aws:iam::aws:policy/AmazonGuardDutyFullAccess",
  "AmazonGuardDutyFullAccess_v2": "arn:aws:iam::aws:policy/AmazonGuardDutyFullAccess_v2",
  "AmazonGuardDutyMalwareProtectionServiceRolePolicy": "arn:aws:iam::aws:policy/aws-service-role/AmazonGuardDutyMalwareProtectionServiceRolePolicy",
  "AmazonGuardDutyReadOnlyAccess": "arn:aws:iam::aws:policy/AmazonGuardDutyReadOnlyAccess",


### PR DESCRIPTION
*Description of changes:*
The AWS managed policy AmazonGuardDutyFullAccess is being deprecated, so this policy reference should be removed. The recommendation is to use AmazonGuardDutyFullAccess_v2 instead.

AmazonGuardDutyFullAccess is scheduled to be deprecated on 08/26/2025. 
When creating new users/groups/roles after the deprecation date, you will only be able to attach the new policy (AmazonGuardDutyFullAccess_v2). Existing users/groups/roles with the old policy (AmazonGuardDutyFullAccess) will continue to work.

[1] https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AmazonGuardDutyFullAccess.html
[2] https://docs.aws.amazon.com/guardduty/latest/ug/security-iam-awsmanpol.html#security-iam-awsmanpol-AmazonGuardDutyFullAccess

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
