### PR TITLE
Add graph() function to cfnlint.api

### DIFF
--- a/src/cfnlint/api.py
+++ b/src/cfnlint/api.py
@@ -161,3 +161,29 @@ def lint_by_config(config: ManualArgs) -> list[Match]:
 
     runner = Runner(config_mixin)
     return list(runner.run())
+
+
+def graph(s: str) -> str | None:
+    """Generate a DOT graph from a template string.
+
+    Parameters
+    ----------
+    s : str
+        the template string
+
+    Returns
+    -------
+    str or None
+        the DOT format string, or None if the graph could not be built
+    """
+    template, errors = decode_str(s)
+    if errors or template is None:
+        return None
+
+    from cfnlint.template import Template
+
+    cfn = Template("", template)
+    if cfn.graph is None:
+        return None
+
+    return cfn.graph.to_dot_string()

--- a/src/cfnlint/graph.py
+++ b/src/cfnlint/graph.py
@@ -322,3 +322,25 @@ class Graph:
                     networkx.drawing.nx_pydot.write_dot(view, path)
             except ImportError as e:
                 raise e
+
+    def to_dot_string(self) -> str:
+        """Export the graph to a DOT format string"""
+        from io import StringIO
+
+        graph = deepcopy(self.graph)
+        view = self.settings.subgraph_view(graph)
+        try:
+            buf = StringIO()
+            networkx.drawing.nx_agraph.write_dot(view, buf)
+            return buf.getvalue()
+        except ImportError:
+            try:
+                with warnings.catch_warnings():
+                    warnings.simplefilter("ignore", category=PendingDeprecationWarning)
+                    warnings.simplefilter("ignore", category=DeprecationWarning)
+
+                    buf = StringIO()
+                    networkx.drawing.nx_pydot.write_dot(view, buf)
+                    return buf.getvalue()
+            except ImportError as e:
+                raise e

--- a/test/unit/module/test_api.py
+++ b/test/unit/module/test_api.py
@@ -371,3 +371,31 @@ Resources:
         finally:
             # Clean up the temporary file
             os.unlink(temp_file)
+
+    def test_graph(self):
+        from cfnlint.api import graph
+
+        template = """
+AWSTemplateFormatVersion: '2010-09-09'
+Resources:
+  VPC:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: 10.0.0.0/16
+  Subnet:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref VPC
+      CidrBlock: 10.0.1.0/24
+"""
+        result = graph(template)
+        self.assertIsNotNone(result)
+        self.assertIn("VPC", result)
+        self.assertIn("Subnet", result)
+        self.assertIn("Ref", result)
+
+    def test_graph_invalid_template(self):
+        from cfnlint.api import graph
+
+        result = graph("not: [valid: yaml: {")
+        self.assertIsNone(result)


### PR DESCRIPTION
## Summary

Adds a `graph()` function to `cfnlint.api` that returns a DOT format string from a template string. This enables programmatic access to the graph generation feature that was previously only available via the CLI `--build-graph` flag.

Usage:
```python
from cfnlint.api import graph

dot_string = graph(template_string)
```

Also adds `Graph.to_dot_string()` for direct access to the DOT output without writing to a file.

Fixes #4174