### PR TITLE
Update CreationPolicy StartFleet type

### DIFF
--- a/src/cfnlint/rules/resources/CreationPolicy.py
+++ b/src/cfnlint/rules/resources/CreationPolicy.py
@@ -31,9 +31,7 @@ class CreationPolicy(CfnLintJsonSchema):
                 "additionalProperties": False,
                 "properties": {
                     "StartFleet": {
-                        "additionalProperties": False,
-                        "type": "object",
-                        "properties": {"Type": {"type": "boolean"}},
+                        "type": "boolean",
                     }
                 },
             }

--- a/test/unit/rules/resources/test_creationpolicy.py
+++ b/test/unit/rules/resources/test_creationpolicy.py
@@ -44,7 +44,7 @@ def template():
     [
         (
             "Correct for app stream",
-            {"StartFleet": {"Type": True}},
+            {"StartFleet": True},
             {
                 "path": deque(["Resources", "MyAppStreamFleet", "CreationPolicy"]),
             },
@@ -62,14 +62,12 @@ def template():
             },
             [
                 ValidationError(
-                    "{} is not of type 'boolean'",
+                    "{'Type': {}} is not of type 'boolean'",
                     rule=CreationPolicy(),
-                    path=deque(["StartFleet", "Type"]),
-                    schema_path=deque(
-                        ["properties", "StartFleet", "properties", "Type", "type"]
-                    ),
+                    path=deque(["StartFleet"]),
+                    schema_path=deque(["properties", "StartFleet", "type"]),
                     validator="type",
-                )
+                ),
             ],
         ),
         (


### PR DESCRIPTION
*Description of changes:*

AWS Documentation [1] for the `AWS::AppStream::Fleet` resource's CreationPolicy attribute is inconsistent with CloudFormation behavior.

CloudFormation only accepts template syntax such as:

```
CreationPolicy:
  StartFleet: True
```

However, cfn-lint validation is consistent with AWS Documentation and expects:
```
CreationPolicy:
  StartFleet: 
    Type: True
```


**This change is meant to update `cfn-lint` validations to align with CloudFormation CreationPolicy behavior for the `AWS::AppStream::Fleet` resource**


[1] https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-attribute-creationpolicy.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
