### PR TITLE
Fix max recursion crash when cfnlintrc has non_zero_exit_code

### DIFF
--- a/src/cfnlint/config.py
+++ b/src/cfnlint/config.py
@@ -193,12 +193,6 @@ class ConfigFileArgs:
                 else "root"
             )
 
-            # Create a minimal config with just the format setting for error formatting
-            format_setting = config.get("format") if isinstance(config, dict) else None
-            minimal_config = ConfigMixIn(
-                [], **({"format": format_setting} if format_setting else {})
-            )
-
             if hasattr(e, "validator") and e.validator == "additionalProperties":
                 invalid_key = (
                     list(e.instance.keys() - e.schema.get("properties", {}).keys())[0]
@@ -210,7 +204,7 @@ class ConfigFileArgs:
                         f"Invalid configuration key '{invalid_key}' "
                         f"in .cfnlintrc at {error_path}"
                     ),
-                    minimal_config,
+                    None,
                 )
             elif hasattr(e, "validator") and e.validator == "type":
                 expected_type = (
@@ -223,7 +217,7 @@ class ConfigFileArgs:
                         f"Invalid type for '{error_path}' "
                         f"in .cfnlintrc. Expected {expected_type}"
                     ),
-                    minimal_config,
+                    None,
                 )
             elif hasattr(e, "validator") and e.validator == "required":
                 missing_prop = (
@@ -234,7 +228,7 @@ class ConfigFileArgs:
                         f"Missing required property '{missing_prop}' "
                         f"in .cfnlintrc at {error_path}"
                     ),
-                    minimal_config,
+                    None,
                 )
             else:
                 # Fallback for other validation errors
@@ -243,7 +237,7 @@ class ConfigFileArgs:
                         f"Invalid configuration in .cfnlintrc at {error_path}: "
                         f"{e.message if hasattr(e, 'message') else str(e)}"
                     ),
-                    minimal_config,
+                    None,
                 )
 
     def merge_config(self, user_config, project_config):

--- a/src/cfnlint/data/CfnLintCli/config/schema.json
+++ b/src/cfnlint/data/CfnLintCli/config/schema.json
@@ -68,6 +68,18 @@
    },
    "type": "array"
   },
+  "format": {
+   "description": "Output format",
+   "enum": [
+    "quiet",
+    "parseable",
+    "json",
+    "junit",
+    "pretty",
+    "sarif"
+   ],
+   "type": "string"
+  },
   "ignore_bad_template": {
    "description": "Ignore bad templates",
    "type": "boolean"
@@ -93,6 +105,10 @@
    },
    "type": "array"
   },
+  "include_experimental": {
+   "description": "Include experimental rules",
+   "type": "boolean"
+  },
   "mandatory_checks": {
    "description": "List of mandatory checks to enforce",
    "items": {
@@ -103,6 +119,16 @@
   "merge_configs": {
    "description": "Merges lists between configuration layers",
    "type": "boolean"
+  },
+  "non_zero_exit_code": {
+   "description": "Exit code will be non zero from the specified rule class and higher",
+   "enum": [
+    "informational",
+    "warning",
+    "error",
+    "none"
+   ],
+   "type": "string"
   },
   "output_file": {
    "description": "Path to the file to write the main output to",

--- a/src/cfnlint/runner/cli.py
+++ b/src/cfnlint/runner/cli.py
@@ -342,11 +342,14 @@ def main() -> None:
     try:
         config = ConfigMixIn(sys.argv[1:])
     except ConfigFileError as e:
-        formatter = get_formatter(e.config)
-        match = Match(str(e), ConfigError(), None)
-        output = formatter.print_matches([match], Rules(), config=e.config)
-        if output:
-            print(output)
+        if e.config is not None:
+            formatter = get_formatter(e.config)
+            match = Match(str(e), ConfigError(), None)
+            output = formatter.print_matches([match], Rules(), config=e.config)
+            if output:
+                print(output)
+        else:
+            print(str(e))
         sys.exit(1)
     except Exception as e:
         print(e)

--- a/test/fixtures/configs/non_zero_exit_code.yaml
+++ b/test/fixtures/configs/non_zero_exit_code.yaml
@@ -1,0 +1,1 @@
+non_zero_exit_code: error

--- a/test/unit/module/config/test_config_file_args.py
+++ b/test/unit/module/config/test_config_file_args.py
@@ -184,3 +184,40 @@ class TestConfigFileArgs(BaseTestCase):
 
         self.assertIn("Invalid type for 'regions'", str(context.exception))
         self.assertIn("Expected array", str(context.exception))
+
+    def test_config_parser_non_zero_exit_code(self):
+        """test that non_zero_exit_code is accepted in config file"""
+        config = cfnlint.config.ConfigFileArgs(
+            config_file=Path("test/fixtures/configs/non_zero_exit_code.yaml")
+        )
+        self.assertEqual(
+            config.file_args,
+            {"non_zero_exit_code": "error"},
+        )
+
+    @patch("cfnlint.config.ConfigFileArgs._read_config", create=True)
+    def test_config_parser_non_zero_exit_code_invalid(self, yaml_mock):
+        """test that invalid non_zero_exit_code value is rejected"""
+
+        yaml_mock.side_effect = [{"non_zero_exit_code": "invalid"}, {}, {}, {}]
+
+        with self.assertRaises(ConfigFileError):
+            cfnlint.config.ConfigFileArgs()
+
+    @patch("cfnlint.config.ConfigFileArgs._read_config", create=True)
+    def test_config_parser_format(self, yaml_mock):
+        """test that format is accepted in config file"""
+
+        yaml_mock.side_effect = [{"format": "json"}, {}]
+
+        results = cfnlint.config.ConfigFileArgs()
+        self.assertEqual(results.file_args, {"format": "json"})
+
+    @patch("cfnlint.config.ConfigFileArgs._read_config", create=True)
+    def test_config_parser_include_experimental(self, yaml_mock):
+        """test that include_experimental is accepted in config file"""
+
+        yaml_mock.side_effect = [{"include_experimental": True}, {}]
+
+        results = cfnlint.config.ConfigFileArgs()
+        self.assertEqual(results.file_args, {"include_experimental": True})

--- a/test/unit/module/runner/test_cli.py
+++ b/test/unit/module/runner/test_cli.py
@@ -303,3 +303,16 @@ class TestCli(BaseTestCase):
             runner.cli()
 
         self.assertEqual(e.exception.code, 2)
+
+    @patch("cfnlint.runner.cli.ConfigMixIn")
+    def test_main_config_file_error_none_config(self, mock_config):
+        from cfnlint.exceptions import ConfigFileError
+        from cfnlint.runner.cli import main
+
+        mock_config.side_effect = ConfigFileError("Invalid key 'bad'", None)
+
+        with patch("sys.exit", side_effect=SystemExit(1)):
+            with patch("builtins.print") as mock_print:
+                with self.assertRaises(SystemExit):
+                    main()
+                mock_print.assert_called_once_with("Invalid key 'bad'")


### PR DESCRIPTION
## Summary

Using `non_zero_exit_code`, `format`, or `include_experimental` in `.cfnlintrc` caused a `maximum recursion depth exceeded` crash. The config schema was missing these properties, and with `additionalProperties: false`, validation failed. The error handler then created a new `ConfigMixIn` which loaded the same config file, triggering the same error — infinite recursion.

## Changes

- Add `non_zero_exit_code`, `format`, and `include_experimental` to the config schema
- Remove recursive `ConfigMixIn` creation from the validation error handler (pass `None` instead)
- Handle `None` config gracefully in CLI error output

## Note

The config file value for `non_zero_exit_code` is accepted but doesn't take effect due to a pre-existing config precedence issue (argparse default is truthy and wins over file values). That's a separate issue.

Fixes #4326