### PR TITLE
State Machine Unit Test: Fix StartAt typo

### DIFF
--- a/test/unit/rules/resources/stepfunctions/test_state_machine_definition.py
+++ b/test/unit/rules/resources/stepfunctions/test_state_machine_definition.py
@@ -779,7 +779,7 @@ def rule():
                         "Language for notification on an "
                         "AWS Batch job completion"
                     ),
-                    "StartAt": "Submit Batch Job",
+                    "StartAt": "Submit Batch Job 1",
                     "TimeoutSeconds": 3600,
                     "States": {
                         "Submit Batch Job 1": {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

While working on https://github.com/aws-cloudformation/cfn-lint/issues/4074 i noticed a typo in a unit test.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
