### PR TITLE
Update Lambda runtime lifecycle data with latest AWS runtimes

### DIFF
--- a/src/cfnlint/data/AdditionalSpecs/LmbdRuntimeLifecycle.json
+++ b/src/cfnlint/data/AdditionalSpecs/LmbdRuntimeLifecycle.json
@@ -1,152 +1,266 @@
 {
  "dotnet6": {
-  "create-block": "2025-10-01",
-  "deprecated": "2024-11-12",
-  "successor": "dotnet8",
-  "update-block": "2025-11-01"
+  "create-block": "2026-06-01",
+  "deprecated": "2024-12-20",
+  "successor": "dotnet9",
+  "update-block": "2026-07-01"
  },
- "dotnet7": {
-  "create-block": "2024-05-14",
-  "deprecated": "2024-05-14",
-  "successor": "dotnet8",
-  "update-block": "2024-05-14"
+ "dotnet8": {
+  "create-block": "2026-12-10",
+  "deprecated": "2026-11-10",
+  "successor": "dotnet9",
+  "update-block": "2027-01-11"
  },
  "dotnetcore1.0": {
-  "create-block": "2019-07-30",
+  "create-block": "2019-06-30",
   "deprecated": "2019-06-27",
-  "successor": "dotnet8",
+  "successor": "dotnet9",
   "update-block": "2019-07-30"
  },
  "dotnetcore2.0": {
-  "create-block": "2019-05-30",
+  "create-block": "2019-04-30",
   "deprecated": "2019-05-30",
-  "successor": "dotnet8",
+  "successor": "dotnet9",
   "update-block": "2019-05-30"
  },
  "dotnetcore2.1": {
   "create-block": "2022-01-05",
   "deprecated": "2022-01-05",
-  "successor": "dotnet8",
+  "successor": "dotnet9",
   "update-block": "2022-04-13"
  },
  "dotnetcore3.1": {
   "create-block": "2023-04-03",
   "deprecated": "2023-04-03",
-  "successor": "dotnet8",
+  "successor": "dotnet9",
   "update-block": "2023-05-03"
  },
  "go1.x": {
   "create-block": "2024-02-08",
   "deprecated": "2024-01-08",
   "successor": "provided.al2023",
-  "update-block": "2025-11-01"
+  "update-block": "2026-07-01"
+ },
+ "java11": {
+  "create-block": "2026-07-31",
+  "deprecated": "2026-06-30",
+  "successor": "java25",
+  "update-block": "2026-08-31"
+ },
+ "java17": {
+  "create-block": "2026-07-31",
+  "deprecated": "2026-06-30",
+  "successor": "java25",
+  "update-block": "2026-08-31"
+ },
+ "java21": {
+  "create-block": "2029-07-31",
+  "deprecated": "2029-06-30",
+  "successor": "java25",
+  "update-block": "2029-08-31"
+ },
+ "java25": {
+  "create-block": "2029-07-31",
+  "deprecated": "2029-06-30",
+  "successor": null,
+  "update-block": "2029-08-31"
  },
  "java8": {
   "create-block": "2024-02-08",
   "deprecated": "2024-01-08",
-  "successor": "java21",
-  "update-block": "2025-11-01"
+  "successor": "java25",
+  "update-block": "2026-07-01"
+ },
+ "java8.al2": {
+  "create-block": "2026-07-31",
+  "deprecated": "2026-06-30",
+  "successor": "java25",
+  "update-block": "2026-08-31"
  },
  "nodejs": {
-  "create-block": "2016-10-31",
-  "deprecated": "2016-10-31",
-  "successor": "nodejs22.x",
+  "create-block": "2016-09-30",
+  "deprecated": "2016-08-30",
+  "successor": "nodejs24.x",
   "update-block": "2016-10-31"
  },
  "nodejs10.x": {
   "create-block": "2021-07-30",
   "deprecated": "2021-07-30",
-  "successor": "nodejs22.x",
+  "successor": "nodejs24.x",
   "update-block": "2022-02-14"
  },
  "nodejs12.x": {
   "create-block": "2023-03-31",
   "deprecated": "2023-03-31",
-  "successor": "nodejs22.x",
+  "successor": "nodejs24.x",
   "update-block": "2023-04-30"
  },
  "nodejs14.x": {
-  "create-block": "2024-07-09",
+  "create-block": "2024-01-09",
   "deprecated": "2023-12-04",
-  "successor": "nodejs22.x",
-  "update-block": "2025-11-01"
+  "successor": "nodejs24.x",
+  "update-block": "2026-07-01"
  },
  "nodejs16.x": {
-  "create-block": "2025-10-01",
+  "create-block": "2026-06-01",
   "deprecated": "2024-06-12",
-  "successor": "nodejs22.x",
-  "update-block": "2025-11-01"
+  "successor": "nodejs24.x",
+  "update-block": "2026-07-01"
  },
  "nodejs18.x": {
-  "create-block": "2026-02-03",
+  "create-block": "2026-06-01",
   "deprecated": "2025-09-01",
-  "successor": "nodejs22.x",
-  "update-block": "2026-03-09"
+  "successor": "nodejs24.x",
+  "update-block": "2026-07-01"
+ },
+ "nodejs20.x": {
+  "create-block": "2026-06-01",
+  "deprecated": "2026-04-30",
+  "successor": "nodejs24.x",
+  "update-block": "2026-07-01"
+ },
+ "nodejs22.x": {
+  "create-block": "2027-06-01",
+  "deprecated": "2027-04-30",
+  "successor": "nodejs24.x",
+  "update-block": "2027-07-01"
+ },
+ "nodejs24.x": {
+  "create-block": "2028-06-01",
+  "deprecated": "2028-04-30",
+  "successor": null,
+  "update-block": "2028-07-01"
  },
  "nodejs4.3": {
-  "create-block": "2020-03-05",
+  "create-block": "2020-02-03",
   "deprecated": "2020-03-05",
-  "successor": "nodejs22.x",
+  "successor": "nodejs24.x",
   "update-block": "2020-03-05"
  },
  "nodejs4.3-edge": {
-  "create-block": "2019-04-30",
+  "create-block": "2019-03-31",
   "deprecated": "2020-03-05",
-  "successor": "nodejs22.x",
+  "successor": "nodejs24.x",
   "update-block": "2019-04-30"
  },
  "nodejs6.10": {
-  "create-block": "2019-08-12",
+  "create-block": "2019-07-12",
   "deprecated": "2019-08-12",
-  "successor": "nodejs22.x",
+  "successor": "nodejs24.x",
   "update-block": "2019-08-12"
  },
  "nodejs8.10": {
-  "create-block": "2020-03-06",
+  "create-block": "2020-02-04",
   "deprecated": "2020-03-06",
-  "successor": "nodejs22.x",
+  "successor": "nodejs24.x",
   "update-block": "2020-03-06"
  },
  "provided": {
   "create-block": "2024-02-08",
   "deprecated": "2024-01-08",
   "successor": "provided.al2023",
-  "update-block": "2025-11-01"
+  "update-block": "2026-07-01"
+ },
+ "provided.al2": {
+  "create-block": "2026-07-31",
+  "deprecated": "2026-06-30",
+  "successor": "provided.al2023",
+  "update-block": "2026-08-31"
+ },
+ "provided.al2023": {
+  "create-block": "2029-07-31",
+  "deprecated": "2029-06-30",
+  "successor": null,
+  "update-block": "2029-08-31"
  },
  "python2.7": {
   "create-block": "2021-07-15",
   "deprecated": "2021-07-15",
-  "successor": "python3.13",
+  "successor": "python3.14",
   "update-block": "2022-05-30"
+ },
+ "python3.10": {
+  "create-block": "2026-07-31",
+  "deprecated": "2026-06-30",
+  "successor": "python3.14",
+  "update-block": "2026-08-31"
+ },
+ "python3.11": {
+  "create-block": "2026-07-31",
+  "deprecated": "2026-06-30",
+  "successor": "python3.14",
+  "update-block": "2026-08-31"
+ },
+ "python3.12": {
+  "create-block": "2028-11-30",
+  "deprecated": "2028-10-31",
+  "successor": "python3.14",
+  "update-block": "2029-01-10"
+ },
+ "python3.13": {
+  "create-block": "2029-07-31",
+  "deprecated": "2029-06-30",
+  "successor": "python3.14",
+  "update-block": "2029-08-31"
+ },
+ "python3.14": {
+  "create-block": "2029-07-31",
+  "deprecated": "2029-06-30",
+  "successor": null,
+  "update-block": "2029-08-31"
  },
  "python3.6": {
   "create-block": "2022-07-18",
   "deprecated": "2022-07-18",
-  "successor": "python3.13",
+  "successor": "python3.14",
   "update-block": "2022-08-29"
  },
  "python3.7": {
   "create-block": "2024-01-09",
   "deprecated": "2023-12-04",
-  "successor": "python3.13",
-  "update-block": "2025-11-01"
+  "successor": "python3.14",
+  "update-block": "2026-03-09"
  },
  "python3.8": {
-  "create-block": "2025-10-01",
+  "create-block": "2026-06-01",
   "deprecated": "2024-10-14",
-  "successor": "python3.13",
-  "update-block": "2025-11-01"
+  "successor": "python3.14",
+  "update-block": "2026-07-01"
+ },
+ "python3.9": {
+  "create-block": "2026-06-01",
+  "deprecated": "2025-12-15",
+  "successor": "python3.14",
+  "update-block": "2026-07-01"
  },
  "ruby2.5": {
   "create-block": "2021-07-30",
   "deprecated": "2021-07-30",
-  "successor": "ruby3.2",
+  "successor": "ruby3.4",
   "update-block": "2022-03-31"
  },
  "ruby2.7": {
   "create-block": "2024-01-09",
   "deprecated": "2023-12-07",
-  "successor": "ruby3.2",
-  "update-block": "2025-11-01"
+  "successor": "ruby3.4",
+  "update-block": "2026-07-01"
+ },
+ "ruby3.2": {
+  "create-block": "2026-06-01",
+  "deprecated": "2026-03-31",
+  "successor": "ruby3.4",
+  "update-block": "2026-07-01"
+ },
+ "ruby3.3": {
+  "create-block": "2027-04-30",
+  "deprecated": "2027-03-31",
+  "successor": "ruby3.4",
+  "update-block": "2027-05-31"
+ },
+ "ruby3.4": {
+  "create-block": "2028-04-30",
+  "deprecated": "2028-03-31",
+  "successor": null,
+  "update-block": "2028-05-31"
  }
 }

--- a/test/fixtures/results/public/lambda-poller.json
+++ b/test/fixtures/results/public/lambda-poller.json
@@ -1,7 +1,7 @@
 [
     {
         "Filename": "test/fixtures/templates/public/lambda-poller.yaml",
-        "Id": "7323f9f0-0245-2b9f-4a1c-ce279bd36988",
+        "Id": "746cb432-12f9-7d28-65e4-d390dea55df6",
         "Level": "Error",
         "Location": {
             "End": {
@@ -19,7 +19,7 @@
                 "LineNumber": 151
             }
         },
-        "Message": "Runtime 'nodejs6.10' was deprecated on '2019-08-12'. Creation was disabled on '2019-08-12' and update on '2019-08-12'. Please consider updating to 'nodejs22.x'",
+        "Message": "Runtime 'nodejs6.10' was deprecated on '2019-08-12'. Creation was disabled on '2019-07-12' and update on '2019-08-12'. Please consider updating to 'nodejs24.x'",
         "ParentId": null,
         "Rule": {
             "Description": "Check if an EOL Lambda Runtime is specified and you cannot update the function",

--- a/test/fixtures/results/quickstart/cis_benchmark.json
+++ b/test/fixtures/results/quickstart/cis_benchmark.json
@@ -30,8 +30,8 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/cis_benchmark.yaml",
-        "Id": "81390465-4bbb-3762-7d80-b63140c6f3b4",
-        "Level": "Error",
+        "Id": "89700488-9e01-d6a1-50c8-63305524dd97",
+        "Level": "Warning",
         "Location": {
             "End": {
                 "ColumnNumber": 16,
@@ -48,12 +48,12 @@
                 "LineNumber": 176
             }
         },
-        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2025-10-01' and update on '2025-11-01'. Please consider updating to 'python3.13'",
+        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2026-06-01' and update on '2026-07-01'. Please consider updating to 'python3.14'",
         "ParentId": null,
         "Rule": {
-            "Description": "Check if an EOL Lambda Runtime is specified and you cannot update the function",
-            "Id": "E2533",
-            "ShortDescription": "Check if Lambda Function Runtimes are updatable",
+            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Id": "W2531",
+            "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
             "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
         }
     },
@@ -116,8 +116,8 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/cis_benchmark.yaml",
-        "Id": "2c9690c6-5552-1893-8a37-b46a03ab90b2",
-        "Level": "Error",
+        "Id": "306a5b5f-5a34-7d43-12bd-b6d16e14e8a6",
+        "Level": "Warning",
         "Location": {
             "End": {
                 "ColumnNumber": 16,
@@ -134,12 +134,12 @@
                 "LineNumber": 309
             }
         },
-        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2025-10-01' and update on '2025-11-01'. Please consider updating to 'python3.13'",
+        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2026-06-01' and update on '2026-07-01'. Please consider updating to 'python3.14'",
         "ParentId": null,
         "Rule": {
-            "Description": "Check if an EOL Lambda Runtime is specified and you cannot update the function",
-            "Id": "E2533",
-            "ShortDescription": "Check if Lambda Function Runtimes are updatable",
+            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Id": "W2531",
+            "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
             "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
         }
     },
@@ -202,8 +202,8 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/cis_benchmark.yaml",
-        "Id": "e05317c1-3187-89b6-b3b5-10df6823bd46",
-        "Level": "Error",
+        "Id": "85ece31c-5811-377a-5555-e04a8b5d2b7d",
+        "Level": "Warning",
         "Location": {
             "End": {
                 "ColumnNumber": 16,
@@ -220,12 +220,12 @@
                 "LineNumber": 481
             }
         },
-        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2025-10-01' and update on '2025-11-01'. Please consider updating to 'python3.13'",
+        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2026-06-01' and update on '2026-07-01'. Please consider updating to 'python3.14'",
         "ParentId": null,
         "Rule": {
-            "Description": "Check if an EOL Lambda Runtime is specified and you cannot update the function",
-            "Id": "E2533",
-            "ShortDescription": "Check if Lambda Function Runtimes are updatable",
+            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Id": "W2531",
+            "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
             "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
         }
     },
@@ -288,8 +288,8 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/cis_benchmark.yaml",
-        "Id": "757eba91-f901-9ecd-e38c-2065d11a3732",
-        "Level": "Error",
+        "Id": "41835feb-7885-884d-cdc0-7b6f21ff3419",
+        "Level": "Warning",
         "Location": {
             "End": {
                 "ColumnNumber": 16,
@@ -306,12 +306,12 @@
                 "LineNumber": 551
             }
         },
-        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2025-10-01' and update on '2025-11-01'. Please consider updating to 'python3.13'",
+        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2026-06-01' and update on '2026-07-01'. Please consider updating to 'python3.14'",
         "ParentId": null,
         "Rule": {
-            "Description": "Check if an EOL Lambda Runtime is specified and you cannot update the function",
-            "Id": "E2533",
-            "ShortDescription": "Check if Lambda Function Runtimes are updatable",
+            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Id": "W2531",
+            "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
             "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
         }
     },
@@ -432,8 +432,8 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/cis_benchmark.yaml",
-        "Id": "704b0f38-b87d-49d2-f343-a71ef26b8c78",
-        "Level": "Error",
+        "Id": "3fe278d9-8d2b-7c11-8c5b-bf713403de82",
+        "Level": "Warning",
         "Location": {
             "End": {
                 "ColumnNumber": 16,
@@ -450,12 +450,12 @@
                 "LineNumber": 666
             }
         },
-        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2025-10-01' and update on '2025-11-01'. Please consider updating to 'python3.13'",
+        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2026-06-01' and update on '2026-07-01'. Please consider updating to 'python3.14'",
         "ParentId": null,
         "Rule": {
-            "Description": "Check if an EOL Lambda Runtime is specified and you cannot update the function",
-            "Id": "E2533",
-            "ShortDescription": "Check if Lambda Function Runtimes are updatable",
+            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Id": "W2531",
+            "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
             "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
         }
     },
@@ -518,8 +518,8 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/cis_benchmark.yaml",
-        "Id": "68ea4c26-b02b-0788-d816-f0eb52aa092a",
-        "Level": "Error",
+        "Id": "f68035e6-5bce-465a-519f-cab7d18abae2",
+        "Level": "Warning",
         "Location": {
             "End": {
                 "ColumnNumber": 16,
@@ -536,12 +536,12 @@
                 "LineNumber": 760
             }
         },
-        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2025-10-01' and update on '2025-11-01'. Please consider updating to 'python3.13'",
+        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2026-06-01' and update on '2026-07-01'. Please consider updating to 'python3.14'",
         "ParentId": null,
         "Rule": {
-            "Description": "Check if an EOL Lambda Runtime is specified and you cannot update the function",
-            "Id": "E2533",
-            "ShortDescription": "Check if Lambda Function Runtimes are updatable",
+            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Id": "W2531",
+            "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
             "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
         }
     },
@@ -633,8 +633,8 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/cis_benchmark.yaml",
-        "Id": "66986041-e66b-98a8-116b-d2e1902e8f27",
-        "Level": "Error",
+        "Id": "4e1e1b32-8cc2-3d91-0d46-2bac5291e212",
+        "Level": "Warning",
         "Location": {
             "End": {
                 "ColumnNumber": 16,
@@ -651,12 +651,12 @@
                 "LineNumber": 850
             }
         },
-        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2025-10-01' and update on '2025-11-01'. Please consider updating to 'python3.13'",
+        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2026-06-01' and update on '2026-07-01'. Please consider updating to 'python3.14'",
         "ParentId": null,
         "Rule": {
-            "Description": "Check if an EOL Lambda Runtime is specified and you cannot update the function",
-            "Id": "E2533",
-            "ShortDescription": "Check if Lambda Function Runtimes are updatable",
+            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Id": "W2531",
+            "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
             "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
         }
     },
@@ -748,8 +748,8 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/cis_benchmark.yaml",
-        "Id": "74e23491-7b14-a3ce-2491-6768bcd7b865",
-        "Level": "Error",
+        "Id": "71a9bc34-4254-bd7d-01c8-4a8c946578fd",
+        "Level": "Warning",
         "Location": {
             "End": {
                 "ColumnNumber": 16,
@@ -766,12 +766,12 @@
                 "LineNumber": 966
             }
         },
-        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2025-10-01' and update on '2025-11-01'. Please consider updating to 'python3.13'",
+        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2026-06-01' and update on '2026-07-01'. Please consider updating to 'python3.14'",
         "ParentId": null,
         "Rule": {
-            "Description": "Check if an EOL Lambda Runtime is specified and you cannot update the function",
-            "Id": "E2533",
-            "ShortDescription": "Check if Lambda Function Runtimes are updatable",
+            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Id": "W2531",
+            "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
             "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
         }
     },
@@ -863,8 +863,8 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/cis_benchmark.yaml",
-        "Id": "d52e9ac9-0aea-d7a5-29aa-bb59a818765d",
-        "Level": "Error",
+        "Id": "502768f5-0188-396b-8bdf-f31704f9d4f7",
+        "Level": "Warning",
         "Location": {
             "End": {
                 "ColumnNumber": 16,
@@ -881,12 +881,12 @@
                 "LineNumber": 1082
             }
         },
-        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2025-10-01' and update on '2025-11-01'. Please consider updating to 'python3.13'",
+        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2026-06-01' and update on '2026-07-01'. Please consider updating to 'python3.14'",
         "ParentId": null,
         "Rule": {
-            "Description": "Check if an EOL Lambda Runtime is specified and you cannot update the function",
-            "Id": "E2533",
-            "ShortDescription": "Check if Lambda Function Runtimes are updatable",
+            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Id": "W2531",
+            "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
             "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
         }
     },
@@ -978,8 +978,8 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/cis_benchmark.yaml",
-        "Id": "e2fce2c6-ee10-5735-d038-fe976eb6589c",
-        "Level": "Error",
+        "Id": "d89dbfee-7fbc-bc71-d76a-7503a02103b9",
+        "Level": "Warning",
         "Location": {
             "End": {
                 "ColumnNumber": 16,
@@ -996,12 +996,12 @@
                 "LineNumber": 1178
             }
         },
-        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2025-10-01' and update on '2025-11-01'. Please consider updating to 'python3.13'",
+        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2026-06-01' and update on '2026-07-01'. Please consider updating to 'python3.14'",
         "ParentId": null,
         "Rule": {
-            "Description": "Check if an EOL Lambda Runtime is specified and you cannot update the function",
-            "Id": "E2533",
-            "ShortDescription": "Check if Lambda Function Runtimes are updatable",
+            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Id": "W2531",
+            "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
             "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
         }
     },
@@ -1093,8 +1093,8 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/cis_benchmark.yaml",
-        "Id": "67ad084e-5cd7-b830-18d8-22b5c09ddcea",
-        "Level": "Error",
+        "Id": "beaf1813-b278-5516-a279-d808390eb29c",
+        "Level": "Warning",
         "Location": {
             "End": {
                 "ColumnNumber": 16,
@@ -1111,12 +1111,12 @@
                 "LineNumber": 1260
             }
         },
-        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2025-10-01' and update on '2025-11-01'. Please consider updating to 'python3.13'",
+        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2026-06-01' and update on '2026-07-01'. Please consider updating to 'python3.14'",
         "ParentId": null,
         "Rule": {
-            "Description": "Check if an EOL Lambda Runtime is specified and you cannot update the function",
-            "Id": "E2533",
-            "ShortDescription": "Check if Lambda Function Runtimes are updatable",
+            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Id": "W2531",
+            "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
             "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
         }
     },
@@ -1208,8 +1208,8 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/cis_benchmark.yaml",
-        "Id": "c5dd49e3-6488-d0af-fde2-ca230d0d92b2",
-        "Level": "Error",
+        "Id": "6898fb73-1dfe-1b57-abf0-5b89cb591517",
+        "Level": "Warning",
         "Location": {
             "End": {
                 "ColumnNumber": 16,
@@ -1226,12 +1226,12 @@
                 "LineNumber": 1357
             }
         },
-        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2025-10-01' and update on '2025-11-01'. Please consider updating to 'python3.13'",
+        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2026-06-01' and update on '2026-07-01'. Please consider updating to 'python3.14'",
         "ParentId": null,
         "Rule": {
-            "Description": "Check if an EOL Lambda Runtime is specified and you cannot update the function",
-            "Id": "E2533",
-            "ShortDescription": "Check if Lambda Function Runtimes are updatable",
+            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Id": "W2531",
+            "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
             "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
         }
     },
@@ -1323,8 +1323,8 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/cis_benchmark.yaml",
-        "Id": "5da7b42e-2652-487d-f4a0-037e72c390ed",
-        "Level": "Error",
+        "Id": "91d48bfb-4be4-758c-e257-bbd507aa6c44",
+        "Level": "Warning",
         "Location": {
             "End": {
                 "ColumnNumber": 16,
@@ -1341,12 +1341,12 @@
                 "LineNumber": 1465
             }
         },
-        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2025-10-01' and update on '2025-11-01'. Please consider updating to 'python3.13'",
+        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2026-06-01' and update on '2026-07-01'. Please consider updating to 'python3.14'",
         "ParentId": null,
         "Rule": {
-            "Description": "Check if an EOL Lambda Runtime is specified and you cannot update the function",
-            "Id": "E2533",
-            "ShortDescription": "Check if Lambda Function Runtimes are updatable",
+            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Id": "W2531",
+            "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
             "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
         }
     },
@@ -1409,8 +1409,8 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/cis_benchmark.yaml",
-        "Id": "14d580bf-aab6-2fd0-fb43-fe7c633690cb",
-        "Level": "Error",
+        "Id": "b8998327-de50-7d75-a842-6a6e66199dde",
+        "Level": "Warning",
         "Location": {
             "End": {
                 "ColumnNumber": 16,
@@ -1427,12 +1427,12 @@
                 "LineNumber": 1550
             }
         },
-        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2025-10-01' and update on '2025-11-01'. Please consider updating to 'python3.13'",
+        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2026-06-01' and update on '2026-07-01'. Please consider updating to 'python3.14'",
         "ParentId": null,
         "Rule": {
-            "Description": "Check if an EOL Lambda Runtime is specified and you cannot update the function",
-            "Id": "E2533",
-            "ShortDescription": "Check if Lambda Function Runtimes are updatable",
+            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Id": "W2531",
+            "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
             "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
         }
     },
@@ -1523,8 +1523,8 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/cis_benchmark.yaml",
-        "Id": "237c2297-6b3e-7604-080c-f7e8ba3a0e86",
-        "Level": "Error",
+        "Id": "4fa2cbb4-711c-ca01-5552-8e91fe932932",
+        "Level": "Warning",
         "Location": {
             "End": {
                 "ColumnNumber": 16,
@@ -1541,12 +1541,12 @@
                 "LineNumber": 1633
             }
         },
-        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2025-10-01' and update on '2025-11-01'. Please consider updating to 'python3.13'",
+        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2026-06-01' and update on '2026-07-01'. Please consider updating to 'python3.14'",
         "ParentId": null,
         "Rule": {
-            "Description": "Check if an EOL Lambda Runtime is specified and you cannot update the function",
-            "Id": "E2533",
-            "ShortDescription": "Check if Lambda Function Runtimes are updatable",
+            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Id": "W2531",
+            "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
             "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
         }
     },
@@ -1966,8 +1966,8 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/cis_benchmark.yaml",
-        "Id": "d21431ad-72d1-082f-65e7-1431ef5e5fba",
-        "Level": "Error",
+        "Id": "6cd14302-8cd4-b497-16e5-803f14b63abb",
+        "Level": "Warning",
         "Location": {
             "End": {
                 "ColumnNumber": 16,
@@ -1984,12 +1984,12 @@
                 "LineNumber": 1889
             }
         },
-        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2025-10-01' and update on '2025-11-01'. Please consider updating to 'python3.13'",
+        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2026-06-01' and update on '2026-07-01'. Please consider updating to 'python3.14'",
         "ParentId": null,
         "Rule": {
-            "Description": "Check if an EOL Lambda Runtime is specified and you cannot update the function",
-            "Id": "E2533",
-            "ShortDescription": "Check if Lambda Function Runtimes are updatable",
+            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Id": "W2531",
+            "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
             "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
         }
     },
@@ -2112,8 +2112,8 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/cis_benchmark.yaml",
-        "Id": "06ade5eb-299d-dad3-9028-2d93cdb3493a",
-        "Level": "Error",
+        "Id": "03f32390-31ea-6e2c-643a-f99eb15f37e5",
+        "Level": "Warning",
         "Location": {
             "End": {
                 "ColumnNumber": 16,
@@ -2130,12 +2130,12 @@
                 "LineNumber": 2334
             }
         },
-        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2025-10-01' and update on '2025-11-01'. Please consider updating to 'python3.13'",
+        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2026-06-01' and update on '2026-07-01'. Please consider updating to 'python3.14'",
         "ParentId": null,
         "Rule": {
-            "Description": "Check if an EOL Lambda Runtime is specified and you cannot update the function",
-            "Id": "E2533",
-            "ShortDescription": "Check if Lambda Function Runtimes are updatable",
+            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Id": "W2531",
+            "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
             "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
         }
     },

--- a/test/fixtures/results/quickstart/nist_config_rules.json
+++ b/test/fixtures/results/quickstart/nist_config_rules.json
@@ -58,7 +58,7 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/nist_config_rules.yaml",
-        "Id": "0c84132f-4f49-2dbc-df3a-6721a33e8098",
+        "Id": "97080445-d6e4-6198-6d62-dca2cdb88863",
         "Level": "Error",
         "Location": {
             "End": {
@@ -76,7 +76,7 @@
                 "LineNumber": 94
             }
         },
-        "Message": "Runtime 'nodejs' was deprecated on '2016-10-31'. Creation was disabled on '2016-10-31' and update on '2016-10-31'. Please consider updating to 'nodejs22.x'",
+        "Message": "Runtime 'nodejs' was deprecated on '2016-08-30'. Creation was disabled on '2016-09-30' and update on '2016-10-31'. Please consider updating to 'nodejs24.x'",
         "ParentId": null,
         "Rule": {
             "Description": "Check if an EOL Lambda Runtime is specified and you cannot update the function",
@@ -144,7 +144,7 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/nist_config_rules.yaml",
-        "Id": "18a51293-c6d5-2890-079c-eeedebd10314",
+        "Id": "e3939bea-03c8-f7fb-599a-5fd56a81318c",
         "Level": "Error",
         "Location": {
             "End": {
@@ -162,7 +162,7 @@
                 "LineNumber": 159
             }
         },
-        "Message": "Runtime 'nodejs' was deprecated on '2016-10-31'. Creation was disabled on '2016-10-31' and update on '2016-10-31'. Please consider updating to 'nodejs22.x'",
+        "Message": "Runtime 'nodejs' was deprecated on '2016-08-30'. Creation was disabled on '2016-09-30' and update on '2016-10-31'. Please consider updating to 'nodejs24.x'",
         "ParentId": null,
         "Rule": {
             "Description": "Check if an EOL Lambda Runtime is specified and you cannot update the function",

--- a/test/fixtures/results/quickstart/non_strict/cis_benchmark.json
+++ b/test/fixtures/results/quickstart/non_strict/cis_benchmark.json
@@ -30,8 +30,8 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/cis_benchmark.yaml",
-        "Id": "81390465-4bbb-3762-7d80-b63140c6f3b4",
-        "Level": "Error",
+        "Id": "89700488-9e01-d6a1-50c8-63305524dd97",
+        "Level": "Warning",
         "Location": {
             "End": {
                 "ColumnNumber": 16,
@@ -48,12 +48,12 @@
                 "LineNumber": 176
             }
         },
-        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2025-10-01' and update on '2025-11-01'. Please consider updating to 'python3.13'",
+        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2026-06-01' and update on '2026-07-01'. Please consider updating to 'python3.14'",
         "ParentId": null,
         "Rule": {
-            "Description": "Check if an EOL Lambda Runtime is specified and you cannot update the function",
-            "Id": "E2533",
-            "ShortDescription": "Check if Lambda Function Runtimes are updatable",
+            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Id": "W2531",
+            "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
             "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
         }
     },
@@ -116,8 +116,8 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/cis_benchmark.yaml",
-        "Id": "2c9690c6-5552-1893-8a37-b46a03ab90b2",
-        "Level": "Error",
+        "Id": "306a5b5f-5a34-7d43-12bd-b6d16e14e8a6",
+        "Level": "Warning",
         "Location": {
             "End": {
                 "ColumnNumber": 16,
@@ -134,12 +134,12 @@
                 "LineNumber": 309
             }
         },
-        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2025-10-01' and update on '2025-11-01'. Please consider updating to 'python3.13'",
+        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2026-06-01' and update on '2026-07-01'. Please consider updating to 'python3.14'",
         "ParentId": null,
         "Rule": {
-            "Description": "Check if an EOL Lambda Runtime is specified and you cannot update the function",
-            "Id": "E2533",
-            "ShortDescription": "Check if Lambda Function Runtimes are updatable",
+            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Id": "W2531",
+            "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
             "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
         }
     },
@@ -202,8 +202,8 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/cis_benchmark.yaml",
-        "Id": "e05317c1-3187-89b6-b3b5-10df6823bd46",
-        "Level": "Error",
+        "Id": "85ece31c-5811-377a-5555-e04a8b5d2b7d",
+        "Level": "Warning",
         "Location": {
             "End": {
                 "ColumnNumber": 16,
@@ -220,12 +220,12 @@
                 "LineNumber": 481
             }
         },
-        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2025-10-01' and update on '2025-11-01'. Please consider updating to 'python3.13'",
+        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2026-06-01' and update on '2026-07-01'. Please consider updating to 'python3.14'",
         "ParentId": null,
         "Rule": {
-            "Description": "Check if an EOL Lambda Runtime is specified and you cannot update the function",
-            "Id": "E2533",
-            "ShortDescription": "Check if Lambda Function Runtimes are updatable",
+            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Id": "W2531",
+            "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
             "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
         }
     },
@@ -288,8 +288,8 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/cis_benchmark.yaml",
-        "Id": "757eba91-f901-9ecd-e38c-2065d11a3732",
-        "Level": "Error",
+        "Id": "41835feb-7885-884d-cdc0-7b6f21ff3419",
+        "Level": "Warning",
         "Location": {
             "End": {
                 "ColumnNumber": 16,
@@ -306,12 +306,12 @@
                 "LineNumber": 551
             }
         },
-        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2025-10-01' and update on '2025-11-01'. Please consider updating to 'python3.13'",
+        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2026-06-01' and update on '2026-07-01'. Please consider updating to 'python3.14'",
         "ParentId": null,
         "Rule": {
-            "Description": "Check if an EOL Lambda Runtime is specified and you cannot update the function",
-            "Id": "E2533",
-            "ShortDescription": "Check if Lambda Function Runtimes are updatable",
+            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Id": "W2531",
+            "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
             "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
         }
     },
@@ -432,8 +432,8 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/cis_benchmark.yaml",
-        "Id": "704b0f38-b87d-49d2-f343-a71ef26b8c78",
-        "Level": "Error",
+        "Id": "3fe278d9-8d2b-7c11-8c5b-bf713403de82",
+        "Level": "Warning",
         "Location": {
             "End": {
                 "ColumnNumber": 16,
@@ -450,12 +450,12 @@
                 "LineNumber": 666
             }
         },
-        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2025-10-01' and update on '2025-11-01'. Please consider updating to 'python3.13'",
+        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2026-06-01' and update on '2026-07-01'. Please consider updating to 'python3.14'",
         "ParentId": null,
         "Rule": {
-            "Description": "Check if an EOL Lambda Runtime is specified and you cannot update the function",
-            "Id": "E2533",
-            "ShortDescription": "Check if Lambda Function Runtimes are updatable",
+            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Id": "W2531",
+            "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
             "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
         }
     },
@@ -518,8 +518,8 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/cis_benchmark.yaml",
-        "Id": "68ea4c26-b02b-0788-d816-f0eb52aa092a",
-        "Level": "Error",
+        "Id": "f68035e6-5bce-465a-519f-cab7d18abae2",
+        "Level": "Warning",
         "Location": {
             "End": {
                 "ColumnNumber": 16,
@@ -536,12 +536,12 @@
                 "LineNumber": 760
             }
         },
-        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2025-10-01' and update on '2025-11-01'. Please consider updating to 'python3.13'",
+        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2026-06-01' and update on '2026-07-01'. Please consider updating to 'python3.14'",
         "ParentId": null,
         "Rule": {
-            "Description": "Check if an EOL Lambda Runtime is specified and you cannot update the function",
-            "Id": "E2533",
-            "ShortDescription": "Check if Lambda Function Runtimes are updatable",
+            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Id": "W2531",
+            "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
             "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
         }
     },
@@ -633,8 +633,8 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/cis_benchmark.yaml",
-        "Id": "66986041-e66b-98a8-116b-d2e1902e8f27",
-        "Level": "Error",
+        "Id": "4e1e1b32-8cc2-3d91-0d46-2bac5291e212",
+        "Level": "Warning",
         "Location": {
             "End": {
                 "ColumnNumber": 16,
@@ -651,12 +651,12 @@
                 "LineNumber": 850
             }
         },
-        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2025-10-01' and update on '2025-11-01'. Please consider updating to 'python3.13'",
+        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2026-06-01' and update on '2026-07-01'. Please consider updating to 'python3.14'",
         "ParentId": null,
         "Rule": {
-            "Description": "Check if an EOL Lambda Runtime is specified and you cannot update the function",
-            "Id": "E2533",
-            "ShortDescription": "Check if Lambda Function Runtimes are updatable",
+            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Id": "W2531",
+            "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
             "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
         }
     },
@@ -748,8 +748,8 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/cis_benchmark.yaml",
-        "Id": "74e23491-7b14-a3ce-2491-6768bcd7b865",
-        "Level": "Error",
+        "Id": "71a9bc34-4254-bd7d-01c8-4a8c946578fd",
+        "Level": "Warning",
         "Location": {
             "End": {
                 "ColumnNumber": 16,
@@ -766,12 +766,12 @@
                 "LineNumber": 966
             }
         },
-        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2025-10-01' and update on '2025-11-01'. Please consider updating to 'python3.13'",
+        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2026-06-01' and update on '2026-07-01'. Please consider updating to 'python3.14'",
         "ParentId": null,
         "Rule": {
-            "Description": "Check if an EOL Lambda Runtime is specified and you cannot update the function",
-            "Id": "E2533",
-            "ShortDescription": "Check if Lambda Function Runtimes are updatable",
+            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Id": "W2531",
+            "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
             "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
         }
     },
@@ -863,8 +863,8 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/cis_benchmark.yaml",
-        "Id": "d52e9ac9-0aea-d7a5-29aa-bb59a818765d",
-        "Level": "Error",
+        "Id": "502768f5-0188-396b-8bdf-f31704f9d4f7",
+        "Level": "Warning",
         "Location": {
             "End": {
                 "ColumnNumber": 16,
@@ -881,12 +881,12 @@
                 "LineNumber": 1082
             }
         },
-        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2025-10-01' and update on '2025-11-01'. Please consider updating to 'python3.13'",
+        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2026-06-01' and update on '2026-07-01'. Please consider updating to 'python3.14'",
         "ParentId": null,
         "Rule": {
-            "Description": "Check if an EOL Lambda Runtime is specified and you cannot update the function",
-            "Id": "E2533",
-            "ShortDescription": "Check if Lambda Function Runtimes are updatable",
+            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Id": "W2531",
+            "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
             "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
         }
     },
@@ -978,8 +978,8 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/cis_benchmark.yaml",
-        "Id": "e2fce2c6-ee10-5735-d038-fe976eb6589c",
-        "Level": "Error",
+        "Id": "d89dbfee-7fbc-bc71-d76a-7503a02103b9",
+        "Level": "Warning",
         "Location": {
             "End": {
                 "ColumnNumber": 16,
@@ -996,12 +996,12 @@
                 "LineNumber": 1178
             }
         },
-        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2025-10-01' and update on '2025-11-01'. Please consider updating to 'python3.13'",
+        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2026-06-01' and update on '2026-07-01'. Please consider updating to 'python3.14'",
         "ParentId": null,
         "Rule": {
-            "Description": "Check if an EOL Lambda Runtime is specified and you cannot update the function",
-            "Id": "E2533",
-            "ShortDescription": "Check if Lambda Function Runtimes are updatable",
+            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Id": "W2531",
+            "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
             "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
         }
     },
@@ -1093,8 +1093,8 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/cis_benchmark.yaml",
-        "Id": "67ad084e-5cd7-b830-18d8-22b5c09ddcea",
-        "Level": "Error",
+        "Id": "beaf1813-b278-5516-a279-d808390eb29c",
+        "Level": "Warning",
         "Location": {
             "End": {
                 "ColumnNumber": 16,
@@ -1111,12 +1111,12 @@
                 "LineNumber": 1260
             }
         },
-        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2025-10-01' and update on '2025-11-01'. Please consider updating to 'python3.13'",
+        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2026-06-01' and update on '2026-07-01'. Please consider updating to 'python3.14'",
         "ParentId": null,
         "Rule": {
-            "Description": "Check if an EOL Lambda Runtime is specified and you cannot update the function",
-            "Id": "E2533",
-            "ShortDescription": "Check if Lambda Function Runtimes are updatable",
+            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Id": "W2531",
+            "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
             "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
         }
     },
@@ -1208,8 +1208,8 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/cis_benchmark.yaml",
-        "Id": "c5dd49e3-6488-d0af-fde2-ca230d0d92b2",
-        "Level": "Error",
+        "Id": "6898fb73-1dfe-1b57-abf0-5b89cb591517",
+        "Level": "Warning",
         "Location": {
             "End": {
                 "ColumnNumber": 16,
@@ -1226,12 +1226,12 @@
                 "LineNumber": 1357
             }
         },
-        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2025-10-01' and update on '2025-11-01'. Please consider updating to 'python3.13'",
+        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2026-06-01' and update on '2026-07-01'. Please consider updating to 'python3.14'",
         "ParentId": null,
         "Rule": {
-            "Description": "Check if an EOL Lambda Runtime is specified and you cannot update the function",
-            "Id": "E2533",
-            "ShortDescription": "Check if Lambda Function Runtimes are updatable",
+            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Id": "W2531",
+            "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
             "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
         }
     },
@@ -1323,8 +1323,8 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/cis_benchmark.yaml",
-        "Id": "5da7b42e-2652-487d-f4a0-037e72c390ed",
-        "Level": "Error",
+        "Id": "91d48bfb-4be4-758c-e257-bbd507aa6c44",
+        "Level": "Warning",
         "Location": {
             "End": {
                 "ColumnNumber": 16,
@@ -1341,12 +1341,12 @@
                 "LineNumber": 1465
             }
         },
-        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2025-10-01' and update on '2025-11-01'. Please consider updating to 'python3.13'",
+        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2026-06-01' and update on '2026-07-01'. Please consider updating to 'python3.14'",
         "ParentId": null,
         "Rule": {
-            "Description": "Check if an EOL Lambda Runtime is specified and you cannot update the function",
-            "Id": "E2533",
-            "ShortDescription": "Check if Lambda Function Runtimes are updatable",
+            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Id": "W2531",
+            "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
             "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
         }
     },
@@ -1409,8 +1409,8 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/cis_benchmark.yaml",
-        "Id": "14d580bf-aab6-2fd0-fb43-fe7c633690cb",
-        "Level": "Error",
+        "Id": "b8998327-de50-7d75-a842-6a6e66199dde",
+        "Level": "Warning",
         "Location": {
             "End": {
                 "ColumnNumber": 16,
@@ -1427,12 +1427,12 @@
                 "LineNumber": 1550
             }
         },
-        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2025-10-01' and update on '2025-11-01'. Please consider updating to 'python3.13'",
+        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2026-06-01' and update on '2026-07-01'. Please consider updating to 'python3.14'",
         "ParentId": null,
         "Rule": {
-            "Description": "Check if an EOL Lambda Runtime is specified and you cannot update the function",
-            "Id": "E2533",
-            "ShortDescription": "Check if Lambda Function Runtimes are updatable",
+            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Id": "W2531",
+            "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
             "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
         }
     },
@@ -1523,8 +1523,8 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/cis_benchmark.yaml",
-        "Id": "237c2297-6b3e-7604-080c-f7e8ba3a0e86",
-        "Level": "Error",
+        "Id": "4fa2cbb4-711c-ca01-5552-8e91fe932932",
+        "Level": "Warning",
         "Location": {
             "End": {
                 "ColumnNumber": 16,
@@ -1541,12 +1541,12 @@
                 "LineNumber": 1633
             }
         },
-        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2025-10-01' and update on '2025-11-01'. Please consider updating to 'python3.13'",
+        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2026-06-01' and update on '2026-07-01'. Please consider updating to 'python3.14'",
         "ParentId": null,
         "Rule": {
-            "Description": "Check if an EOL Lambda Runtime is specified and you cannot update the function",
-            "Id": "E2533",
-            "ShortDescription": "Check if Lambda Function Runtimes are updatable",
+            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Id": "W2531",
+            "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
             "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
         }
     },
@@ -1811,8 +1811,8 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/cis_benchmark.yaml",
-        "Id": "d21431ad-72d1-082f-65e7-1431ef5e5fba",
-        "Level": "Error",
+        "Id": "6cd14302-8cd4-b497-16e5-803f14b63abb",
+        "Level": "Warning",
         "Location": {
             "End": {
                 "ColumnNumber": 16,
@@ -1829,12 +1829,12 @@
                 "LineNumber": 1889
             }
         },
-        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2025-10-01' and update on '2025-11-01'. Please consider updating to 'python3.13'",
+        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2026-06-01' and update on '2026-07-01'. Please consider updating to 'python3.14'",
         "ParentId": null,
         "Rule": {
-            "Description": "Check if an EOL Lambda Runtime is specified and you cannot update the function",
-            "Id": "E2533",
-            "ShortDescription": "Check if Lambda Function Runtimes are updatable",
+            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Id": "W2531",
+            "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
             "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
         }
     },
@@ -1926,8 +1926,8 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/cis_benchmark.yaml",
-        "Id": "06ade5eb-299d-dad3-9028-2d93cdb3493a",
-        "Level": "Error",
+        "Id": "03f32390-31ea-6e2c-643a-f99eb15f37e5",
+        "Level": "Warning",
         "Location": {
             "End": {
                 "ColumnNumber": 16,
@@ -1944,12 +1944,12 @@
                 "LineNumber": 2334
             }
         },
-        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2025-10-01' and update on '2025-11-01'. Please consider updating to 'python3.13'",
+        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2026-06-01' and update on '2026-07-01'. Please consider updating to 'python3.14'",
         "ParentId": null,
         "Rule": {
-            "Description": "Check if an EOL Lambda Runtime is specified and you cannot update the function",
-            "Id": "E2533",
-            "ShortDescription": "Check if Lambda Function Runtimes are updatable",
+            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Id": "W2531",
+            "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
             "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
         }
     },

--- a/test/fixtures/results/quickstart/non_strict/openshift.json
+++ b/test/fixtures/results/quickstart/non_strict/openshift.json
@@ -337,8 +337,8 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/openshift.yaml",
-        "Id": "8461993d-35e6-91fc-e7e8-d1b5ef008d54",
-        "Level": "Error",
+        "Id": "b6b57550-26a1-c7a4-a747-53df118e2340",
+        "Level": "Warning",
         "Location": {
             "End": {
                 "ColumnNumber": 14,
@@ -355,12 +355,12 @@
                 "LineNumber": 810
             }
         },
-        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2025-10-01' and update on '2025-11-01'. Please consider updating to 'python3.13'",
+        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2026-06-01' and update on '2026-07-01'. Please consider updating to 'python3.14'",
         "ParentId": null,
         "Rule": {
-            "Description": "Check if an EOL Lambda Runtime is specified and you cannot update the function",
-            "Id": "E2533",
-            "ShortDescription": "Check if Lambda Function Runtimes are updatable",
+            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Id": "W2531",
+            "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
             "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
         }
     },

--- a/test/fixtures/results/quickstart/openshift.json
+++ b/test/fixtures/results/quickstart/openshift.json
@@ -399,8 +399,8 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/openshift.yaml",
-        "Id": "8461993d-35e6-91fc-e7e8-d1b5ef008d54",
-        "Level": "Error",
+        "Id": "b6b57550-26a1-c7a4-a747-53df118e2340",
+        "Level": "Warning",
         "Location": {
             "End": {
                 "ColumnNumber": 14,
@@ -417,12 +417,12 @@
                 "LineNumber": 810
             }
         },
-        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2025-10-01' and update on '2025-11-01'. Please consider updating to 'python3.13'",
+        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2026-06-01' and update on '2026-07-01'. Please consider updating to 'python3.14'",
         "ParentId": null,
         "Rule": {
-            "Description": "Check if an EOL Lambda Runtime is specified and you cannot update the function",
-            "Id": "E2533",
-            "ShortDescription": "Check if Lambda Function Runtimes are updatable",
+            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Id": "W2531",
+            "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
             "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
         }
     },

--- a/test/integration/test_good_templates.py
+++ b/test/integration/test_good_templates.py
@@ -211,7 +211,7 @@ class TestQuickStartTemplates(BaseCliTestCase):
                             "test/fixtures/templates/good/transform_serverless_globals.yaml"
                         )
                     ),
-                    "Id": "f69e6049-a69c-5754-4744-74aa1c4ae90d",
+                    "Id": "0d9d3690-14a9-8a30-2bf4-d6515e1fe983",
                     "Level": "Error",
                     "Location": {
                         "End": {"ColumnNumber": 13, "LineNumber": 10},
@@ -220,8 +220,8 @@ class TestQuickStartTemplates(BaseCliTestCase):
                     },
                     "Message": (
                         "Runtime 'nodejs6.10' was deprecated on '2019-08-12'. Creation"
-                        " was disabled on '2019-08-12' and update on '2019-08-12'."
-                        " Please consider updating to 'nodejs22.x'"
+                        " was disabled on '2019-07-12' and update on '2019-08-12'."
+                        " Please consider updating to 'nodejs24.x'"
                     ),
                     "ParentId": None,
                     "Rule": {

--- a/test/integration/test_quickstart_templates_non_strict.py
+++ b/test/integration/test_quickstart_templates_non_strict.py
@@ -31,14 +31,14 @@ class TestQuickStartTemplates(BaseCliTestCase):
             "results_filename": (
                 "test/fixtures/results/quickstart/non_strict/openshift.json"
             ),
-            "exit_code": 14,
+            "exit_code": 12,
         },
         {
             "filename": "test/fixtures/templates/quickstart/cis_benchmark.yaml",
             "results_filename": (
                 "test/fixtures/results/quickstart/non_strict/cis_benchmark.json"
             ),
-            "exit_code": 6,
+            "exit_code": 4,
         },
     ]
 

--- a/test/unit/rules/resources/lmbd/test_deprecated_runtime_create.py
+++ b/test/unit/rules/resources/lmbd/test_deprecated_runtime_create.py
@@ -42,15 +42,15 @@ def rule():
                 ValidationError(
                     "Runtime 'python3.7' was deprecated on "
                     "'2023-12-04'. Creation was disabled on "
-                    "'2024-01-09' and update on '2025-11-01'. "
-                    "Please consider updating to 'python3.13'",
+                    "'2024-01-09' and update on '2026-03-09'. "
+                    "Please consider updating to 'python3.14'",
                 )
             ],
         ),
         (
             # will be caught by the update rule
             "python3.7",
-            datetime(2025, 11, 1),
+            datetime(2026, 3, 10),
             [],
         ),
         (

--- a/test/unit/rules/resources/lmbd/test_deprecated_runtime_eol.py
+++ b/test/unit/rules/resources/lmbd/test_deprecated_runtime_eol.py
@@ -42,8 +42,8 @@ def rule():
                 ValidationError(
                     "Runtime 'python3.7' was deprecated on "
                     "'2023-12-04'. Creation was disabled on "
-                    "'2024-01-09' and update on '2025-11-01'. "
-                    "Please consider updating to 'python3.13'",
+                    "'2024-01-09' and update on '2026-03-09'. "
+                    "Please consider updating to 'python3.14'",
                 )
             ],
         ),

--- a/test/unit/rules/resources/lmbd/test_deprecated_runtime_update.py
+++ b/test/unit/rules/resources/lmbd/test_deprecated_runtime_update.py
@@ -37,13 +37,13 @@ def rule():
         ),
         (
             "python3.7",
-            datetime(2025, 11, 2),
+            datetime(2026, 3, 10),
             [
                 ValidationError(
                     "Runtime 'python3.7' was deprecated on "
                     "'2023-12-04'. Creation was disabled on "
-                    "'2024-01-09' and update on '2025-11-01'. "
-                    "Please consider updating to 'python3.13'",
+                    "'2024-01-09' and update on '2026-03-09'. "
+                    "Please consider updating to 'python3.14'",
                 )
             ],
         ),
@@ -54,9 +54,9 @@ def rule():
             [
                 ValidationError(
                     "Runtime 'nodejs' was deprecated on "
-                    "'2016-10-31'. Creation was disabled on "
-                    "'2016-10-31' and update on '2016-10-31'. "
-                    "Please consider updating to 'nodejs22.x'",
+                    "'2016-08-30'. Creation was disabled on "
+                    "'2016-09-30' and update on '2016-10-31'. "
+                    "Please consider updating to 'nodejs24.x'",
                 )
             ],
         ),


### PR DESCRIPTION
*Issue #, if available:*
fix #4334 

*Description of changes:*
- Add missing supported runtimes: Python 3.10-3.14, Java 8.al2/11/17/21/25, Node.js 20.x/22.x/24.x, .NET 8/9, Ruby 3.3/3.4, provided.al2023
- Fix successor relationships to point to latest supported runtimes
- Update deprecation dates based on current AWS documentation


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
