### PR TITLE
feat: add rule E3530 to validate AssumeRolePolicyDocument principal ARNs

### DIFF
--- a/src/cfnlint/data/schemas/other/iam/policy_trust.json
+++ b/src/cfnlint/data/schemas/other/iam/policy_trust.json
@@ -1,0 +1,77 @@
+{
+ "$id": "trust",
+ "additionalProperties": false,
+ "definitions": {
+  "Statement": {
+   "additionalProperties": false,
+   "allOf": [
+    {
+     "requiredXor": [
+      "Action",
+      "NotAction"
+     ]
+    },
+    {
+     "requiredXor": [
+      "Principal",
+      "NotPrincipal"
+     ]
+    },
+    {
+     "required": [
+      "Effect"
+     ]
+    }
+   ],
+   "properties": {
+    "Action": {
+     "$ref": "policy#/definitions/Action"
+    },
+    "Condition": {
+     "$ref": "policy#/definitions/Condition"
+    },
+    "Effect": {
+     "$ref": "policy#/definitions/Statement/properties/Effect"
+    },
+    "NotAction": {
+     "$ref": "policy#/definitions/Action"
+    },
+    "NotPrincipal": {
+     "$ref": "policy#/definitions/Principal"
+    },
+    "Principal": {
+     "$ref": "policy#/definitions/Principal"
+    },
+    "Sid": {
+     "$ref": "policy#/definitions/Statement/properties/Sid"
+    }
+   }
+  }
+ },
+ "properties": {
+  "Id": {
+   "$ref": "policy#/properties/Id"
+  },
+  "Statement": {
+   "$ref": "#/definitions/Statement",
+   "items": {
+    "$ref": "#/definitions/Statement",
+    "type": "object"
+   },
+   "type": [
+    "object",
+    "array"
+   ],
+   "uniqueKeys": [
+    "Sid"
+   ]
+  },
+  "Version": {
+   "$ref": "policy#/properties/Version"
+  }
+ },
+ "required": [
+  "Statement"
+ ],
+ "type": "object"
+}

--- a/src/cfnlint/rules/resources/iam/TrustPolicy.py
+++ b/src/cfnlint/rules/resources/iam/TrustPolicy.py
@@ -1,0 +1,28 @@
+"""
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+"""
+
+from cfnlint.rules.resources.iam.Policy import Policy
+
+
+class TrustPolicy(Policy):
+    """Check IAM trust Policies"""
+
+    id = "E3530"
+    shortdesc = "Validate IAM trust polices"
+    description = (
+        "IAM trust polices are embedded JSON in CloudFormation. "
+        "This rule validates those embedded policies."
+    )
+    source_url = "https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html"
+    tags = ["resources", "iam"]
+
+    def __init__(self):
+        super().__init__(
+            [
+                "Resources/AWS::IAM::Role/Properties/AssumeRolePolicyDocument",
+            ],
+            "trust",
+            "policy_trust.json",
+        )

--- a/test/fixtures/results/integration/ref-no-value.json
+++ b/test/fixtures/results/integration/ref-no-value.json
@@ -1,6 +1,35 @@
 [
     {
         "Filename": "test/fixtures/templates/integration/ref-no-value.yaml",
+        "Id": "34a6a87d-10dd-2bd9-1c1a-ceceba271dc7",
+        "Level": "Error",
+        "Location": {
+            "End": {
+                "ColumnNumber": 31,
+                "LineNumber": 10
+            },
+            "Path": [
+                "Resources",
+                "IamRole1",
+                "Properties",
+                "AssumeRolePolicyDocument"
+            ],
+            "Start": {
+                "ColumnNumber": 7,
+                "LineNumber": 10
+            }
+        },
+        "Message": "'Statement' is a required property",
+        "ParentId": null,
+        "Rule": {
+            "Description": "IAM trust polices are embedded JSON in CloudFormation. This rule validates those embedded policies.",
+            "Id": "E3530",
+            "ShortDescription": "Validate IAM trust polices",
+            "Source": "https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html"
+        }
+    },
+    {
+        "Filename": "test/fixtures/templates/integration/ref-no-value.yaml",
         "Id": "bc432adb-6b22-c519-4df7-26cd9aa0c67f",
         "Level": "Error",
         "Location": {
@@ -86,6 +115,35 @@
             "Id": "E3012",
             "ShortDescription": "Check resource properties values",
             "Source": "https://github.com/aws-cloudformation/cfn-lint/blob/main/docs/cfn-schema-specification.md#type"
+        }
+    },
+    {
+        "Filename": "test/fixtures/templates/integration/ref-no-value.yaml",
+        "Id": "d2a1ac33-b077-ea54-1d8f-aaed4ebf0c67",
+        "Level": "Error",
+        "Location": {
+            "End": {
+                "ColumnNumber": 31,
+                "LineNumber": 30
+            },
+            "Path": [
+                "Resources",
+                "IamRole3",
+                "Properties",
+                "AssumeRolePolicyDocument"
+            ],
+            "Start": {
+                "ColumnNumber": 7,
+                "LineNumber": 30
+            }
+        },
+        "Message": "'Statement' is a required property",
+        "ParentId": null,
+        "Rule": {
+            "Description": "IAM trust polices are embedded JSON in CloudFormation. This rule validates those embedded policies.",
+            "Id": "E3530",
+            "ShortDescription": "Validate IAM trust polices",
+            "Source": "https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html"
         }
     },
     {

--- a/test/unit/module/cfn_yaml/test_yaml.py
+++ b/test/unit/module/cfn_yaml/test_yaml.py
@@ -27,7 +27,7 @@ class TestYamlParse(BaseTestCase):
             },
             "generic_bad": {
                 "filename": "test/fixtures/templates/bad/generic.yaml",
-                "failures": 35,
+                "failures": 36,
             },
         }
 

--- a/test/unit/module/test_rules_collections.py
+++ b/test/unit/module/test_rules_collections.py
@@ -69,7 +69,7 @@ class TestRulesCollection(BaseTestCase):
         filename = "test/fixtures/templates/bad/generic.yaml"
         template = cfnlint.decode.cfn_yaml.load(filename)
         cfn = Template(filename, template, ["us-east-1"])
-        expected_err_count = 38
+        expected_err_count = 39
         matches = []
         matches.extend(self.rules.run(filename, cfn))
         assert len(matches) == expected_err_count, (

--- a/test/unit/rules/resources/iam/test_trust_policy.py
+++ b/test/unit/rules/resources/iam/test_trust_policy.py
@@ -1,0 +1,277 @@
+"""
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+"""
+
+from collections import deque
+from unittest import TestCase
+
+from cfnlint.context import Context, Path
+from cfnlint.helpers import FUNCTIONS
+from cfnlint.jsonschema import CfnTemplateValidator
+from cfnlint.rules.resources.iam.TrustPolicy import TrustPolicy
+
+
+class TestTrustPolicy(TestCase):
+    """Test IAM trust Policies"""
+
+    def setUp(self):
+        """Setup"""
+        self.rule = TrustPolicy()
+
+    def test_valid_trust_policy(self):
+        """Test a valid trust policy passes"""
+        validator = CfnTemplateValidator({}).evolve(
+            context=Context(
+                functions=FUNCTIONS,
+                path=Path(
+                    cfn_path=deque(["Resources", "AWS::IAM::Role", "Properties"])
+                ),
+            )
+        )
+
+        policy = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Action": "sts:AssumeRole",
+                    "Principal": {
+                        "AWS": "arn:aws:iam::123456789012:root",
+                    },
+                }
+            ],
+        }
+
+        errs = list(
+            self.rule.validate(
+                validator=validator, policy=policy, schema={}, policy_type=None
+            )
+        )
+        self.assertListEqual(errs, [])
+
+    def test_valid_trust_policy_account_id(self):
+        """Test a valid trust policy with account ID principal"""
+        validator = CfnTemplateValidator({}).evolve(
+            context=Context(
+                functions=FUNCTIONS,
+                path=Path(
+                    cfn_path=deque(["Resources", "AWS::IAM::Role", "Properties"])
+                ),
+            )
+        )
+
+        policy = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Action": "sts:AssumeRole",
+                    "Principal": {
+                        "AWS": "123456789012",
+                    },
+                }
+            ],
+        }
+
+        errs = list(
+            self.rule.validate(
+                validator=validator, policy=policy, schema={}, policy_type=None
+            )
+        )
+        self.assertListEqual(errs, [])
+
+    def test_valid_trust_policy_wildcard(self):
+        """Test a valid trust policy with wildcard principal"""
+        validator = CfnTemplateValidator({}).evolve(
+            context=Context(
+                functions=FUNCTIONS,
+                path=Path(
+                    cfn_path=deque(["Resources", "AWS::IAM::Role", "Properties"])
+                ),
+            )
+        )
+
+        policy = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Action": "sts:AssumeRole",
+                    "Principal": "*",
+                }
+            ],
+        }
+
+        errs = list(
+            self.rule.validate(
+                validator=validator, policy=policy, schema={}, policy_type=None
+            )
+        )
+        self.assertListEqual(errs, [])
+
+    def test_valid_trust_policy_service(self):
+        """Test a valid trust policy with service principal"""
+        validator = CfnTemplateValidator({}).evolve(
+            context=Context(
+                functions=FUNCTIONS,
+                path=Path(
+                    cfn_path=deque(["Resources", "AWS::IAM::Role", "Properties"])
+                ),
+            )
+        )
+
+        policy = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Action": "sts:AssumeRole",
+                    "Principal": {
+                        "Service": "ec2.amazonaws.com",
+                    },
+                }
+            ],
+        }
+
+        errs = list(
+            self.rule.validate(
+                validator=validator, policy=policy, schema={}, policy_type=None
+            )
+        )
+        self.assertListEqual(errs, [])
+
+    def test_malformed_principal_arn_double_colon(self):
+        """Test that a malformed ARN with double colon is caught"""
+        validator = CfnTemplateValidator({}).evolve(
+            context=Context(
+                functions=FUNCTIONS,
+                path=Path(
+                    cfn_path=deque(["Resources", "AWS::IAM::Role", "Properties"])
+                ),
+            )
+        )
+
+        policy = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Action": "sts:AssumeRole",
+                    "Principal": {
+                        "AWS": "arn:aws::iam::123456789012:root",
+                    },
+                }
+            ],
+        }
+
+        errs = list(
+            self.rule.validate(
+                validator=validator, policy=policy, schema={}, policy_type=None
+            )
+        )
+        self.assertTrue(len(errs) > 0, "Expected errors for malformed ARN")
+        err_messages = [e.message for e in errs]
+        self.assertTrue(
+            any("is not valid under any of the given schemas" in m for m in err_messages),
+            f"Expected anyOf validation error, got: {err_messages}",
+        )
+
+    def test_missing_principal(self):
+        """Test that missing principal is caught"""
+        validator = CfnTemplateValidator({}).evolve(
+            context=Context(
+                functions=FUNCTIONS,
+                path=Path(
+                    cfn_path=deque(["Resources", "AWS::IAM::Role", "Properties"])
+                ),
+            )
+        )
+
+        policy = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Action": "sts:AssumeRole",
+                }
+            ],
+        }
+
+        errs = list(
+            self.rule.validate(
+                validator=validator, policy=policy, schema={}, policy_type=None
+            )
+        )
+        self.assertTrue(len(errs) > 0, "Expected errors for missing principal")
+        err_messages = [e.message for e in errs]
+        self.assertTrue(
+            any("Principal" in m for m in err_messages),
+            f"Expected Principal required error, got: {err_messages}",
+        )
+
+    def test_no_resource_required(self):
+        """Test that Resource is NOT required in trust policies"""
+        validator = CfnTemplateValidator({}).evolve(
+            context=Context(
+                functions=FUNCTIONS,
+                path=Path(
+                    cfn_path=deque(["Resources", "AWS::IAM::Role", "Properties"])
+                ),
+            )
+        )
+
+        policy = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Action": "sts:AssumeRole",
+                    "Principal": {
+                        "AWS": "arn:aws:iam::123456789012:root",
+                    },
+                }
+            ],
+        }
+
+        errs = list(
+            self.rule.validate(
+                validator=validator, policy=policy, schema={}, policy_type=None
+            )
+        )
+        err_messages = [e.message for e in errs]
+        self.assertFalse(
+            any("Resource" in m for m in err_messages),
+            f"Trust policies should not require Resource, got: {err_messages}",
+        )
+
+    def test_assumed_role_principal(self):
+        """Test a valid assumed role principal"""
+        validator = CfnTemplateValidator({}).evolve(
+            context=Context(
+                functions=FUNCTIONS,
+                path=Path(
+                    cfn_path=deque(["Resources", "AWS::IAM::Role", "Properties"])
+                ),
+            )
+        )
+
+        policy = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Action": "sts:AssumeRole",
+                    "Principal": {
+                        "AWS": "arn:aws:sts::123456789012:assumed-role/rolename/session",
+                    },
+                }
+            ],
+        }
+
+        errs = list(
+            self.rule.validate(
+                validator=validator, policy=policy, schema={}, policy_type=None
+            )
+        )
+        self.assertListEqual(errs, [])


### PR DESCRIPTION
Closes #4287

## Summary
- New rule **E3530** validates principal ARNs in `AssumeRolePolicyDocument` (trust policies)
- Catches malformed ARNs like `arn:aws::iam::123456789012:root` (double colon between partition and service)
- New trust policy JSON schema that requires `Principal`/`NotPrincipal` and `Action`/`NotAction` but not `Resource`/`NotResource`
- Reuses existing `AwsPrincipalArn` patterns from `policy.json`

## Changes
- `src/cfnlint/data/schemas/other/iam/policy_trust.json`: New trust policy schema
- `src/cfnlint/rules/resources/iam/TrustPolicy.py`: New rule E3530
- `test/unit/rules/resources/iam/test_trust_policy.py`: 8 unit tests

## Test plan
- [x] 2295 tests pass, 0 failures
- [x] Valid ARNs, account IDs, wildcards, service principals all accepted
- [x] Malformed double-colon ARN correctly flagged
- [x] Trust policies without Resource field accepted (unlike resource policies)