### PR TITLE
Add W1053: Warn on dynamic references with spaces

### DIFF
--- a/src/cfnlint/helpers.py
+++ b/src/cfnlint/helpers.py
@@ -153,6 +153,9 @@ REGEX_IPV6 = re.compile(
     re.I | re.S,
 )
 REGEX_DYN_REF = re.compile(r"^.*{{(resolve:.+)}}.*$")
+REGEX_DYN_REF_SPACES = re.compile(
+    r"\{\{\s+resolve\s*:\s*(?:ssm|ssm-secure|secretsmanager)\s*:"
+)
 REGEX_DYN_REF_SSM = re.compile(r"^.*{{resolve:ssm:[a-zA-Z0-9_\.\-/]+(:\d+)?}}.*$")
 REGEX_DYN_REF_SSM_SECURE = re.compile(
     r"^.*{{resolve:ssm-secure:[a-zA-Z0-9_\.\-/]+(:\d+)?}}.*$"

--- a/src/cfnlint/jsonschema/_filter.py
+++ b/src/cfnlint/jsonschema/_filter.py
@@ -8,7 +8,13 @@ from __future__ import annotations
 from dataclasses import dataclass, field, fields
 from typing import TYPE_CHECKING, Any, Iterator, Sequence, Tuple
 
-from cfnlint.helpers import FUNCTIONS, REGEX_DYN_REF, ToPy, ensure_list
+from cfnlint.helpers import (
+    FUNCTIONS,
+    REGEX_DYN_REF,
+    REGEX_DYN_REF_SPACES,
+    ToPy,
+    ensure_list,
+)
 
 if TYPE_CHECKING:
     from cfnlint.jsonschema.protocols import Validator
@@ -127,6 +133,9 @@ class FunctionFilter:
                 ):
                     yield (instance, {"dynamicReference": schema}, validator)
                     return
+                return
+            elif REGEX_DYN_REF_SPACES.search(instance):
+                yield (instance, {"dynamicReferenceSpaces": schema}, validator)
                 return
 
         # if there are no functions then we don't need to worry

--- a/src/cfnlint/rules/functions/DynamicReferenceSpaces.py
+++ b/src/cfnlint/rules/functions/DynamicReferenceSpaces.py
@@ -1,0 +1,30 @@
+"""
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+"""
+
+from typing import Any
+
+from cfnlint.jsonschema import ValidationError, Validator
+from cfnlint.rules import CloudFormationLintRule
+
+
+class DynamicReferenceSpaces(CloudFormationLintRule):
+    id = "W1053"
+    shortdesc = "Dynamic references should not contain spaces"
+    description = (
+        "Dynamic references with spaces between '{{' and 'resolve' "
+        "will not be resolved by CloudFormation and will be treated as "
+        "a literal string"
+    )
+    source_url = "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/dynamic-references.html"
+    tags = ["functions", "dynamic reference"]
+
+    def dynamicReferenceSpaces(
+        self, validator: Validator, s: Any, instance: Any, schema: Any
+    ):
+        yield ValidationError(
+            f"{instance!r} has spaces and will not be resolved as a "
+            f"dynamic reference. Remove spaces from '{{{{resolve:...}}}}'",
+            rule=self,
+        )

--- a/src/cfnlint/rules/jsonschema/JsonSchema.py
+++ b/src/cfnlint/rules/jsonschema/JsonSchema.py
@@ -31,6 +31,7 @@ class JsonSchema(BaseJsonSchema):
             "cfnLint": "E1101",
             "condition": "E8007",
             "dynamicReference": "E1050",
+            "dynamicReferenceSpaces": "W1053",
             "fn_and": "E8004",
             "fn_base64": "E1021",
             "fn_cidr": "E1024",

--- a/test/fixtures/results/integration/dynamic-references.json
+++ b/test/fixtures/results/integration/dynamic-references.json
@@ -27,5 +27,34 @@
             "ShortDescription": "Check if property values adhere to a specific pattern",
             "Source": "https://github.com/aws-cloudformation/cfn-lint/blob/main/docs/cfn-schema-specification.md#pattern"
         }
+    },
+    {
+        "Filename": "test/fixtures/templates/integration/dynamic-references.yaml",
+        "Id": "477ff95e-7c8c-ed10-6221-7bce06ffb0bc",
+        "Level": "Warning",
+        "Location": {
+            "End": {
+                "ColumnNumber": 21,
+                "LineNumber": 37
+            },
+            "Path": [
+                "Resources",
+                "SESEventSourceMappingSpaces",
+                "Properties",
+                "EventSourceArn"
+            ],
+            "Start": {
+                "ColumnNumber": 7,
+                "LineNumber": 37
+            }
+        },
+        "Message": "'{{ resolve:ssm:/SQS_Queue/SQS_ARN }}' has spaces and will not be resolved as a dynamic reference. Remove spaces from '{{resolve:...}}'",
+        "ParentId": null,
+        "Rule": {
+            "Description": "Dynamic references with spaces between '{{' and 'resolve' will not be resolved by CloudFormation and will be treated as a literal string",
+            "Id": "W1053",
+            "ShortDescription": "Dynamic references should not contain spaces",
+            "Source": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/dynamic-references.html"
+        }
     }
 ]

--- a/test/fixtures/templates/integration/dynamic-references.yaml
+++ b/test/fixtures/templates/integration/dynamic-references.yaml
@@ -29,3 +29,10 @@ Resources:
         AutoMinorVersionUpgrade: true
         BrokerName: test
         PubliclyAccessible: false
+  SESEventSourceMappingSpaces:
+    Type: AWS::Lambda::EventSourceMapping
+    Properties:
+      BatchSize: 10
+      Enabled: true
+      EventSourceArn: '{{ resolve:ssm:/SQS_Queue/SQS_ARN }}'
+      FunctionName: MyFunctionNameHere

--- a/test/integration/test_integration_templates.py
+++ b/test/integration/test_integration_templates.py
@@ -26,7 +26,7 @@ class TestQuickStartTemplates(BaseCliTestCase):
             "results_filename": (
                 "test/fixtures/results/integration/dynamic-references.json"
             ),
-            "exit_code": 2,
+            "exit_code": 6,
         },
         {
             "filename": "test/fixtures/templates/integration/ref-no-value.yaml",

--- a/test/unit/module/jsonschema/test_filter.py
+++ b/test/unit/module/jsonschema/test_filter.py
@@ -55,6 +55,19 @@ def template():
             ],
         ),
         (
+            "Validate dynamic references with spaces",
+            "{{ resolve:ssm:secret }}",
+            {"enum": "Foo"},
+            deque(["Foo", "Test"]),
+            [],
+            [
+                (
+                    "{{ resolve:ssm:secret }}",
+                    {"dynamicReferenceSpaces": {"enum": "Foo"}},
+                ),
+            ],
+        ),
+        (
             "Lack of functions returns the schema and instance",
             {
                 "Foo": {"Ref": "AWS::NoValue"},

--- a/test/unit/rules/functions/test_dynamic_reference_spaces.py
+++ b/test/unit/rules/functions/test_dynamic_reference_spaces.py
@@ -1,0 +1,84 @@
+"""
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+"""
+
+import pytest
+
+from cfnlint.context import create_context_for_template
+from cfnlint.jsonschema import CfnTemplateValidator, ValidationError
+from cfnlint.rules.functions.DynamicReferenceSpaces import DynamicReferenceSpaces
+from cfnlint.template import Template
+
+
+@pytest.fixture(scope="module")
+def rule():
+    rule = DynamicReferenceSpaces()
+    yield rule
+
+
+@pytest.fixture(scope="module")
+def cfn():
+    return Template(
+        "",
+        {},
+        regions=["us-east-1"],
+    )
+
+
+@pytest.fixture(scope="module")
+def context(cfn):
+    return create_context_for_template(cfn)
+
+
+@pytest.mark.parametrize(
+    "name,instance,expected",
+    [
+        (
+            "Invalid - space before resolve for ssm",
+            "{{ resolve:ssm:SomeParameter }}",
+            [
+                ValidationError(
+                    (
+                        "'{{ resolve:ssm:SomeParameter }}' has spaces and will"
+                        " not be resolved as a dynamic reference. Remove spaces"
+                        " from '{{resolve:...}}'"
+                    ),
+                    rule=DynamicReferenceSpaces(),
+                ),
+            ],
+        ),
+        (
+            "Invalid - space before resolve for ssm-secure",
+            "{{ resolve:ssm-secure:SomeParameter }}",
+            [
+                ValidationError(
+                    (
+                        "'{{ resolve:ssm-secure:SomeParameter }}' has spaces"
+                        " and will not be resolved as a dynamic reference."
+                        " Remove spaces from '{{resolve:...}}'"
+                    ),
+                    rule=DynamicReferenceSpaces(),
+                ),
+            ],
+        ),
+        (
+            "Invalid - space before resolve for secretsmanager",
+            "{{ resolve:secretsmanager:SomeSecret }}",
+            [
+                ValidationError(
+                    (
+                        "'{{ resolve:secretsmanager:SomeSecret }}' has spaces"
+                        " and will not be resolved as a dynamic reference."
+                        " Remove spaces from '{{resolve:...}}'"
+                    ),
+                    rule=DynamicReferenceSpaces(),
+                ),
+            ],
+        ),
+    ],
+)
+def test_validate(name, instance, expected, rule, context, cfn):
+    validator = CfnTemplateValidator(context=context, cfn=cfn)
+    errs = list(rule.dynamicReferenceSpaces(validator, {}, instance, {}))
+    assert errs == expected, f"Test {name!r} got {errs!r}"


### PR DESCRIPTION
## Summary

Dynamic references like `{{ resolve:ssm:Param }}` with spaces between `{{` and `resolve` are silently treated as literal strings by CloudFormation instead of being resolved. This adds W1053, a warning rule to detect this common mistake.

## Testing

Confirmed against CloudFormation directly:
- `{{resolve:ssm:CfnLintTest4171}}` → resolves to the parameter value ✅
- `{{ resolve:ssm:CfnLintTest4171 }}` → left as a literal string, not resolved ❌

## Changes

- `src/cfnlint/helpers.py` — Added `REGEX_DYN_REF_SPACES` regex
- `src/cfnlint/jsonschema/_filter.py` — Detect spaced dynamic references in the filter
- `src/cfnlint/rules/jsonschema/JsonSchema.py` — Register `dynamicReferenceSpaces` keyword
- `src/cfnlint/rules/functions/DynamicReferenceSpaces.py` — New W1053 rule
- Unit tests for the rule and filter
- Integration test with end-to-end validation

Fixes #4171