### PR TITLE
Fix E2533 not reporting deprecated runtimes from AllowedValues

### DIFF
--- a/src/cfnlint/context/context.py
+++ b/src/cfnlint/context/context.py
@@ -286,6 +286,7 @@ class Context:
                             value_path=deque(["Parameters", instance]) + path
                         ),
                         ref_values={instance: v},
+                        is_resolved_from_parameters=True,
                     ),
                 )
 

--- a/test/unit/module/context/test_parameter.py
+++ b/test/unit/module/context/test_parameter.py
@@ -136,3 +136,17 @@ def test_errors(name, instance):
 def test_parameters():
     with pytest.raises(ValueError):
         _init_parameters([])
+
+
+def test_ref_value_allowed_values_sets_resolved_from_parameters():
+    """Test that resolving AllowedValues sets is_resolved_from_parameters"""
+    context = Context(
+        ["us-east-1"],
+        parameters={
+            "Runtime": Parameter({"Type": "String", "AllowedValues": ["a", "b"]})
+        },
+    )
+    results = list(context.ref_value("Runtime"))
+    assert len(results) == 2
+    for _, ctx in results:
+        assert ctx.is_resolved_from_parameters is True


### PR DESCRIPTION
## Summary

When resolving a `!Ref` to a parameter's `AllowedValues`, the context did not set `is_resolved_from_parameters`. This caused the resolved value validation to early-return on the first valid value, skipping deprecation warnings for other values in the list.

One-line fix: set `is_resolved_from_parameters=True` when yielding values from `AllowedValues`.

Does not regress #3380 — the `Fn::Sub` combinatorial case still works correctly because the early-return logic only applies when `is_resolved_from_parameters` is `False`.

Fixes #4191