### PR TITLE
Cap resolve_value permutations to prevent exponential blowup

### DIFF
--- a/src/cfnlint/jsonschema/validators.py
+++ b/src/cfnlint/jsonschema/validators.py
@@ -166,9 +166,12 @@ def create(
                         fn_resolved_err,
                     )
 
+        _RESOLVE_MAX_YIELDS: int = 512
+
         def resolve_value(self, instance: Any) -> ResolutionResult:
             key, value = is_function(instance)
             if key in self.fn_resolvers:
+                count = 0
                 # There is no None in self.fn_resolvers
                 for r_value, r_validator, r_errs in self._resolve_fn(key, value):  # type: ignore
                     if not r_errs:
@@ -185,6 +188,9 @@ def create(
                                     region_context.conditions.status,
                                     region_context.ref_values,
                                 ):
+                                    count += 1
+                                    if count > self._RESOLVE_MAX_YIELDS:
+                                        return
                                     yield (
                                         r_value,
                                         r_validator.evolve(

--- a/test/unit/module/jsonschema/test_resolve_max_yields.py
+++ b/test/unit/module/jsonschema/test_resolve_max_yields.py
@@ -1,0 +1,43 @@
+"""
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+"""
+
+from typing import Any
+
+import pytest
+
+from cfnlint.jsonschema._resolvers_cfn import ResolutionResult, Validator
+from cfnlint.jsonschema.validators import CfnTemplateValidator
+
+
+def _many_resolver(validator: Validator, instance: Any) -> ResolutionResult:
+    for i in range(instance):
+        yield i, validator, None
+
+
+@pytest.fixture
+def validator():
+    validator = CfnTemplateValidator({})
+    validator.fn_resolvers = {"Ref": _many_resolver}
+    validator.context = validator.context.evolve(functions=["Ref"])
+    return validator
+
+
+class TestResolveMaxYields:
+    def test_under_cap(self, validator):
+        results = list(validator.resolve_value({"Ref": 100}))
+        assert len(results) == 100
+
+    def test_at_cap(self, validator):
+        results = list(validator.resolve_value({"Ref": 512}))
+        assert len(results) == 512
+
+    def test_over_cap(self, validator):
+        results = list(validator.resolve_value({"Ref": 1000}))
+        assert len(results) == 512
+
+    def test_no_function_not_capped(self, validator):
+        results = list(validator.resolve_value("plain"))
+        assert len(results) == 1
+        assert results[0][0] == "plain"


### PR DESCRIPTION
When deeply nested functions (Fn::If, Fn::Select, etc.) are resolved against schemas with value constraints, the number of condition permutations can grow exponentially. Cap at 512 yields per resolve_value call as a safety valve — best effort validation beyond that point.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
