### PR TITLE
State Machine Unit Test: Fix another StartAt typo

### DIFF
--- a/test/unit/rules/resources/stepfunctions/test_state_machine_definition.py
+++ b/test/unit/rules/resources/stepfunctions/test_state_machine_definition.py
@@ -1087,7 +1087,7 @@ def rule():
                         "Language for notification on an "
                         "AWS Batch job completion"
                     ),
-                    "StartAt": "Submit Batch Job",
+                    "StartAt": "Submit Batch Job 1",
                     "TimeoutSeconds": 3600,
                     "QueryLanguage": "JSONata",
                     "States": {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

In preparation of https://github.com/aws-cloudformation/cfn-lint/issues/4074 i found another typo in the State Machine UnitTest, which somehow slipped through in my previous PR https://github.com/aws-cloudformation/cfn-lint/pull/4251

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
