### PR TITLE
Add unknown validation state for intrinsic functions in composite validators

### DIFF
--- a/src/cfnlint/context/context.py
+++ b/src/cfnlint/context/context.py
@@ -164,6 +164,11 @@ class Context:
 
     strict_types: bool = field(init=True, default=True)
 
+    # When True, function validators should return unknown errors
+    # instead of validating. Used in composite validators
+    # (if/then/else, oneOf, anyOf) to handle unresolvable functions
+    unresolvable_function_mode: bool = field(init=True, default=False)
+
     pseudo_parameters: Set[str] = field(
         init=True, default_factory=lambda: set(PSEUDOPARAMS)
     )

--- a/src/cfnlint/jsonschema/_keywords.py
+++ b/src/cfnlint/jsonschema/_keywords.py
@@ -85,10 +85,33 @@ def allOf(
     validator = validator.evolve(
         function_filter=validator.function_filter.evolve(
             add_cfn_lint_keyword=False,
-        )
+        ),
+        context=validator.context.evolve(
+            unresolvable_function_mode=True,
+        ),
     )
+    has_unknown = False
+    known_errors = []
+
     for index, subschema in enumerate(allOf):
-        yield from validator.descend(instance, subschema, schema_path=index)
+        errs = list(validator.descend(instance, subschema, schema_path=index))
+
+        if any(getattr(err, "unknown", False) for err in errs):
+            has_unknown = True
+        else:
+            known_errors.extend(errs)
+
+    # If we have unknown branches, we can't determine if allOf is satisfied
+    if has_unknown:
+        yield ValidationError(
+            f"Cannot determine allOf for {instance!r}",
+            unknown=True,
+        )
+        return
+
+    # Yield all known errors
+    for err in known_errors:
+        yield err
 
 
 def anyOf(
@@ -97,10 +120,16 @@ def anyOf(
     validator = validator.evolve(
         function_filter=validator.function_filter.evolve(
             add_cfn_lint_keyword=False,
-        )
+        ),
+        context=validator.context.evolve(
+            unresolvable_function_mode=True,
+        ),
     )
     all_errors = []
     other_errors = []
+    has_valid = False
+    has_unknown = False
+
     for index, subschema in enumerate(anyOf):
         errs = []
         # warning and informational shouldn't count towards if anyOf is
@@ -110,14 +139,32 @@ def anyOf(
                 other_errors.append(err)
                 continue
             errs.append(err)
-        if not errs:
+
+        if any(getattr(err, "unknown", False) for err in errs):
+            has_unknown = True
+        elif not errs:
+            has_valid = True
             break
-        all_errors.extend(errs)
-    else:
+        else:
+            all_errors.extend(errs)
+
+    # If we found a valid branch, we're done
+    if has_valid:
+        return
+
+    # If we have unknown branches, we can't determine
+    if has_unknown:
         yield ValidationError(
-            f"{instance!r} is not valid under any of the given schemas",
-            context=all_errors + other_errors,
+            f"Cannot determine anyOf for {instance!r}",
+            unknown=True,
         )
+        return
+
+    # All known branches failed
+    yield ValidationError(
+        f"{instance!r} is not valid under any of the given schemas",
+        context=all_errors + other_errors,
+    )
 
 
 def const(
@@ -134,22 +181,39 @@ def contains(
         return
 
     matches = 0
+    unknown_count = 0
     min_contains = schema.get("minContains", 1)
     max_contains = schema.get("maxContains", len(instance))
 
     contains_validator = validator.evolve(schema=contains)
 
     for each in instance:
-        if contains_validator.is_valid(each):
-            matches += 1
-            if matches > max_contains:
-                yield ValidationError(
-                    "Too many items match the given schema "
-                    f"(expected at most {max_contains})",
-                    validator="maxContains",
-                    validator_value=max_contains,
-                )
-                return
+        errs = list(contains_validator.iter_errors(each))
+        # Filter unknown errors
+        non_unknown_errs = [err for err in errs if not err.unknown]
+
+        if not non_unknown_errs:
+            # If no non-unknown errors, it's either valid or unknown
+            if any(err.unknown for err in errs):
+                unknown_count += 1
+            else:
+                matches += 1
+                if matches > max_contains:
+                    yield ValidationError(
+                        "Too many items match the given schema "
+                        f"(expected at most {max_contains})",
+                        validator="maxContains",
+                        validator_value=max_contains,
+                    )
+                    return
+
+    # If we have unknown items, we can't determine if contains is satisfied
+    if unknown_count > 0 and matches < min_contains:
+        yield ValidationError(
+            "Cannot determine if contains constraint is satisfied",
+            unknown=True,
+        )
+        return
 
     if matches < min_contains:
         if not matches:
@@ -314,10 +378,22 @@ def if_(
     if_validator = validator.evolve(
         context=validator.context.evolve(
             allow_exceptions=False,
+            unresolvable_function_mode=True,
         )
     )
 
-    if if_validator.evolve(schema=if_schema).is_valid(instance):
+    if_errors = list(if_validator.evolve(schema=if_schema).iter_errors(instance))
+
+    # If any error is unknown, we can't determine the condition
+    if any(getattr(err, "unknown", False) for err in if_errors):
+        yield ValidationError(
+            f"Cannot determine if condition for {instance!r}",
+            unknown=True,
+        )
+        return
+
+    # Original logic
+    if not if_errors:
         if "then" in schema:
             then = schema["then"]
             yield from validator.descend(instance, then, schema_path="then")
@@ -477,9 +553,24 @@ def not_(
     validator = validator.evolve(
         function_filter=validator.function_filter.evolve(
             add_cfn_lint_keyword=False,
-        )
+        ),
+        context=validator.context.evolve(
+            unresolvable_function_mode=True,
+        ),
     )
-    if validator.evolve(schema=not_schema).is_valid(instance):
+
+    errs = list(validator.evolve(schema=not_schema).iter_errors(instance))
+
+    # If there are unknown errors, we can't determine if not is satisfied
+    if any(getattr(err, "unknown", False) for err in errs):
+        yield ValidationError(
+            f"Cannot determine not for {instance!r}",
+            unknown=True,
+        )
+        return
+
+    # If no errors, the schema is valid, so 'not' fails
+    if not errs:
         message = f"{instance!r} should not be valid under {not_schema!r}"
         yield ValidationError(message)
 
@@ -490,30 +581,48 @@ def oneOf(
     validator = validator.evolve(
         function_filter=validator.function_filter.evolve(
             add_cfn_lint_keyword=False,
-        )
+        ),
+        context=validator.context.evolve(
+            unresolvable_function_mode=True,
+        ),
     )
     subschemas = enumerate(oneOf)
     all_errors = []
+    valid_count = 0
+    has_unknown = False
+    valid_schemas = []
+
     for index, subschema in subschemas:
         errs = list(validator.descend(instance, subschema, schema_path=index))
-        if not errs:
-            first_valid = subschema
-            break
-        all_errors.extend(errs)
-    else:
+
+        if any(getattr(err, "unknown", False) for err in errs):
+            has_unknown = True
+        elif not errs:
+            valid_count += 1
+            valid_schemas.append(subschema)
+        else:
+            all_errors.extend(errs)
+
+    # If we can't determine, yield unknown error
+    if has_unknown and valid_count < 2:
+        yield ValidationError(
+            f"Cannot determine oneOf for {instance!r}",
+            unknown=True,
+        )
+        return
+
+    # Definitive results
+    if valid_count == 1:
+        return
+
+    if valid_count == 0:
         yield ValidationError(
             f"{instance!r} is not valid under any of the given schemas",
             context=all_errors,
         )
-
-    more_valid = [
-        each
-        for _, each in subschemas
-        if validator.evolve(schema=each).is_valid(instance)
-    ]
-    if more_valid:
-        more_valid.append(first_valid)
-        reprs = ", ".join(repr(schema) for schema in more_valid)
+    else:
+        # Multiple valid schemas
+        reprs = ", ".join(repr(schema) for schema in valid_schemas)
         yield ValidationError(f"{instance!r} is valid under each of {reprs}")
 
 

--- a/src/cfnlint/jsonschema/_keywords_cfn.py
+++ b/src/cfnlint/jsonschema/_keywords_cfn.py
@@ -223,9 +223,40 @@ def cfn_type(validator: Validator, tS: Any, instance: Any, schema: Any):
         yield ValidationError(f"{instance!r} is not of type {reprs}")
 
 
+def _function_unknown(
+    validator: Validator, s: Any, instance: Any, schema: dict[str, Any]
+) -> ValidationResult:
+    """Default validator for CloudFormation intrinsic functions.
+    Returns unknown error in unresolvable mode to prevent incorrect validation.
+    Overridden by function rules in full validation environments."""
+    if validator.context.unresolvable_function_mode:
+        yield ValidationError(
+            "Cannot resolve function in composite validation",
+            unknown=True,
+        )
+    # In normal mode, do nothing - let the function pass through
+    return
+
+
 cfn_validators: dict[str, V] = {
     "additionalProperties": additionalProperties,
     "cfnContext": cfnContext,
     "dynamicValidation": dynamicValidation,
     "type": cfn_type,
+    # CloudFormation intrinsic functions - default to unknown
+    "ref": _function_unknown,
+    "fn_base64": _function_unknown,
+    "fn_cidr": _function_unknown,
+    "fn_findinmap": _function_unknown,
+    "fn_getatt": _function_unknown,
+    "fn_getazs": _function_unknown,
+    "fn_importvalue": _function_unknown,
+    "fn_join": _function_unknown,
+    "fn_select": _function_unknown,
+    "fn_split": _function_unknown,
+    "fn_sub": _function_unknown,
+    "fn_transform": _function_unknown,
+    "fn_tojsonstring": _function_unknown,
+    "fn_length": _function_unknown,
+    "fn_if": _function_unknown,
 }

--- a/src/cfnlint/jsonschema/exceptions.py
+++ b/src/cfnlint/jsonschema/exceptions.py
@@ -56,6 +56,7 @@ class _Error(Exception):
         extra_args=None,
         rule: CloudFormationLintRule | None = None,
         path_override: Deque | Tuple = (),
+        unknown: bool = False,
     ):
         super().__init__(
             message,
@@ -83,6 +84,7 @@ class _Error(Exception):
         self.extra_args = extra_args or {}
         self.rule = rule
         self.path_override = deque(path_override)
+        self.unknown = unknown
 
         for error in context:
             error.parent = self

--- a/src/cfnlint/rules/functions/_BaseFn.py
+++ b/src/cfnlint/rules/functions/_BaseFn.py
@@ -174,6 +174,14 @@ class BaseFn(CfnLintJsonSchema):
         instance: Any,
         schema: Any,
     ) -> ValidationResult:
+        # If in unresolvable mode, return unknown error immediately
+        if validator.context.unresolvable_function_mode:
+            yield ValidationError(
+                f"Cannot resolve {self.fn.name} in composite validation",
+                unknown=True,
+            )
+            return
+
         # validate this function will return the correct type
         errs = list(
             self.fix_errors(self.validate_fn_output_types(validator, s, instance))

--- a/src/cfnlint/rules/jsonschema/Base.py
+++ b/src/cfnlint/rules/jsonschema/Base.py
@@ -32,6 +32,10 @@ class BaseJsonSchema(CloudFormationLintRule):
         path: Sequence[str],
         e: ValidationError,
     ):
+        # Don't convert unknown errors to matches
+        if getattr(e, "unknown", False):
+            return []
+
         matches = []
         kwargs: dict[Any, Any] = {}
 

--- a/src/cfnlint/rules/jsonschema/CfnLintJsonSchema.py
+++ b/src/cfnlint/rules/jsonschema/CfnLintJsonSchema.py
@@ -45,7 +45,7 @@ class CfnLintJsonSchema(BaseJsonSchema):
         return self.shortdesc
 
     def _iter_errors(self, validator, instance):
-        errs = list(validator.iter_errors(instance))
+        errs = [err for err in validator.iter_errors(instance) if not err.unknown]
         if not self.all_matches:
             err = best_match(errs)
             if err is not None:
@@ -75,9 +75,10 @@ class CfnLintJsonSchema(BaseJsonSchema):
             ),
             schema=schema,
             context=validator.context.evolve(
-                functions=[],
-                strict_types=True,
+                unresolvable_function_mode=True,
             ),
         )
 
-        yield from self._iter_errors(cfn_validator, instance)
+        for err in self._iter_errors(cfn_validator, instance):
+            if not getattr(err, "unknown", False):
+                yield err

--- a/test/unit/module/jsonschema/test_keywords.py
+++ b/test/unit/module/jsonschema/test_keywords.py
@@ -8,6 +8,8 @@ from unittest.mock import Mock
 
 import pytest
 
+from cfnlint.context import Context
+from cfnlint.helpers import FUNCTIONS
 from cfnlint.jsonschema import ValidationError, _keywords
 from cfnlint.jsonschema.validators import CfnTemplateValidator
 from cfnlint.rules import CloudFormationLintRule
@@ -169,6 +171,7 @@ def test_if_validator_context_evolution():
     # Mock the final evolve call (for schema) and is_valid
     mock_final_validator = Mock()
     mock_final_validator.is_valid.return_value = True
+    mock_final_validator.iter_errors.return_value = iter([])
     mock_if_validator.evolve.return_value = mock_final_validator
 
     # Create a simple schema
@@ -178,7 +181,207 @@ def test_if_validator_context_evolution():
     list(_keywords.if_(mock_validator, schema, "test", schema))
 
     # Verify that context.evolve was called with allow_exceptions=False
-    mock_context.evolve.assert_called_once_with(allow_exceptions=False)
+    mock_context.evolve.assert_called_once_with(
+        allow_exceptions=False, unresolvable_function_mode=True
+    )
 
     # Verify that the evolved validator's evolve was called with the evolved context
     mock_evolved_validator.evolve.assert_called_once_with(context=mock_evolved_context)
+
+
+@pytest.fixture
+def validator_unresolvable():
+    context = Context(
+        regions=["us-east-1"], functions=FUNCTIONS, unresolvable_function_mode=True
+    )
+    return CfnTemplateValidator(schema={}, context=context)
+
+
+@pytest.mark.parametrize(
+    "name,validator_name,instance,schema,expected_unknown",
+    [
+        (
+            "anyOf one valid one unknown",
+            "anyOf",
+            {"Engine": "mysql", "Port": {"Ref": "PortParam"}},
+            [
+                {"properties": {"Engine": {"const": "mysql"}}},
+                {"properties": {"Port": {"const": 5432}}},
+            ],
+            False,
+        ),
+        (
+            "anyOf all unknown",
+            "anyOf",
+            {"Engine": {"Ref": "EngineParam"}, "Port": {"Ref": "PortParam"}},
+            [
+                {"properties": {"Engine": {"const": "mysql"}, "Port": {"const": 3306}}},
+                {
+                    "properties": {
+                        "Engine": {"const": "postgres"},
+                        "Port": {"const": 5432},
+                    }
+                },
+            ],
+            True,
+        ),
+        (
+            "anyOf one valid",
+            "anyOf",
+            {"Engine": "mysql", "Port": 3306},
+            [
+                {"properties": {"Engine": {"const": "mysql"}, "Port": {"const": 3306}}},
+                {
+                    "properties": {
+                        "Engine": {"const": "postgres"},
+                        "Port": {"const": 5432},
+                    }
+                },
+            ],
+            False,
+        ),
+        (
+            "oneOf one valid one unknown",
+            "oneOf",
+            {"Engine": "mysql", "Port": {"Ref": "PortParam"}},
+            [
+                {"properties": {"Engine": {"const": "mysql"}}},
+                {"properties": {"Port": {"const": 5432}}},
+            ],
+            True,
+        ),
+        (
+            "oneOf all unknown",
+            "oneOf",
+            {"Engine": {"Ref": "EngineParam"}, "Port": {"Ref": "PortParam"}},
+            [
+                {"properties": {"Engine": {"const": "mysql"}, "Port": {"const": 3306}}},
+                {
+                    "properties": {
+                        "Engine": {"const": "postgres"},
+                        "Port": {"const": 5432},
+                    }
+                },
+            ],
+            True,
+        ),
+        (
+            "oneOf one valid",
+            "oneOf",
+            {"Engine": "mysql", "Port": 3306},
+            [
+                {"properties": {"Engine": {"const": "mysql"}, "Port": {"const": 3306}}},
+                {
+                    "properties": {
+                        "Engine": {"const": "postgres"},
+                        "Port": {"const": 5432},
+                    }
+                },
+            ],
+            False,
+        ),
+        (
+            "allOf one unknown",
+            "allOf",
+            {"Engine": "mysql", "Port": {"Ref": "PortParam"}},
+            [
+                {"properties": {"Engine": {"const": "mysql"}}},
+                {"properties": {"Port": {"const": 3306}}},
+            ],
+            True,
+        ),
+        (
+            "allOf all valid",
+            "allOf",
+            {"Engine": "mysql", "Port": 3306},
+            [
+                {"properties": {"Engine": {"const": "mysql"}}},
+                {"properties": {"Port": {"const": 3306}}},
+            ],
+            False,
+        ),
+        (
+            "not unknown",
+            "not_",
+            {"Engine": {"Ref": "EngineParam"}},
+            {"properties": {"Engine": {"const": "mysql"}}},
+            True,
+        ),
+        (
+            "contains unknown",
+            "contains",
+            [{"Engine": {"Ref": "EngineParam"}}],
+            {"properties": {"Engine": {"const": "mysql"}}},
+            True,
+        ),
+        (
+            "contains one valid",
+            "contains",
+            [{"Engine": "mysql"}, {"Engine": {"Ref": "EngineParam"}}],
+            {"properties": {"Engine": {"const": "mysql"}}},
+            False,
+        ),
+    ],
+)
+def test_composite_unknown(
+    name, validator_name, instance, schema, expected_unknown, validator_unresolvable
+):
+    validator_fn = getattr(_keywords, validator_name)
+    errs = list(validator_fn(validator_unresolvable, schema, instance, {}))
+
+    if expected_unknown:
+        assert len(errs) == 1
+        assert errs[0].unknown is True
+    else:
+        assert len(errs) == 0
+
+
+@pytest.mark.parametrize(
+    "name,instance,schema,expected_unknown",
+    [
+        (
+            "if unknown skips then",
+            {"Engine": {"Ref": "EngineParam"}},
+            {
+                "if": {"properties": {"Engine": {"const": "mysql"}}},
+                "then": {"properties": {"Port": {"const": 3306}}},
+            },
+            True,
+        ),
+        (
+            "if valid then valid",
+            {"Engine": "mysql", "Port": 3306},
+            {
+                "if": {"properties": {"Engine": {"const": "mysql"}}},
+                "then": {"properties": {"Port": {"const": 3306}}},
+            },
+            False,
+        ),
+        (
+            "if valid then unknown",
+            {"Engine": "mysql", "Port": {"Ref": "PortParam"}},
+            {
+                "if": {"properties": {"Engine": {"const": "mysql"}}},
+                "then": {"properties": {"Port": {"const": 3306}}},
+            },
+            True,
+        ),
+        (
+            "if fails else unknown",
+            {"Engine": "postgres", "Port": {"Ref": "PortParam"}},
+            {
+                "if": {"properties": {"Engine": {"const": "mysql"}}},
+                "else": {"properties": {"Port": {"const": 5432}}},
+            },
+            True,
+        ),
+    ],
+)
+def test_if_unknown(name, instance, schema, expected_unknown, validator_unresolvable):
+    errs = list(_keywords.if_(validator_unresolvable, schema, instance, schema))
+
+    if expected_unknown:
+        assert len(errs) == 1, f"{name}: expected 1 error, got {len(errs)}"
+        assert errs[0].unknown is True, f"{name}: expected unknown=True"
+    else:
+        assert len(errs) == 0, f"{name}: expected 0 errors, got {len(errs)}"

--- a/test/unit/rules/jsonschema/test_base.py
+++ b/test/unit/rules/jsonschema/test_base.py
@@ -115,11 +115,13 @@ class TestBaseJsonSchema(BaseRuleTestCase):
             )
             yield ValidationError("Failure4", path=deque(["A"]), validator="foobar")
             yield ValidationError("Failure5", path=deque(["A"]), validator="foo")
+            yield ValidationError("Failure6", path=deque(["A"]), unknown=True)
 
         validator.iter_errors = iter_errors
 
         errors = list(rule.json_schema_validate(validator, {}, []))
         # 5th error is ignored because the rule is None which means
+        # 6th error is ignored because unknown=True
         # the length is 4
         self.assertEqual(len(errors), 4)
 

--- a/test/unit/rules/resources/ecs/test_task_definition_essentials.py
+++ b/test/unit/rules/resources/ecs/test_task_definition_essentials.py
@@ -57,8 +57,8 @@ def rule():
                     "At least one essential container is required",
                     rule=TaskDefinitionEssentialContainer(),
                     path=deque([]),
-                    validator="contains",
-                    schema_path=deque(["contains"]),
+                    validator="minItems",
+                    schema_path=deque(["minItems"]),
                 )
             ],
         ),

--- a/test/unit/rules/resources/route53/test_recordsets.py
+++ b/test/unit/rules/resources/route53/test_recordsets.py
@@ -340,6 +340,23 @@ def rule():
             },
             [
                 ValidationError(
+                    "expected maximum item count: 1, found: 2",
+                    rule=RecordSet(),
+                    path=deque(["ResourceRecords"]),
+                    validator="maxItems",
+                    validator_value=1,
+                    schema_path=deque(
+                        [
+                            "allOf",
+                            3,
+                            "then",
+                            "properties",
+                            "ResourceRecords",
+                            "maxItems",
+                        ]
+                    ),
+                ),
+                ValidationError(
                     "'foo√bar' is not valid under any of the given schemas",
                     rule=RecordSet(),
                     path=deque(["ResourceRecords", 1]),
@@ -373,22 +390,6 @@ def rule():
                             "ResourceRecords",
                             "items",
                             "anyOf",
-                        ]
-                    ),
-                ),
-                ValidationError(
-                    "expected maximum item count: 1, found: 2",
-                    rule=RecordSet(),
-                    path=deque(["ResourceRecords"]),
-                    validator="maxItems",
-                    schema_path=deque(
-                        [
-                            "allOf",
-                            3,
-                            "then",
-                            "properties",
-                            "ResourceRecords",
-                            "maxItems",
                         ]
                     ),
                 ),


### PR DESCRIPTION
- Add unknown field to `ValidationError` and `unresolvable_function_mode` to Context
- Update composite validators (`if`, `oneOf`, `anyOf`, `allOf`, `not`, `contains`) to propagate unknown errors when functions cannot be resolved
- Add default function validators in `_keywords_cfn.py` that return unknown in unresolvable mode, overridden by full function rules at runtime
- Filter unknown errors in `Base.py` and `CfnLintJsonSchema`
- Return unknown from `BaseFn.validate()` in unresolvable mode
- Fix `oneOf` to collect valid schemas in single pass
- Add unit tests for unknown handling in all composite validators

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
