### PR TITLE
Pin cfn-lint version to 1.44.0 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM public.ecr.aws/docker/library/python:3.13-alpine3.20
 
-RUN pip install cfn-lint[full]
+RUN pip install cfn-lint[full]==1.44.0
 RUN pip install pydot
 
 ENTRYPOINT ["cfn-lint"]


### PR DESCRIPTION
Currently, there is no guarantee that the version of cfn-lint installed by the Dockerfile will match the release tag.

*Description of changes:*

Pins the cfn-lint version in the Dockerfile to that of the current release. This pinned version should be updated with each new release to match the release version.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
