### PR TITLE
Add JSONPath pattern validation for Step Functions state machine

### DIFF
--- a/src/cfnlint/data/schemas/other/step_functions/statemachine.json
+++ b/src/cfnlint/data/schemas/other/step_functions/statemachine.json
@@ -226,6 +226,7 @@
        "type": "string"
       },
       "Variable": {
+       "pattern": "^\\$",
        "type": "string"
       }
      },
@@ -298,6 +299,7 @@
      ]
     },
     "InputPath": {
+     "pattern": "^\\$",
      "type": [
       "string",
       "null"
@@ -314,6 +316,7 @@
      ]
     },
     "OutputPath": {
+     "pattern": "^\\$",
      "type": [
       "string",
       "null"
@@ -412,6 +415,7 @@
      "type": "string"
     },
     "InputPath": {
+     "pattern": "^\\$",
      "type": [
       "string",
       "null"
@@ -424,6 +428,7 @@
      ]
     },
     "OutputPath": {
+     "pattern": "^\\$",
      "type": [
       "string",
       "null"
@@ -499,6 +504,7 @@
      ]
     },
     "InputPath": {
+     "pattern": "^\\$",
      "type": [
       "string",
       "null"
@@ -585,6 +591,7 @@
      ]
     },
     "OutputPath": {
+     "pattern": "^\\$",
      "type": [
       "string",
       "null"
@@ -597,6 +604,7 @@
      "$ref": "#/definitions/queryLanguage"
     },
     "ResultPath": {
+     "pattern": "^\\$",
      "type": [
       "string",
       "null"
@@ -708,6 +716,7 @@
      ]
     },
     "InputPath": {
+     "pattern": "^\\$",
      "type": [
       "string",
       "null"
@@ -724,6 +733,7 @@
      ]
     },
     "OutputPath": {
+     "pattern": "^\\$",
      "type": [
       "string",
       "null"
@@ -733,6 +743,7 @@
      "$ref": "#/definitions/queryLanguage"
     },
     "ResultPath": {
+     "pattern": "^\\$",
      "type": [
       "string",
       "null"
@@ -806,6 +817,7 @@
      ]
     },
     "InputPath": {
+     "pattern": "^\\$",
      "type": [
       "string",
       "null"
@@ -822,6 +834,7 @@
      ]
     },
     "OutputPath": {
+     "pattern": "^\\$",
      "type": [
       "string",
       "null"
@@ -835,6 +848,7 @@
     },
     "Result": {},
     "ResultPath": {
+     "pattern": "^\\$",
      "type": "string"
     },
     "Type": {
@@ -1080,6 +1094,7 @@
      "type": "string"
     },
     "InputPath": {
+     "pattern": "^\\$",
      "type": [
       "string",
       "null"
@@ -1096,6 +1111,7 @@
      ]
     },
     "OutputPath": {
+     "pattern": "^\\$",
      "type": [
       "string",
       "null"
@@ -1114,6 +1130,7 @@
      ]
     },
     "ResultPath": {
+     "pattern": "^\\$",
      "type": [
       "string",
       "null"
@@ -1194,6 +1211,7 @@
      ]
     },
     "InputPath": {
+     "pattern": "^\\$",
      "type": [
       "string",
       "null"
@@ -1210,6 +1228,7 @@
      ]
     },
     "OutputPath": {
+     "pattern": "^\\$",
      "type": [
       "string",
       "null"


### PR DESCRIPTION
## Summary

Add `pattern: '^\\$'` to `Variable`, `OutputPath`, `InputPath`, and `ResultPath` in the state machine definition schema. These fields must be valid JSONPath references starting with `$`. CloudFormation rejects values that don't start with `$` but cfn-lint wasn't catching it.

Fixes #4076
Fixes #4078