### PR TITLE
Fix E3009 false positive for Fn::Transform in additional properties

### DIFF
--- a/src/cfnlint/jsonschema/_utils.py
+++ b/src/cfnlint/jsonschema/_utils.py
@@ -22,6 +22,8 @@ from collections.abc import Mapping, Sequence
 
 import regex as re
 
+from cfnlint.helpers import FUNCTION_TRANSFORM
+
 
 class Unset:
     """
@@ -45,6 +47,11 @@ def find_additional_properties(validator, instance, schema):
     properties = schema.get("properties", {})
     patterns = "|".join(schema.get("patternProperties", {}))
     for property in instance:
+        if (
+            property == FUNCTION_TRANSFORM
+            and FUNCTION_TRANSFORM in validator.context.functions
+        ):
+            continue
         if property not in properties:
             if validator.is_type(property, "string"):
                 if patterns and re.search(patterns, property):


### PR DESCRIPTION
Exclude Fn::Transform from additional properties validation when it's in the validator's context functions list. This allows Fn::Transform to be used in CloudFormation Init metadata and other contexts where CloudFormation supports it.

Fixes #4363

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
