### PR TITLE
Fix maintenance workflow to update requirements/base.txt

### DIFF
--- a/.github/workflows/maintenance-v1.yaml
+++ b/.github/workflows/maintenance-v1.yaml
@@ -22,7 +22,7 @@ jobs:
         run: |
           latest_sam_cli=`curl -s https://api.github.com/repos/aws/aws-sam-cli/releases/latest | jq -r .tag_name | cut -c 2-`
           latest=`curl "https://pypi.org/pypi/aws-sam-cli/$latest_sam_cli/json" -s | jq -r '.info.requires_dist[] | select(contains("aws-sam-translator"))' | cut -c 21-`
-          sed -i -E "s/aws-sam-translator>=[0-9.]+/aws-sam-translator>=$latest/" pyproject.toml
+          sed -i -E "s/aws-sam-translator>=[0-9.]+/aws-sam-translator>=$latest/" requirements/base.txt
           pip install -e .
           pip install requests
           rm -rf src/cfnlint/data/DownloadsMetadata/*


### PR DESCRIPTION
The maintenance workflow's `sed` command was targeting `pyproject.toml` but the `aws-sam-translator` dependency lives in `requirements/base.txt`. The version floor was never being bumped as a result.