### PR TITLE
Improved handling of directories for --list-templates

### DIFF
--- a/src/cfnlint/runner/cli.py
+++ b/src/cfnlint/runner/cli.py
@@ -284,11 +284,27 @@ class Runner:
         if self.config.listrules:
             print(self.rules)
             sys.exit(0)
+        
         if self.config.listtemplates:
             if not self.config.templates:
                 print("None")
-            else:
-                print("\n".join(self.config.templates))
+                sys.exit(0)
+            
+            # Separate directories and files
+            directories = []
+            files = []
+            for template in self.config.templates:
+                if os.path.isdir(template):
+                    directories.append(f"not a file: {template}")
+                else:
+                    files.append(template)
+            
+            # Print directories first, then files
+            for msg in directories:
+                print(msg)
+            for file in files:
+                print(file)
+            
             sys.exit(0)
 
         # Use centralized configuration validation

--- a/test/unit/module/config/test_cli_args.py
+++ b/test/unit/module/config/test_cli_args.py
@@ -5,6 +5,7 @@ SPDX-License-Identifier: MIT-0
 
 import logging
 import os
+import subprocess
 from test.testlib.testcase import BaseTestCase
 from unittest.mock import patch
 
@@ -143,3 +144,124 @@ class TestArgsParser(BaseTestCase):
             with patch("sys.stderr", devnull):
                 with self.assertRaises(SystemExit):
                     cfnlint.config.CliArgs(["--non-zero-exit-code", "bad"])
+    
+    def test_list_templates_none(self):
+        """Test that --list-templates prints 'None' and exits cleanly"""
+
+        args = ["--list-templates"]
+
+        # Test the CLI argument parsing for --list-templates
+        config = cfnlint.config.CliArgs(args)
+        self.assertEqual(config.cli_args.listtemplates, True)
+        self.assertEqual(config.cli_args.templates, [])
+        self.assertEqual(config.cli_args.template_alt, [])
+
+        # Run cfn-lint and validate the output
+        result = subprocess.run(
+            ['cfn-lint', *args],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True
+        )
+
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stdout.strip(), 'None')
+
+    def test_list_templates_files_only(self):
+        """Test that --list-templates prints the file names"""
+
+        args = [
+            "--list-templates", 
+            "-t", "test/fixtures/templates/public/lambda-poller.yaml",
+            "-t", "test/fixtures/templates/public/rds-cluster.yaml"
+        ]
+
+        # Test the CLI argument parsing for --list-templates with multiple templates
+        config = cfnlint.config.CliArgs(args)
+        self.assertEqual(config.cli_args.listtemplates, True)
+        self.assertEqual(config.cli_args.templates, [])
+        self.assertEqual(config.cli_args.template_alt, [
+            "test/fixtures/templates/public/lambda-poller.yaml", 
+            "test/fixtures/templates/public/rds-cluster.yaml"
+        ])
+
+        # Run cfn-lint and validate the output
+        result = subprocess.run(
+            ['cfn-lint', *args],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True
+        )
+
+        expected_output = (
+            'test/fixtures/templates/public/lambda-poller.yaml\n'
+            'test/fixtures/templates/public/rds-cluster.yaml'
+        )
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stdout.strip(), expected_output)
+
+    def test_list_templates_directories_only(self):
+        """Test that --list-templates prints directory warnings"""
+
+        pwd = os.getcwd()
+        args = [
+            "--list-templates", 
+            "-t", pwd # Current directory
+        ]
+
+        # Test the CLI argument parsing for --list-templates with multiple templates
+        config = cfnlint.config.CliArgs(args)
+        self.assertEqual(config.cli_args.listtemplates, True)
+        self.assertEqual(config.cli_args.templates, [])
+        self.assertEqual(config.cli_args.template_alt, [pwd])
+
+        # Run cfn-lint and validate the output
+        result = subprocess.run(
+            ['cfn-lint', *args],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True
+        )
+
+        expected_output = 'not a file: {}'.format(pwd)
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stdout.strip(), expected_output)
+
+    def test_list_templates_files_and_directories(self):
+        """Test that --list-templates prints file names and directory warnings"""
+        
+        template1 = "test/fixtures/templates/public/lambda-poller.yaml"
+        template2 = "test/fixtures/templates/public/rds-cluster.yaml"
+        pwd = os.getcwd()
+        args = [
+            "--list-templates", 
+            "-t", template1,
+            "-t", template2,
+            "-t", pwd # Current directory
+        ]
+
+        # Test the CLI argument parsing for --list-templates with multiple templates
+        config = cfnlint.config.CliArgs(args)
+        self.assertEqual(config.cli_args.listtemplates, True)
+        self.assertEqual(config.cli_args.templates, [])
+        self.assertEqual(config.cli_args.template_alt, [
+            template1,
+            template2,
+            pwd
+        ])
+
+        # Run cfn-lint and validate the output
+        result = subprocess.run(
+            ['cfn-lint', *args],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True
+        )
+
+        expected_output = (
+            f'not a file: {pwd}\n'
+            f'{template1}\n'
+            f'{template2}'
+        )
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stdout.strip(), expected_output)


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Adds improved handling of directories in the output of --list-templates:

```shell
$ cfn-lint --list-templates -t template1.yaml -t template2.yaml -t $PWD
not a file: /home/user/build/mystack
template1.yaml
template2.yaml
$
```

I'm not sure how to implement the testing out cfn-lint output in the unit tests, other than running cfn-lint itself. More than happy to take advice on this.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
