### PR TITLE
Ignore CVE-2026-4539 (pygments) in pip-audit

### DIFF
--- a/.github/workflows/ci-pr.yaml
+++ b/.github/workflows/ci-pr.yaml
@@ -78,3 +78,4 @@ jobs:
             PYSEC-2022-43012
             PYSEC-2024-60
             GHSA-4xh5-x5gv-qwph
+            CVE-2026-4539


### PR DESCRIPTION
Pygments is not a direct cfn-lint dependency — it's pulled in transitively. CVE-2026-4539 has no fix version yet and is blocking all PR CI. Adding to ignore list.