### PR TITLE
Allow JSONata string expressions for Arguments in Step Functions

### DIFF
--- a/src/cfnlint/rules/resources/stepfunctions/StateMachineDefinition.py
+++ b/src/cfnlint/rules/resources/stepfunctions/StateMachineDefinition.py
@@ -98,6 +98,10 @@ class StateMachineDefinition(CfnLintJsonSchema):
         }
         for k in ["ItemsPath", "MaxConcurrencyPath"]:
             schema["definitions"]["map"]["properties"][k] = False
+        for state_type in ["choice", "fail", "map", "parallel", "pass", "task", "wait"]:
+            schema["definitions"][state_type]["properties"]["Arguments"] = {
+                "type": ["string", "object"],
+            }
         return schema
 
     def _clean_schema(self, validator: Validator, instance: Any):

--- a/test/unit/rules/resources/stepfunctions/test_state_machine_definition.py
+++ b/test/unit/rules/resources/stepfunctions/test_state_machine_definition.py
@@ -1542,6 +1542,24 @@ def rule():
                 ),
             ],
         ),
+        (
+            "JSONata string Arguments in task",
+            {
+                "Definition": {
+                    "QueryLanguage": "JSONata",
+                    "StartAt": "MyTask",
+                    "States": {
+                        "MyTask": {
+                            "Type": "Task",
+                            "Resource": "arn:aws:states:::aws-sdk:s3:listObjectsV2",
+                            "Arguments": '{% $merge([{"Bucket": "my-bucket"}]) %}',
+                            "End": True,
+                        },
+                    },
+                }
+            },
+            [],
+        ),
     ],
 )
 def test_validate(


### PR DESCRIPTION
When QueryLanguage is JSONata, Arguments can be a JSONata string expression that evaluates to a JSON object, not just a literal object.

Per the [States Language spec](https://states-language.net/#arguments-and-output): *The value of "Arguments" MUST be a JSON text, or a JSONata string that evaluates to a JSON text.*

Fixes #4398