### PR TITLE
Fix Step Functions StartAt path resolution in Parallel branches

### DIFF
--- a/src/cfnlint/rules/resources/stepfunctions/StateMachineDefinition.py
+++ b/src/cfnlint/rules/resources/stepfunctions/StateMachineDefinition.py
@@ -138,7 +138,10 @@ class StateMachineDefinition(CfnLintJsonSchema):
             yield ValidationError(message, path=error_path, rule=self)
 
         # Validate nested StartAt in Parallel and Map states
+        base_path = deque() if path is None else deque(path)
         for state_name, state in states.items():
+            if not isinstance(state, dict):
+                continue
             state_type = state.get("Type")
 
             if state_type == "Parallel":
@@ -146,7 +149,8 @@ class StateMachineDefinition(CfnLintJsonSchema):
                 if not isinstance(branches, list):
                     continue
                 for idx, branch in enumerate(branches):
-                    branch_path = deque(["States", state_name, "Branches", idx])
+                    branch_path = deque(base_path)
+                    branch_path.extend(["States", state_name, "Branches", idx])
                     yield from self._validate_start_at(
                         branch, k, add_path_to_message, branch_path
                     )
@@ -155,14 +159,16 @@ class StateMachineDefinition(CfnLintJsonSchema):
                 # ItemProcessor (distributed/inline mode)
                 processor = state.get("ItemProcessor")
                 if isinstance(processor, dict):
-                    processor_path = deque(["States", state_name, "ItemProcessor"])
+                    processor_path = deque(base_path)
+                    processor_path.extend(["States", state_name, "ItemProcessor"])
                     yield from self._validate_start_at(
                         processor, k, add_path_to_message, processor_path
                     )
                 # Iterator (classic map)
                 iterator = state.get("Iterator")
                 if isinstance(iterator, dict):
-                    iterator_path = deque(["States", state_name, "Iterator"])
+                    iterator_path = deque(base_path)
+                    iterator_path.extend(["States", state_name, "Iterator"])
                     yield from self._validate_start_at(
                         iterator, k, add_path_to_message, iterator_path
                     )

--- a/test/unit/rules/resources/stepfunctions/test_state_machine_definition.py
+++ b/test/unit/rules/resources/stepfunctions/test_state_machine_definition.py
@@ -1420,6 +1420,65 @@ def rule():
             ],
         ),
         (
+            "Parallel state with Map/ItemProcessor missing StartAt target",
+            {
+                "Definition": {
+                    "StartAt": "ParallelExecution",
+                    "States": {
+                        "ParallelExecution": {
+                            "Type": "Parallel",
+                            "Branches": [
+                                {
+                                    "StartAt": "Pass1",
+                                    "States": {"Pass1": {"Type": "Pass", "End": True}},
+                                },
+                                {
+                                    "StartAt": "TestMap",
+                                    "States": {
+                                        "TestMap": {
+                                            "Type": "Map",
+                                            "ItemsPath": "$",
+                                            "ItemProcessor": {
+                                                "ProcessorConfig": {"Mode": "INLINE"},
+                                                "StartAt": "FAIL",
+                                                "States": {
+                                                    "Pass2": {
+                                                        "Type": "Pass",
+                                                        "End": True,
+                                                    }
+                                                },
+                                            },
+                                            "End": True,
+                                        }
+                                    },
+                                },
+                            ],
+                            "End": True,
+                        }
+                    },
+                }
+            },
+            [
+                ValidationError(
+                    "Missing 'Next' target 'FAIL' at /States/ParallelExecution/Branches/1/States/TestMap/ItemProcessor/StartAt",
+                    rule=StateMachineDefinition(),
+                    path=deque(
+                        [
+                            "Definition",
+                            "States",
+                            "ParallelExecution",
+                            "Branches",
+                            1,
+                            "States",
+                            "TestMap",
+                            "ItemProcessor",
+                            "StartAt",
+                        ]
+                    ),
+                ),
+            ],
+        ),
+        (
             "Map state with missing StartAt target in ItemProcessor",
             {
                 "Definition": {


### PR DESCRIPTION
# Issue #4311 

# Description of changes:

This PR improves StartAt validation for Step Functions Parallel states.
- When a StartAt target is missing inside a Parallel state branch (Branches[n]), cfn-lint now reports the correct nested location/path.
- Adds a unit test to cover a Parallel branch with a missing StartAt target, ensuring the error message and path match the expected .../States/<ParallelState>/Branches/<index>/StartAt structure.

**Note**: This PR is based on PR #4308. It would be helpful if you could review #4308 first, since this PR builds on top of it.