### PR TITLE
Update nodejs18.x lifecycle dates in LmbdRuntimeLifecycle.json to match official AWS Docs

### DIFF
--- a/src/cfnlint/data/AdditionalSpecs/LmbdRuntimeLifecycle.json
+++ b/src/cfnlint/data/AdditionalSpecs/LmbdRuntimeLifecycle.json
@@ -78,10 +78,10 @@
   "update-block": "2025-11-01"
  },
  "nodejs18.x": {
-  "create-block": "2025-10-01",
-  "deprecated": "2025-07-31",
+  "create-block": "2026-02-03",
+  "deprecated": "2025-09-01",
   "successor": "nodejs22.x",
-  "update-block": "2025-11-01"
+  "update-block": "2026-03-09"
  },
  "nodejs4.3": {
   "create-block": "2020-03-05",


### PR DESCRIPTION
*Issue #, if available:*  
[issue #4249](https://github.com/aws-cloudformation/cfn-lint/issues/4249)

*Description of changes:*  
This pull request updates the deprecation and lifecycle dates for the `nodejs18.x` Lambda runtime in the `LmbdRuntimeLifecycle.json` file based on the dates listed in the [official AWS docs](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html#runtimes-deprecated).

- **Lambda Runtime Lifecycle Updates:**
  * Updated the `create-block` date for `nodejs18.x` to `2026-02-03`
  * Changed the `deprecated` date for `nodejs18.x` to `2025-09-01`
  * Updated the `update-block` date for `nodejs18.x` to `2026-03-09`

*Verification:*  
A simple CloudFormation template was used to validate the new lifecycle dates:

```yaml
AWSTemplateFormatVersion: '2010-09-09'
Description: Updated Lambda function with Node.js 18.x

Resources:
  TestFunction:
    Type: AWS::Lambda::Function
    Properties:
      FunctionName: test-node18-runtime
      Handler: index.handler
      Role: arn:aws:iam::123456789012:role/dummy-lambda-role
      Code:
        ZipFile: |
          exports.handler = async (event) => {
            return { statusCode: 200, body: "Hello from Node.js 18.x (updated)" };
          };
      Runtime: nodejs18.x
      Timeout: 5
```

Running cfn-lint against this template now shows the corrected AWS official dates:
```
(venv) ➜  cfn-lint git:(issue-4249-fix-node18-dates) ✗ ./venv/bin/cfn-lint -t test-template.yml
W2531 Runtime 'nodejs18.x' was deprecated on '2025-09-01'. Creation was disabled on '2026-02-03' and update on '2026-03-09'. Please consider updating to 'nodejs22.x'
test-template.yml:16:7
```