### PR TITLE
feat: add region filtering to --update-specs

### DIFF
--- a/src/cfnlint/maintenance.py
+++ b/src/cfnlint/maintenance.py
@@ -20,8 +20,12 @@ REGISTRY_SCHEMA_ZIP = (
 )
 
 
-def update_resource_specs(force: bool = False) -> int:
+def update_resource_specs(force: bool = False, regions: list[str] | None = None) -> int:
     """Update provider schemas
+
+    Args:
+        force: force the schemas to be downloaded
+        regions: list of regions to update, None for all regions
 
     Returns:
         int: exit code (0=success, 1=partial failure, 2=complete failure)
@@ -31,7 +35,7 @@ def update_resource_specs(force: bool = False) -> int:
     # so it will fail Python2.7 style linting, as well as throw AttributeError
 
     # Update provider Schemas
-    return PROVIDER_SCHEMA_MANAGER.update(force)
+    return PROVIDER_SCHEMA_MANAGER.update(force, regions)
 
 
 def patch_resource_specs():

--- a/src/cfnlint/runner/cli.py
+++ b/src/cfnlint/runner/cli.py
@@ -269,7 +269,13 @@ class Runner:
         configure_logging(self.config.debug, self.config.info)
 
         if self.config.update_specs:
-            exit_code = cfnlint.maintenance.update_resource_specs(self.config.force)
+            # For update-specs, only use regions if explicitly specified
+            regions = None
+            if self.config._get_argument_value("regions", True, True):
+                regions = self.config.regions
+            exit_code = cfnlint.maintenance.update_resource_specs(
+                self.config.force, regions
+            )
             sys.exit(exit_code)
 
         if self.config.patch_specs:

--- a/src/cfnlint/schema/manager.py
+++ b/src/cfnlint/schema/manager.py
@@ -247,20 +247,24 @@ class ProviderSchemaManager:
 
         return resource_types
 
-    def update(self, force: bool) -> int:
+    def update(self, force: bool, regions: list[str] | None = None) -> int:
         """Update every regions provider schemas
 
         Args:
             force (bool): force the schemas to be downloaded
+            regions (list[str] | None): list of regions to update, None for all regions
         Returns:
             int: exit code (0=success, 1=partial failure, 2=complete failure)
         """
         import hashlib
         from pathlib import Path
 
+        # Use all regions if none specified
+        target_regions = regions if regions else REGIONS
+
         # Separate ISO regions (not publicly accessible) from regular regions
-        iso_regions = [r for r in REGIONS if "iso" in r or r.startswith("eusc")]
-        regular_regions = [r for r in REGIONS if r not in iso_regions]
+        iso_regions = [r for r in target_regions if "iso" in r or r.startswith("eusc")]
+        regular_regions = [r for r in target_regions if r not in iso_regions]
 
         # Download all regular regions in parallel
         downloaded_regions: dict[str, dict[str, dict]] = {}

--- a/test/unit/module/runner/test_cli.py
+++ b/test/unit/module/runner/test_cli.py
@@ -46,7 +46,20 @@ class TestCli(BaseTestCase):
             runner.cli()
 
         self.assertEqual(e.exception.code, 0)
-        mock_maintenance.assert_called_once()
+        mock_maintenance.assert_called_once_with(False, None)
+
+    @patch("cfnlint.maintenance.update_resource_specs")
+    def test_update_specs_with_regions(self, mock_maintenance):
+        mock_maintenance.return_value = 0
+        config = ConfigMixIn(["--update-specs", "--regions", "us-east-1", "us-west-2"])
+
+        runner = Runner(config)
+
+        with self.assertRaises(SystemExit) as e:
+            runner.cli()
+
+        self.assertEqual(e.exception.code, 0)
+        mock_maintenance.assert_called_once_with(False, ["us-east-1", "us-west-2"])
 
     @patch("cfnlint.maintenance.patch_resource_specs")
     def test_patch_specs(self, mock_maintenance):


### PR DESCRIPTION
Allow users to specify which regions to update when running --update-specs by using the --regions flag. This reduces download time and bandwidth usage when only specific regions are needed.

Usage:
- cfn-lint --update-specs (updates all regions, default behavior)
- cfn-lint --update-specs --regions us-east-1 us-west-2 (updates only specified regions)
- cfn-lint --update-specs --regions ALL_REGIONS (explicit all regions)

Changes:
- Add regions parameter to update_resource_specs() and ProviderSchemaManager.update()
- Pass regions from CLI config to update functions when explicitly specified
- Add test coverage for region-specific updates

*Issue #, if available:*
#4379 
*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
