### PR TITLE
Fix deployment file template path resolution from CWD

### DIFF
--- a/src/cfnlint/runner/deployment_file/runner.py
+++ b/src/cfnlint/runner/deployment_file/runner.py
@@ -81,7 +81,7 @@ def expand_deployment_files(
 
         try:
             template_path = (
-                (Path(deployment_file).parent / deployment_data.template_file_path)
+                Path(deployment_data.template_file_path)
                 .resolve()
                 .relative_to(Path.cwd())
             )
@@ -90,9 +90,7 @@ def expand_deployment_files(
                 f"Template file path {deployment_data.template_file_path!r} "
                 "is not relative to the current working directory"
             )
-            template_path = (
-                Path(deployment_file).parent / deployment_data.template_file_path
-            )
+            template_path = Path(deployment_data.template_file_path)
 
         if str(template_path) in deployments:
             deployments[str(template_path)].append(

--- a/test/fixtures/deployment_files/dev.yaml
+++ b/test/fixtures/deployment_files/dev.yaml
@@ -1,4 +1,4 @@
-template-file-path: ../templates/integration/deployment-file-template.yaml
+template-file-path: test/fixtures/templates/integration/deployment-file-template.yaml
 parameters:
   Environment: Dev
 tags:

--- a/test/fixtures/deployment_files/prod.yaml
+++ b/test/fixtures/deployment_files/prod.yaml
@@ -1,4 +1,4 @@
-template-file-path: ../templates/integration/deployment-file-template.yaml
+template-file-path: test/fixtures/templates/integration/deployment-file-template.yaml
 parameters:
   AvailabilityZone: us-east-1a
   ImageId: ami-12345678

--- a/test/fixtures/deployment_files/stage.yaml
+++ b/test/fixtures/deployment_files/stage.yaml
@@ -1,4 +1,4 @@
-template-file-path: ../templates/integration/deployment-file-template.yaml
+template-file-path: test/fixtures/templates/integration/deployment-file-template.yaml
 parameters:
   AvailabilityZone: us-east-1a
   ImageId: ami-zxyzabc123

--- a/test/fixtures/deployment_files/test.yaml
+++ b/test/fixtures/deployment_files/test.yaml
@@ -1,4 +1,4 @@
-template-file-path: ../templates/integration/deployment-file-template.yaml
+template-file-path: test/fixtures/templates/integration/deployment-file-template.yaml
 parameters:
   AvailabilityZone: us-east-1a
   ImageId: ami-zxyzabc123

--- a/test/unit/module/runner/deployment_file/test_runner.py
+++ b/test/unit/module/runner/deployment_file/test_runner.py
@@ -169,6 +169,39 @@ def mock_glob(value, recursive):
             ],
         ),
         (
+            "Git sync file in subdirectory resolves template path from CWD",
+            {
+                "syncs/dev.yml": (
+                    {
+                        "template-file-path": "cloudformation/template.yml",
+                        "parameters": {
+                            "Env": "dev",
+                        },
+                        "tags": {},
+                    },
+                    [],
+                ),
+            },
+            [
+                (
+                    ConfigMixIn(
+                        [],
+                        deployment_files=["syncs/dev.yml"],
+                        parameters=[
+                            ParameterSet(
+                                source="syncs/dev.yml",
+                                parameters={"Env": "dev"},
+                            )
+                        ],
+                        templates=[
+                            "cloudformation/template.yml",
+                        ],
+                    ),
+                    [],
+                )
+            ],
+        ),
+        (
             "Bad template-file-path type",
             {
                 _filename_dev: (


### PR DESCRIPTION
## Summary

`--deployment-files` (GitSync) resolved `template-file-path` relative to the deployment file's parent directory instead of the current working directory. This caused incorrect paths when sync files were in subdirectories (e.g. `syncs/dev.yml` with `template-file-path: cloudformation/template.yml` would look for `syncs/cloudformation/template.yml`).

Per the [AWS docs](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/git-sync-create-stack-from-repository-source-code.html), `template-file-path` should be the "full path from the root of your repository for the stack template file."

## Changes

- `src/cfnlint/runner/deployment_file/runner.py` — Resolve template path from CWD instead of deployment file parent
- Updated test fixture deployment files to use repo-root-relative paths
- Added test case for deployment files in subdirectories

Fixes #4265