### PR TITLE
Support multi-attribute composite keys in DynamoDB GSI KeySchema

### DIFF
--- a/src/cfnlint/data/schemas/patches/providers/all/aws_dynamodb_globaltable/keyschema.json
+++ b/src/cfnlint/data/schemas/patches/providers/all/aws_dynamodb_globaltable/keyschema.json
@@ -28,9 +28,34 @@
   "op": "replace",
   "path": "/definitions/GlobalSecondaryIndex/properties/KeySchema",
   "value": {
-   "$ref": "#/definitions/KeySchema",
-   "maxItems": 2,
-   "minItems": 1
+   "items": {
+    "additionalProperties": false,
+    "properties": {
+     "AttributeName": {
+      "maxLength": 255,
+      "minLength": 1,
+      "type": "string"
+     },
+     "KeyType": {
+      "enum": [
+       "HASH",
+       "RANGE"
+      ],
+      "type": "string"
+     }
+    },
+    "required": [
+     "KeyType",
+     "AttributeName"
+    ],
+    "type": "object"
+   },
+   "minItems": 1,
+   "type": "array",
+   "uniqueItems": true,
+   "uniqueKeys": [
+    "AttributeName"
+   ]
   }
  },
  {

--- a/src/cfnlint/data/schemas/patches/providers/all/aws_dynamodb_table/keyschema.json
+++ b/src/cfnlint/data/schemas/patches/providers/all/aws_dynamodb_table/keyschema.json
@@ -28,9 +28,28 @@
   "op": "replace",
   "path": "/definitions/GlobalSecondaryIndex/properties/KeySchema",
   "value": {
-   "$ref": "#/definitions/KeySchema",
-   "maxItems": 2,
-   "minItems": 1
+   "items": {
+    "additionalProperties": false,
+    "properties": {
+     "AttributeName": {
+      "type": "string"
+     },
+     "KeyType": {
+      "type": "string"
+     }
+    },
+    "required": [
+     "KeyType",
+     "AttributeName"
+    ],
+    "type": "object"
+   },
+   "minItems": 1,
+   "type": "array",
+   "uniqueItems": true,
+   "uniqueKeys": [
+    "AttributeName"
+   ]
   }
  },
  {

--- a/src/cfnlint/data/schemas/resources/50e57ed2b28d4230.json
+++ b/src/cfnlint/data/schemas/resources/50e57ed2b28d4230.json
@@ -131,9 +131,28 @@
      "type": "string"
     },
     "KeySchema": {
-     "$ref": "#/definitions/KeySchema",
-     "maxItems": 2,
-     "minItems": 1
+     "items": {
+      "additionalProperties": false,
+      "properties": {
+       "AttributeName": {
+        "type": "string"
+       },
+       "KeyType": {
+        "type": "string"
+       }
+      },
+      "required": [
+       "KeyType",
+       "AttributeName"
+      ],
+      "type": "object"
+     },
+     "minItems": 1,
+     "type": "array",
+     "uniqueItems": true,
+     "uniqueKeys": [
+      "AttributeName"
+     ]
     },
     "OnDemandThroughput": {
      "$ref": "#/definitions/OnDemandThroughput"

--- a/src/cfnlint/data/schemas/resources/dcad01d68f1b0691.json
+++ b/src/cfnlint/data/schemas/resources/dcad01d68f1b0691.json
@@ -125,9 +125,34 @@
      "type": "string"
     },
     "KeySchema": {
-     "$ref": "#/definitions/KeySchema",
-     "maxItems": 2,
-     "minItems": 1
+     "items": {
+      "additionalProperties": false,
+      "properties": {
+       "AttributeName": {
+        "maxLength": 255,
+        "minLength": 1,
+        "type": "string"
+       },
+       "KeyType": {
+        "enum": [
+         "HASH",
+         "RANGE"
+        ],
+        "type": "string"
+       }
+      },
+      "required": [
+       "KeyType",
+       "AttributeName"
+      ],
+      "type": "object"
+     },
+     "minItems": 1,
+     "type": "array",
+     "uniqueItems": true,
+     "uniqueKeys": [
+      "AttributeName"
+     ]
     },
     "Projection": {
      "$ref": "#/definitions/Projection"

--- a/test/fixtures/templates/integration/aws-dynamodb-table.yaml
+++ b/test/fixtures/templates/integration/aws-dynamodb-table.yaml
@@ -42,3 +42,31 @@ Resources:
         KMSMasterKeyId: !GetAtt KMS.Arn
         SSEEnabled: true
         SSEType: AES256
+  Table3:
+    UpdateReplacePolicy: Retain
+    DeletionPolicy: Retain
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: table3
+      BillingMode: PAY_PER_REQUEST
+      AttributeDefinitions:
+        - AttributeName: pk
+          AttributeType: S
+        - AttributeName: sk1
+          AttributeType: S
+        - AttributeName: sk2
+          AttributeType: S
+      KeySchema:
+        - AttributeName: pk
+          KeyType: HASH
+      GlobalSecondaryIndexes:
+        - IndexName: compositeIndex
+          KeySchema:
+            - AttributeName: pk
+              KeyType: HASH
+            - AttributeName: sk1
+              KeyType: HASH
+            - AttributeName: sk2
+              KeyType: RANGE
+          Projection:
+            ProjectionType: ALL


### PR DESCRIPTION
Remove maxItems and prefixItems constraints from GSI KeySchema to support multi-attribute composite keys. Table-level and LSI KeySchema retain the existing constraints.

Fixes #4377