### PR TITLE
Add enum validation for predictive scaling predefined metric types

### DIFF
--- a/src/cfnlint/data/schemas/patches/extensions/all/aws_applicationautoscaling_scalingpolicy/manual.json
+++ b/src/cfnlint/data/schemas/patches/extensions/all/aws_applicationautoscaling_scalingpolicy/manual.json
@@ -16,5 +16,50 @@
     "ServiceNamespace"
    ]
   }
+ },
+ {
+  "op": "add",
+  "path": "/definitions/PredictiveScalingPredefinedLoadMetric/properties/PredefinedMetricType/enum",
+  "value": [
+   "ALBRequestCount",
+   "ALBRequestCountPerTarget",
+   "ECSServiceAverageCPUUtilization",
+   "ECSServiceAverageMemoryUtilization",
+   "ECSServiceCPUUtilization",
+   "ECSServiceMemoryUtilization",
+   "ECSServiceTotalCPUUtilization",
+   "ECSServiceTotalMemoryUtilization",
+   "TotalALBRequestCount"
+  ]
+ },
+ {
+  "op": "add",
+  "path": "/definitions/PredictiveScalingPredefinedMetricPair/properties/PredefinedMetricType/enum",
+  "value": [
+   "ALBRequestCount",
+   "ALBRequestCountPerTarget",
+   "ECSServiceAverageCPUUtilization",
+   "ECSServiceAverageMemoryUtilization",
+   "ECSServiceCPUUtilization",
+   "ECSServiceMemoryUtilization",
+   "ECSServiceTotalCPUUtilization",
+   "ECSServiceTotalMemoryUtilization",
+   "TotalALBRequestCount"
+  ]
+ },
+ {
+  "op": "add",
+  "path": "/definitions/PredictiveScalingPredefinedScalingMetric/properties/PredefinedMetricType/enum",
+  "value": [
+   "ALBRequestCount",
+   "ALBRequestCountPerTarget",
+   "ECSServiceAverageCPUUtilization",
+   "ECSServiceAverageMemoryUtilization",
+   "ECSServiceCPUUtilization",
+   "ECSServiceMemoryUtilization",
+   "ECSServiceTotalCPUUtilization",
+   "ECSServiceTotalMemoryUtilization",
+   "TotalALBRequestCount"
+  ]
  }
 ]

--- a/src/cfnlint/data/schemas/resources/9b14b927a9c342b5.json
+++ b/src/cfnlint/data/schemas/resources/9b14b927a9c342b5.json
@@ -321,6 +321,17 @@
    "additionalProperties": false,
    "properties": {
     "PredefinedMetricType": {
+     "enum": [
+      "ALBRequestCount",
+      "ALBRequestCountPerTarget",
+      "ECSServiceAverageCPUUtilization",
+      "ECSServiceAverageMemoryUtilization",
+      "ECSServiceCPUUtilization",
+      "ECSServiceMemoryUtilization",
+      "ECSServiceTotalCPUUtilization",
+      "ECSServiceTotalMemoryUtilization",
+      "TotalALBRequestCount"
+     ],
      "maxLength": 128,
      "minLength": 1,
      "type": "string"
@@ -340,6 +351,17 @@
    "additionalProperties": false,
    "properties": {
     "PredefinedMetricType": {
+     "enum": [
+      "ALBRequestCount",
+      "ALBRequestCountPerTarget",
+      "ECSServiceAverageCPUUtilization",
+      "ECSServiceAverageMemoryUtilization",
+      "ECSServiceCPUUtilization",
+      "ECSServiceMemoryUtilization",
+      "ECSServiceTotalCPUUtilization",
+      "ECSServiceTotalMemoryUtilization",
+      "TotalALBRequestCount"
+     ],
      "maxLength": 128,
      "minLength": 1,
      "type": "string"
@@ -359,6 +381,17 @@
    "additionalProperties": false,
    "properties": {
     "PredefinedMetricType": {
+     "enum": [
+      "ALBRequestCount",
+      "ALBRequestCountPerTarget",
+      "ECSServiceAverageCPUUtilization",
+      "ECSServiceAverageMemoryUtilization",
+      "ECSServiceCPUUtilization",
+      "ECSServiceMemoryUtilization",
+      "ECSServiceTotalCPUUtilization",
+      "ECSServiceTotalMemoryUtilization",
+      "TotalALBRequestCount"
+     ],
      "maxLength": 128,
      "minLength": 1,
      "type": "string"


### PR DESCRIPTION
## Summary

Add enum constraints for `PredefinedMetricType` in the three predictive scaling predefined metric definitions for `AWS::ApplicationAutoScaling::ScalingPolicy`. The schema had no enum, so invalid metric types were not caught.

Values sourced from the [API docs](https://docs.aws.amazon.com/autoscaling/application/APIReference/API_PredictiveScalingPredefinedLoadMetricSpecification.html).

Fixes #4192