### PR TITLE
add eusc-de-east-1 to AVAILABILITY_ZONES

### DIFF
--- a/src/cfnlint/helpers.py
+++ b/src/cfnlint/helpers.py
@@ -123,6 +123,8 @@ AVAILABILITY_ZONES = {
     "us-gov-west-1": ["us-gov-west-1a", "us-gov-west-1b", "us-gov-west-1c"],
     "us-west-1": ["us-west-1a", "us-west-1c"],
     "us-west-2": ["us-west-2a", "us-west-2b", "us-west-2c", "us-west-2d"],
+    # Sovereign regions
+    "eusc-de-east-1": ["eusc-de-east-1a", "eusc-de-east-1b", "eusc-de-east-1c"],
     # Isolated regions
     "us-iso-east-1": ["us-iso-east-1a", "us-iso-east-1b", "us-iso-east-1c"],
     "us-iso-west-1": ["us-iso-west-1a", "us-iso-west-1b", "us-iso-west-1c"],


### PR DESCRIPTION
*Issue #, if available:*
#4262 

*Description of changes:*
Adding support for upcoming eusc-de-east-1 region.
Note that this does not pass tests as `src/cfnlint/data/schemas/providers/eusc_de_east_1` still needs to be populated but I do not know how. I was asked to make the PR to show what changes I made and which tests are failing.
See the full output of tests in the first comment.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
