### PR TITLE
Require VpcConfig when FileSystemConfigs is specified on Lambda Function

### DIFF
--- a/src/cfnlint/data/schemas/patches/extensions/all/aws_lambda_function/manual.json
+++ b/src/cfnlint/data/schemas/patches/extensions/all/aws_lambda_function/manual.json
@@ -48,5 +48,14 @@
   "op": "add",
   "path": "/properties/Timeout/minimum",
   "value": 1
+ },
+ {
+  "op": "add",
+  "path": "/dependentRequired",
+  "value": {
+   "FileSystemConfigs": [
+    "VpcConfig"
+   ]
+  }
  }
 ]

--- a/src/cfnlint/data/schemas/resources/3a6aacfd45065c20.json
+++ b/src/cfnlint/data/schemas/resources/3a6aacfd45065c20.json
@@ -389,6 +389,11 @@
    "type": "object"
   }
  },
+ "dependentRequired": {
+  "FileSystemConfigs": [
+   "VpcConfig"
+  ]
+ },
  "primaryIdentifier": [
   "/properties/FunctionName"
  ],


### PR DESCRIPTION
Adds `dependentRequired` to the Lambda Function schema so that `VpcConfig` is required when `FileSystemConfigs` is specified.

Without `VpcConfig`, CloudFormation fails at deploy time with:
> Function must be configured to execute in a VPC to reference access point arn:aws:elasticfilesystem:...

Fixes #4369