### PR TITLE
Freeze date in tests for deterministic runtime deprecation results

### DIFF
--- a/src/cfnlint/rules/resources/lmbd/DeprecatedRuntimeCreate.py
+++ b/src/cfnlint/rules/resources/lmbd/DeprecatedRuntimeCreate.py
@@ -24,7 +24,6 @@ class DeprecatedRuntimeCreate(CfnLintKeyword):
     def __init__(self):
         """Init"""
         super().__init__(["Resources/AWS::Lambda::Function/Properties/Runtime"])
-        self.current_date = datetime.today()
         self.deprecated_runtimes = load_resource(
             AdditionalSpecs, "LmbdRuntimeLifecycle.json"
         )
@@ -40,11 +39,11 @@ class DeprecatedRuntimeCreate(CfnLintKeyword):
 
         if not runtime_data:
             return
+        current_date = datetime.today()
         if (
-            datetime.strptime(runtime_data["create-block"], "%Y-%m-%d")
-            <= self.current_date
+            datetime.strptime(runtime_data["create-block"], "%Y-%m-%d") <= current_date
             and datetime.strptime(runtime_data["update-block"], "%Y-%m-%d")
-            > self.current_date
+            > current_date
         ):
             yield ValidationError(
                 f"Runtime {runtime!r} was deprecated on "

--- a/src/cfnlint/rules/resources/lmbd/DeprecatedRuntimeEol.py
+++ b/src/cfnlint/rules/resources/lmbd/DeprecatedRuntimeEol.py
@@ -28,7 +28,6 @@ class DeprecatedRuntimeEol(CfnLintKeyword):
     def __init__(self):
         """Init"""
         super().__init__(["Resources/AWS::Lambda::Function/Properties/Runtime"])
-        self.current_date = datetime.today()
         self.deprecated_runtimes = load_resource(
             AdditionalSpecs, "LmbdRuntimeLifecycle.json"
         )
@@ -42,13 +41,13 @@ class DeprecatedRuntimeEol(CfnLintKeyword):
         runtime_data = self.deprecated_runtimes.get(runtime)
         if not runtime_data:
             return
+        current_date = datetime.today()
         if (
-            datetime.strptime(runtime_data["deprecated"], "%Y-%m-%d")
-            <= self.current_date
+            datetime.strptime(runtime_data["deprecated"], "%Y-%m-%d") <= current_date
             and datetime.strptime(runtime_data["create-block"], "%Y-%m-%d")
-            > self.current_date
+            > current_date
             and datetime.strptime(runtime_data["update-block"], "%Y-%m-%d")
-            > self.current_date
+            > current_date
         ):
             yield ValidationError(
                 f"Runtime {runtime!r} was deprecated on "

--- a/src/cfnlint/rules/resources/lmbd/DeprecatedRuntimeUpdate.py
+++ b/src/cfnlint/rules/resources/lmbd/DeprecatedRuntimeUpdate.py
@@ -28,7 +28,6 @@ class DeprecatedRuntimeUpdate(CfnLintKeyword):
     def __init__(self):
         """Init"""
         super().__init__(["Resources/AWS::Lambda::Function/Properties/Runtime"])
-        self.current_date = datetime.today()
         self.deprecated_runtimes = load_resource(
             AdditionalSpecs, "LmbdRuntimeLifecycle.json"
         )
@@ -41,10 +40,8 @@ class DeprecatedRuntimeUpdate(CfnLintKeyword):
         runtime_data = self.deprecated_runtimes.get(runtime)
         if not runtime_data:
             return
-        if (
-            datetime.strptime(runtime_data["update-block"], "%Y-%m-%d")
-            <= self.current_date
-        ):
+        current_date = datetime.today()
+        if datetime.strptime(runtime_data["update-block"], "%Y-%m-%d") <= current_date:
             yield ValidationError(
                 f"Runtime {runtime!r} was deprecated on "
                 f"{runtime_data['deprecated']!r}. Creation was disabled on "

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -1,0 +1,31 @@
+"""
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import patch
+
+import pytest
+
+FROZEN_DATE = datetime(2026, 1, 1)
+
+DATETIME_MODULES = [
+    "cfnlint.rules.resources.lmbd.DeprecatedRuntimeCreate.datetime",
+    "cfnlint.rules.resources.lmbd.DeprecatedRuntimeUpdate.datetime",
+    "cfnlint.rules.resources.lmbd.DeprecatedRuntimeEol.datetime",
+]
+
+
+@pytest.fixture(autouse=True)
+def freeze_datetime():
+    patches = [patch(m) for m in DATETIME_MODULES]
+    mocks = [p.start() for p in patches]
+    for mock in mocks:
+        mock.today.return_value = FROZEN_DATE
+        mock.strptime = datetime.strptime
+    yield
+    for p in patches:
+        p.stop()

--- a/test/unit/rules/resources/lmbd/test_deprecated_runtime_create.py
+++ b/test/unit/rules/resources/lmbd/test_deprecated_runtime_create.py
@@ -4,6 +4,7 @@ SPDX-License-Identifier: MIT-0
 """
 
 from datetime import datetime
+from unittest.mock import patch
 
 import pytest
 
@@ -62,6 +63,10 @@ def rule():
     ],
 )
 def test_lambda_runtime(instance, date, expected, rule, validator):
-    rule.current_date = date
-    errs = list(rule.validate(validator, "LambdaRuntime", instance, {}))
+    with patch(
+        "cfnlint.rules.resources.lmbd.DeprecatedRuntimeCreate.datetime"
+    ) as mock_dt:
+        mock_dt.today.return_value = date
+        mock_dt.strptime = datetime.strptime
+        errs = list(rule.validate(validator, "LambdaRuntime", instance, {}))
     assert errs == expected, f"Expected {expected} got {errs}"

--- a/test/unit/rules/resources/lmbd/test_deprecated_runtime_eol.py
+++ b/test/unit/rules/resources/lmbd/test_deprecated_runtime_eol.py
@@ -4,6 +4,7 @@ SPDX-License-Identifier: MIT-0
 """
 
 from datetime import datetime
+from unittest.mock import patch
 
 import pytest
 
@@ -62,6 +63,8 @@ def rule():
     ],
 )
 def test_lambda_runtime(instance, date, expected, rule, validator):
-    rule.current_date = date
-    errs = list(rule.validate(validator, "LambdaRuntime", instance, {}))
+    with patch("cfnlint.rules.resources.lmbd.DeprecatedRuntimeEol.datetime") as mock_dt:
+        mock_dt.today.return_value = date
+        mock_dt.strptime = datetime.strptime
+        errs = list(rule.validate(validator, "LambdaRuntime", instance, {}))
     assert errs == expected, f"Expected {expected} got {errs}"

--- a/test/unit/rules/resources/lmbd/test_deprecated_runtime_update.py
+++ b/test/unit/rules/resources/lmbd/test_deprecated_runtime_update.py
@@ -4,6 +4,7 @@ SPDX-License-Identifier: MIT-0
 """
 
 from datetime import datetime
+from unittest.mock import patch
 
 import pytest
 
@@ -63,6 +64,10 @@ def rule():
     ],
 )
 def test_lambda_runtime(instance, date, expected, rule, validator):
-    rule.current_date = date
-    errs = list(rule.validate(validator, "LambdaRuntime", instance, {}))
+    with patch(
+        "cfnlint.rules.resources.lmbd.DeprecatedRuntimeUpdate.datetime"
+    ) as mock_dt:
+        mock_dt.today.return_value = date
+        mock_dt.strptime = datetime.strptime
+        errs = list(rule.validate(validator, "LambdaRuntime", instance, {}))
     assert errs == expected, f"Expected {expected} got {errs}"


### PR DESCRIPTION
Moves `datetime.today()` from `__init__` to `validate` in the three `DeprecatedRuntime*` rules so the current date is evaluated at validation time rather than rule instantiation time.

This allows both unit and integration tests to mock the date:
- Unit tests patch `datetime` per test case with the specific date needed
- Integration tests freeze the date to `2026-01-01` via a conftest fixture

Without this, integration tests break whenever a runtime crosses a deprecation threshold (e.g. `python3.8` create-block on `2026-06-01`), which is particularly painful for distro packagers running tests at arbitrary future dates.

Fixes #4125