### PR TITLE
feat: add rule E3697 to validate Lambda env var 4KB size limit

### DIFF
--- a/src/cfnlint/rules/resources/lmbd/FunctionEnvironmentSize.py
+++ b/src/cfnlint/rules/resources/lmbd/FunctionEnvironmentSize.py
@@ -30,9 +30,7 @@ class FunctionEnvironmentSize(CfnLintKeyword):
     def __init__(self):
         """Init"""
         super().__init__(
-            [
-                "Resources/AWS::Lambda::Function/Properties/Environment/Variables"
-            ]
+            ["Resources/AWS::Lambda::Function/Properties/Environment/Variables"]
         )
 
     def validate(

--- a/test/unit/rules/resources/lmbd/test_function_environment_size.py
+++ b/test/unit/rules/resources/lmbd/test_function_environment_size.py
@@ -6,9 +6,7 @@ SPDX-License-Identifier: MIT-0
 import pytest
 
 from cfnlint.jsonschema import ValidationError
-from cfnlint.rules.resources.lmbd.FunctionEnvironmentSize import (
-    FunctionEnvironmentSize,
-)
+from cfnlint.rules.resources.lmbd.FunctionEnvironmentSize import FunctionEnvironmentSize
 
 
 @pytest.fixture(scope="module")
@@ -52,6 +50,18 @@ def rule():
                     rule=FunctionEnvironmentSize(),
                 ),
             ],
+        ),
+        (
+            "not-an-object",
+            [],
+        ),
+        (
+            {"KEY": 12345},
+            [],
+        ),
+        (
+            {"KEY": ["a", "b"]},
+            [],
         ),
     ],
 )


### PR DESCRIPTION
Closes #1945

## Summary
- New rule **E3697** that validates `AWS::Lambda::Function` environment variables do not exceed the 4KB (4096 bytes) limit
- Sums byte lengths of all keys and string values in `Environment.Variables`
- Reports the actual total size in the error message for easy debugging
- Follows existing `CfnLintKeyword` pattern used by other Lambda rules

## Changes
- `src/cfnlint/rules/resources/lmbd/FunctionEnvironmentSize.py`: New rule
- `test/unit/rules/resources/lmbd/test_function_environment_size.py`: 5 parametrized tests

## Test plan
- [x] All 98 Lambda rule tests pass (93 existing + 5 new)
- [x] Edge cases: empty vars (pass), exactly 4096 bytes (pass), 4097 bytes (fail)
- [x] Many small keys exceeding limit detected correctly