### PR TITLE
Remove Python 3.9 support (EOL October 2025)

### DIFF
--- a/.github/workflows/ci-branch.yaml
+++ b/.github/workflows/ci-branch.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
+        python: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci-pr.yaml
+++ b/.github/workflows/ci-pr.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v6

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,13 +51,13 @@ $ pip install tox
 $ tox
 
 # Run a specific test suite
-$ tox -e py39 # Run all unit tests against Python 3.9
+$ tox -e py310 # Run all unit tests against Python 3.10
 ```
 Tox test suites available:
-* **py39**: Unit tests (Python 3.9)
 * **py310**: Unit tests (Python 3.10)
 * **py311**: Unit tests (Python 3.11)
 * **py312**: Unit tests (Python 3.12)
+* **py313**: Unit tests (Python 3.13)
 * **py313**: Unit tests (Python 3.13)
 * **style**: Python syntax check
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ _To get information about the [SAM Transformation](https://docs.aws.amazon.com/A
 
 ## Install
 
-Python 3.9 to 3.13 are supported.
+Python 3.10 to 3.13 are supported.
 
 ### Pip
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ optional-dependencies.full = { file = ["requirements/optional-graph.txt","requir
 [project]
 name = "cfn-lint"
 description = "Checks CloudFormation templates for practices and behaviour that could potentially be improved"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = "MIT-0"
 keywords = ["aws", "cloudformation", "lint"]
 authors = [
@@ -32,7 +32,6 @@ classifiers = [
     "Natural Language :: English",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -129,7 +128,7 @@ exclude_lines = [
 ]
 
 [tool.tox]
-env_list = ["py39", "py310", "py311", "py312", "py313", "style"]
+env_list = ["py310", "py311", "py312", "py313", "style"]
 
 [tool.tox.env_run_base]
 skip_install = true
@@ -149,7 +148,6 @@ commands = [
 ]
 
 [tool.tox.gh.python]
-"3.9" = ["py39"]
 "3.10" = ["py310"]
 "3.11" = ["py311"]
 "3.12" = ["py312"]


### PR DESCRIPTION
- Update minimum Python version to 3.10 in pyproject.toml
- Remove Python 3.9 from GitHub Actions CI workflows
- Remove py39 from tox configuration
- Update README and CONTRIBUTING documentation

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
