### PR TITLE
Update E3601 to support Seconds as JSONata in Wait

### DIFF
--- a/src/cfnlint/rules/resources/stepfunctions/StateMachineDefinition.py
+++ b/src/cfnlint/rules/resources/stepfunctions/StateMachineDefinition.py
@@ -89,6 +89,12 @@ class StateMachineDefinition(CfnLintJsonSchema):
                 }
             }
         ]
+        schema["definitions"]["wait"]["properties"]["Seconds"] = {
+            "maximum": 99999999,
+            "minimum": 0,
+            # JSONata supports JSONata expressions for Seconds
+            "type": ["number", "string"],
+        }
         for k in ["ItemsPath", "MaxConcurrencyPath"]:
             schema["definitions"]["map"]["properties"][k] = False
         return schema


### PR DESCRIPTION
*Issue #, if available:*
fix #4342 

*Description of changes:*
- Update E3601 to support Seconds as JSONata in Wait

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
