### PR TITLE
Fix ForEach transform resolving functions in Fn::If condition name

### DIFF
--- a/src/cfnlint/template/template.py
+++ b/src/cfnlint/template/template.py
@@ -934,7 +934,7 @@ class Template:  # pylint: disable=R0904,too-many-lines,too-many-instance-attrib
                 if len(value) == 1:
                     if "Fn::If" in value:
                         if_values = value.get("Fn::If")
-                        if len(if_values) == 3:
+                        if len(if_values) == 3 and isinstance(if_values[0], str):
                             if_path = scenario.get(if_values[0], None)
                             if if_path is not None:
                                 if if_path:
@@ -995,7 +995,7 @@ class Template:  # pylint: disable=R0904,too-many-lines,too-many-instance-attrib
                 if len(value) == 1:
                     if "Fn::If" in value:
                         if_values = value.get("Fn::If")
-                        if len(if_values) == 3:
+                        if len(if_values) == 3 and isinstance(if_values[0], str):
                             if_path = scenario.get(if_values[0], None)
                             if if_path is not None:
                                 if if_path:

--- a/src/cfnlint/template/transforms/_language_extensions.py
+++ b/src/cfnlint/template/transforms/_language_extensions.py
@@ -182,6 +182,13 @@ class _Transform:
                             if r in params:
                                 return params[r]
                         obj[k] = r
+                elif k == "Fn::If":
+                    if isinstance(v, list) and len(v) == 3:
+                        # CloudFormation does not resolve the condition name
+                        # (index 0) inside Fn::ForEach, so we leave it as-is
+                        # and only walk the true/false branches.
+                        obj[k][1] = self._walk(v[1], params, cfn)
+                        obj[k][2] = self._walk(v[2], params, cfn)
                 else:
                     sub_value = self._walk(v, params, cfn)
                     # a sub object may be none or we have returned

--- a/test/unit/module/template/test_template.py
+++ b/test/unit/module/template/test_template.py
@@ -1521,3 +1521,67 @@ ElasticLoadBalancer -> MyEC2Instance [key=0, source_paths="[\\"Properties\\", \\
                     },
                     self.template.get_valid_getatts().json_schema("us-east-1"),
                 )
+
+    def test_get_object_without_conditions_non_string_condition(self):
+        """Test that non-string condition names in Fn::If don't crash"""
+        template = convert_dict(
+            {
+                "Conditions": {"myCondition": {"Fn::Equals": [{"Ref": "Env"}, "prod"]}},
+                "Resources": {
+                    "myInstance": {
+                        "Type": "AWS::EC2::Instance",
+                        "Properties": {
+                            "ImageId": {
+                                "Fn::If": [
+                                    {"Fn::Sub": "myCondition"},
+                                    "ami-prod",
+                                    "ami-dev",
+                                ]
+                            },
+                        },
+                    }
+                },
+            }
+        )
+        template = Template("test.yaml", template)
+
+        results = template.get_object_without_conditions(
+            template.template.get("Resources", {})
+            .get("myInstance", {})
+            .get("Properties", {})
+        )
+        # Should not crash, and should return the object with the Fn::If unresolved
+        self.assertEqual(len(results), 1)
+        self.assertIn("ImageId", results[0]["Object"])
+
+    def test_get_object_without_nested_conditions_non_string_condition(self):
+        """Test that non-string condition names in Fn::If don't crash"""
+        template = convert_dict(
+            {
+                "Conditions": {"myCondition": {"Fn::Equals": [{"Ref": "Env"}, "prod"]}},
+                "Resources": {
+                    "myInstance": {
+                        "Type": "AWS::EC2::Instance",
+                        "Properties": {
+                            "ImageId": {
+                                "Fn::If": [
+                                    {"Fn::Sub": "myCondition"},
+                                    "ami-prod",
+                                    "ami-dev",
+                                ]
+                            },
+                        },
+                    }
+                },
+            }
+        )
+        template = Template("test.yaml", template)
+
+        results = template.get_object_without_nested_conditions(
+            template.template.get("Resources", {})
+            .get("myInstance", {})
+            .get("Properties", {}),
+            ["Resources", "AWS::EC2::Instance", "Properties"],
+        )
+        self.assertEqual(len(results), 1)
+        self.assertIn("ImageId", results[0]["Object"])

--- a/test/unit/module/template/transforms/test_language_extensions.py
+++ b/test/unit/module/template/transforms/test_language_extensions.py
@@ -1303,3 +1303,122 @@ class TestTransformValueIsStringInMap(TestCase):
                 self.result,
                 template,
             )
+
+
+class TestTransformFnIfWithFunctionCondition(TestCase):
+    """Test that Fn::If with a function in the condition position is not resolved"""
+
+    def setUp(self) -> None:
+        self.template_obj = convert_dict(
+            {
+                "Transform": ["AWS::LanguageExtensions"],
+                "Conditions": {
+                    "Fn::ForEach::CondLoop": [
+                        "Identifier",
+                        ["1"],
+                        {
+                            "Condition${Identifier}": {
+                                "Fn::Not": [{"Fn::Equals": ["-", "-"]}]
+                            }
+                        },
+                    ]
+                },
+                "Resources": {
+                    "Fn::ForEach::ResLoop": [
+                        "Identifier",
+                        ["1"],
+                        {
+                            "Resource${Identifier}": {
+                                "Type": "AWS::SSM::Parameter",
+                                "Properties": {
+                                    "Type": "String",
+                                    "Value": {
+                                        "Fn::If": [
+                                            {"Fn::Sub": "Condition${Identifier}"},
+                                            1,
+                                            2,
+                                        ]
+                                    },
+                                },
+                            }
+                        },
+                    ]
+                },
+            }
+        )
+
+    def test_transform(self):
+        with mock.patch(
+            "cfnlint.template.transforms._language_extensions._ACCOUNT_ID", None
+        ):
+            cfn = Template(
+                filename="", template=self.template_obj, regions=["us-east-1"]
+            )
+            matches, template = language_extension(cfn)
+            self.assertListEqual(matches, [])
+            # The Fn::Sub in the condition position should NOT be resolved
+            fn_if = template["Resources"]["Resource1"]["Properties"]["Value"]["Fn::If"]
+            self.assertIsInstance(fn_if[0], dict)
+            self.assertIn("Fn::Sub", fn_if[0])
+            # But the true/false branches should still be walked
+            self.assertEqual(fn_if[1], 1)
+            self.assertEqual(fn_if[2], 2)
+
+
+class TestTransformFnIfWithStringCondition(TestCase):
+    """Test Fn::If with a string condition name is resolved"""
+
+    def setUp(self) -> None:
+        self.template_obj = convert_dict(
+            {
+                "Transform": ["AWS::LanguageExtensions"],
+                "Conditions": {
+                    "Fn::ForEach::CondLoop": [
+                        "Identifier",
+                        ["1"],
+                        {
+                            "Condition${Identifier}": {
+                                "Fn::Not": [{"Fn::Equals": ["-", "-"]}]
+                            }
+                        },
+                    ]
+                },
+                "Resources": {
+                    "Fn::ForEach::ResLoop": [
+                        "Identifier",
+                        ["1"],
+                        {
+                            "Resource${Identifier}": {
+                                "Type": "AWS::SSM::Parameter",
+                                "Properties": {
+                                    "Type": "String",
+                                    "Value": {
+                                        "Fn::If": [
+                                            "Condition${Identifier}",
+                                            1,
+                                            2,
+                                        ]
+                                    },
+                                },
+                            }
+                        },
+                    ]
+                },
+            }
+        )
+
+    def test_transform(self):
+        with mock.patch(
+            "cfnlint.template.transforms._language_extensions._ACCOUNT_ID", None
+        ):
+            cfn = Template(
+                filename="", template=self.template_obj, regions=["us-east-1"]
+            )
+            matches, template = language_extension(cfn)
+            self.assertListEqual(matches, [])
+            fn_if = template["Resources"]["Resource1"]["Properties"]["Value"]["Fn::If"]
+            # String condition name should NOT be resolved — CloudFormation
+            # does not support variable substitution in Fn::If condition names
+            self.assertEqual(fn_if[0], "Condition${Identifier}")
+            self.assertEqual(fn_if[1], 1)
+            self.assertEqual(fn_if[2], 2)


### PR DESCRIPTION
## Summary

CloudFormation does not resolve functions like `Fn::Sub` in the condition name position (index 0) of `Fn::If` inside `Fn::ForEach`. cfn-lint's local transform was resolving them, hiding the error. Now the transform leaves functions in that position unresolved, and E1028 catches it.

Also fixes an E3019 crash (`unhashable type: 'dict_node'`) when `Fn::If` has a non-string condition name by guarding the scenario lookup.

Plain string interpolation (`'Condition${Identifier}'`) in the condition position still works correctly.

Fixes #3996