### PR TITLE
Replace ConfigMixIn with dataclass implementation

### DIFF
--- a/src/cfnlint/runner/template/runner.py
+++ b/src/cfnlint/runner/template/runner.py
@@ -115,9 +115,14 @@ def _run_template(
 
         return
 
-    config.set_template_args(template)
-    cfn = Template(filename, template, config.regions, config.parameters)
-    yield from _dedup(_run_template_per_config(cfn, config, rules))
+    config_with_template = config.with_template_args(template)
+    cfn = Template(
+        filename,
+        template,
+        config_with_template.regions,
+        config_with_template.parameters,
+    )
+    yield from _dedup(_run_template_per_config(cfn, config_with_template, rules))
 
 
 def run_template_by_file_path(
@@ -209,7 +214,8 @@ def run_template_by_file_paths(config: ConfigMixIn, rules: Rules) -> Iterator[Ma
             mandatory_rules=config.mandatory_checks,
         ):
             ignore_bad_template = True
-    for filename in config.templates:
-        yield from run_template_by_file_path(
-            filename, config, rules, ignore_bad_template
-        )
+    if config.templates:
+        for filename in config.templates:
+            yield from run_template_by_file_path(
+                filename, config, rules, ignore_bad_template
+            )

--- a/test/integration/__init__.py
+++ b/test/integration/__init__.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from typing import Any, Dict, List
 from unittest.mock import patch
 
-from cfnlint.config import configure_logging
+from cfnlint.config import ConfigMixIn, configure_logging
 from cfnlint.decode import cfn_yaml
 from cfnlint.formatters import JsonFormatter
 from cfnlint.runner import Runner
@@ -106,10 +106,14 @@ class BaseCliTestCase(unittest.TestCase):
             for result in expected_results:
                 result["Filename"] = str(Path(result.get("Filename")))
 
-            # template = cfn_yaml.load(filename)
-            scenario_config = deepcopy(config)
-            scenario_config.cli_args.template_alt = [filename]
-            scenario_config.cli_args.format = "json"
+            # Create a new config with the format set correctly from the start
+            scenario_config = ConfigMixIn(
+                ["-f", "json", "-t", filename],
+                include_checks=config.include_checks,
+                ignore_checks=config.ignore_checks,
+                configure_rules=config.configure_rules,
+                include_experimental=config.include_experimental,
+            )
 
             runner = Runner(scenario_config)
 

--- a/test/unit/module/config/test_cli_args.py
+++ b/test/unit/module/config/test_cli_args.py
@@ -143,3 +143,19 @@ class TestArgsParser(BaseTestCase):
             with patch("sys.stderr", devnull):
                 with self.assertRaises(SystemExit):
                     cfnlint.config.CliArgs(["--non-zero-exit-code", "bad"])
+
+    def test_parameters_single(self):
+        """Test parsing single parameter"""
+        config = cfnlint.config.CliArgs(["--parameters", "Foo=Bar"])
+        self.assertEqual(config.cli_args.parameters, [{"Foo": "Bar"}])
+
+    def test_parameters_multiple(self):
+        """Test parsing multiple parameters"""
+        config = cfnlint.config.CliArgs(["--parameters", "A=1", "B=2"])
+        self.assertEqual(config.cli_args.parameters, [{"A": "1", "B": "2"}])
+
+    def test_parameters_bad_format(self):
+        """Test error handling for bad parameter format"""
+        with patch("sys.exit") as exit:
+            cfnlint.config.CliArgs(["--parameters", "A"])
+            exit.assert_called_once_with(1)

--- a/test/unit/module/formatters/test_formatters.py
+++ b/test/unit/module/formatters/test_formatters.py
@@ -206,9 +206,10 @@ class TestFormatters(BaseTestCase):
         """Test pretty formatter"""
         isatty_mock.return_value = True
         formatter = PrettyFormatter()
-        self.config.cli_args.templates = None
+        # Create a config with no templates to test formatter behavior
+        config_no_templates = ConfigMixIn([])
         results = formatter.print_matches(
-            self.results, rules=self.rules, config=self.config
+            self.results, rules=self.rules, config=config_no_templates
         ).splitlines()
 
         if sys.stdout.isatty():


### PR DESCRIPTION
- Convert ConfixMixIn to frozen dataclass
- Use functools.cached_property for automatic caching

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
