### PR TITLE
SecurityGroupIds can take a name from a default VPC

### DIFF
--- a/scripts/update_schemas_format.py
+++ b/scripts/update_schemas_format.py
@@ -260,11 +260,21 @@ _manual_patches = {
             path="/properties/SecurityGroups/items",
         ),
         Patch(
-            values={"format": "AWS::EC2::SecurityGroup.Ids"},
+            values={
+                "anyOf": [
+                    {"format": "AWS::EC2::SecurityGroup.Ids"},
+                    {"format": "AWS::EC2::SecurityGroup.Names"},
+                ]
+            },
             path="/properties/SecurityGroupIds",
         ),
         Patch(
-            values={"format": "AWS::EC2::SecurityGroup.Id"},
+            values={
+                "anyOf": [
+                    {"format": "AWS::EC2::SecurityGroup.Id"},
+                    {"format": "AWS::EC2::SecurityGroup.Name"},
+                ]
+            },
             path="/properties/SecurityGroupIds/items",
         ),
         Patch(

--- a/src/cfnlint/data/schemas/patches/extensions/all/aws_ec2_instance/format.json
+++ b/src/cfnlint/data/schemas/patches/extensions/all/aws_ec2_instance/format.json
@@ -21,13 +21,27 @@
  },
  {
   "op": "add",
-  "path": "/properties/SecurityGroupIds/format",
-  "value": "AWS::EC2::SecurityGroup.Ids"
+  "path": "/properties/SecurityGroupIds/anyOf",
+  "value": [
+   {
+    "format": "AWS::EC2::SecurityGroup.Ids"
+   },
+   {
+    "format": "AWS::EC2::SecurityGroup.Names"
+   }
+  ]
  },
  {
   "op": "add",
-  "path": "/properties/SecurityGroupIds/items/format",
-  "value": "AWS::EC2::SecurityGroup.Id"
+  "path": "/properties/SecurityGroupIds/items/anyOf",
+  "value": [
+   {
+    "format": "AWS::EC2::SecurityGroup.Id"
+   },
+   {
+    "format": "AWS::EC2::SecurityGroup.Name"
+   }
+  ]
  },
  {
   "op": "add",

--- a/src/cfnlint/data/schemas/resources/51763c48d327df98.json
+++ b/src/cfnlint/data/schemas/resources/51763c48d327df98.json
@@ -1738,10 +1738,24 @@
    "type": "string"
   },
   "SecurityGroupIds": {
-   "format": "AWS::EC2::SecurityGroup.Ids",
+   "anyOf": [
+    {
+     "format": "AWS::EC2::SecurityGroup.Ids"
+    },
+    {
+     "format": "AWS::EC2::SecurityGroup.Names"
+    }
+   ],
    "insertionOrder": false,
    "items": {
-    "format": "AWS::EC2::SecurityGroup.Id",
+    "anyOf": [
+     {
+      "format": "AWS::EC2::SecurityGroup.Id"
+     },
+     {
+      "format": "AWS::EC2::SecurityGroup.Name"
+     }
+    ],
     "type": "string"
    },
    "type": "array",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- SecurityGroupIds can take a name from a default VPC

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
