### PR TITLE
fix: add required to cfnGather if/then schemas to prevent vacuous matches

### DIFF
--- a/src/cfnlint/data/schemas/extensions/aws_apigateway_method/method_authorizer_type.json
+++ b/src/cfnlint/data/schemas/extensions/aws_apigateway_method/method_authorizer_type.json
@@ -48,9 +48,15 @@
        "AuthorizationType": {
         "const": "CUSTOM"
        }
-      }
+      },
+      "required": [
+       "AuthorizationType"
+      ]
      }
-    }
+    },
+    "required": [
+     "method"
+    ]
    },
    "then": {
     "properties": {

--- a/src/cfnlint/data/schemas/extensions/aws_ecs_service/service_fargate.json
+++ b/src/cfnlint/data/schemas/extensions/aws_ecs_service/service_fargate.json
@@ -28,7 +28,10 @@
        "LaunchType": {
         "const": "FARGATE"
        }
-      }
+      },
+      "required": [
+       "LaunchType"
+      ]
      },
      "taskDef": {
       "properties": {
@@ -43,7 +46,11 @@
        }
       }
      }
-    }
+    },
+    "required": [
+     "service",
+     "taskDef"
+    ]
    },
    "then": {
     "properties": {

--- a/src/cfnlint/data/schemas/extensions/aws_ecs_service/service_network_configuration.json
+++ b/src/cfnlint/data/schemas/extensions/aws_ecs_service/service_network_configuration.json
@@ -30,7 +30,10 @@
        "NetworkMode"
       ]
      }
-    }
+    },
+    "required": [
+     "taskDef"
+    ]
    },
    "then": {
     "properties": {

--- a/src/cfnlint/data/schemas/extensions/aws_lambda_eventsourcemapping/event_source_sqs_fifo_batch_size.json
+++ b/src/cfnlint/data/schemas/extensions/aws_lambda_eventsourcemapping/event_source_sqs_fifo_batch_size.json
@@ -29,9 +29,15 @@
        "FifoQueue": {
         "const": true
        }
-      }
+      },
+      "required": [
+       "FifoQueue"
+      ]
      }
-    }
+    },
+    "required": [
+     "queue"
+    ]
    },
    "then": {
     "properties": {

--- a/src/cfnlint/data/schemas/extensions/aws_lambda_eventsourcemapping/event_source_sqs_timeout.json
+++ b/src/cfnlint/data/schemas/extensions/aws_lambda_eventsourcemapping/event_source_sqs_timeout.json
@@ -49,7 +49,11 @@
        "VisibilityTimeout"
       ]
      }
-    }
+    },
+    "required": [
+     "function",
+     "queue"
+    ]
    },
    "then": {
     "properties": {

--- a/test/unit/rules/resources/apigateway/test_method_authorizer_type.py
+++ b/test/unit/rules/resources/apigateway/test_method_authorizer_type.py
@@ -242,6 +242,27 @@ _template = {
             deque(["Resources", "Method", "Properties"]),
             [],
         ),
+        # Hardcoded AuthorizerId string — no error
+        (
+            {
+                "Resources": {
+                    "RestApi": _template["Resources"]["RestApi"],
+                    "Method": {
+                        "Type": "AWS::ApiGateway::Method",
+                        "Properties": {
+                            "RestApiId": {"Ref": "RestApi"},
+                            "ResourceId": "resource-id",
+                            "HttpMethod": "GET",
+                            "AuthorizationType": "CUSTOM",
+                            "AuthorizerId": "abc123",
+                            "Integration": {"Type": "MOCK"},
+                        },
+                    },
+                },
+            },
+            deque(["Resources", "Method", "Properties"]),
+            [],
+        ),
     ],
     indirect=["template"],
 )

--- a/test/unit/rules/resources/ecs/test_service_fargate.py
+++ b/test/unit/rules/resources/ecs/test_service_fargate.py
@@ -435,6 +435,25 @@ _service = {
                 )
             ],
         ),
+        # Hardcoded TaskDefinition ARN — no error
+        (
+            {
+                "Resources": {
+                    "Service": jsonpatch.apply_patch(
+                        dict(_service),
+                        [
+                            {
+                                "op": "replace",
+                                "path": "/Properties/TaskDefinition",
+                                "value": "arn:aws:ecs:us-east-1:0:task/t:1",
+                            },
+                        ],
+                    ),
+                },
+            },
+            deque(["Resources", "Service", "Properties"]),
+            [],
+        ),
     ],
     indirect=["template"],
 )

--- a/test/unit/rules/resources/ecs/test_service_network_configuration.py
+++ b/test/unit/rules/resources/ecs/test_service_network_configuration.py
@@ -277,6 +277,29 @@ _service = {
             deque(["Resources", "Service", "Properties"]),
             [],
         ),
+        # Hardcoded TaskDefinition ARN — no error
+        (
+            {
+                "Resources": {
+                    "Service": jsonpatch.apply_patch(
+                        dict(_service),
+                        [
+                            {
+                                "op": "remove",
+                                "path": "/Properties/NetworkConfiguration",
+                            },
+                            {
+                                "op": "replace",
+                                "path": "/Properties/TaskDefinition",
+                                "value": "arn:aws:ecs:us-east-1:0:task/t:1",
+                            },
+                        ],
+                    ),
+                },
+            },
+            deque(["Resources", "Service", "Properties"]),
+            [],
+        ),
     ],
     indirect=["template"],
 )

--- a/test/unit/rules/resources/lmbd/test_event_source_mapping_sqs_fifo_batch_size.py
+++ b/test/unit/rules/resources/lmbd/test_event_source_mapping_sqs_fifo_batch_size.py
@@ -123,6 +123,26 @@ _template = {
             deque(["Resources", "Mapping", "Properties"]),
             [],
         ),
+        # Hardcoded DynamoDB stream ARN with BatchSize 100 — valid (not SQS)
+        (
+            {
+                "Resources": {
+                    "Mapping": {
+                        "Type": "AWS::Lambda::EventSourceMapping",
+                        "Properties": {
+                            "EventSourceArn": (
+                                "arn:aws:dynamodb:us-east-1:"
+                                "123456789012:table/T/stream/2024"
+                            ),
+                            "FunctionName": "my-func",
+                            "BatchSize": 100,
+                        },
+                    },
+                },
+            },
+            deque(["Resources", "Mapping", "Properties"]),
+            [],
+        ),
     ],
     indirect=["template"],
 )

--- a/test/unit/rules/resources/lmbd/test_event_source_mapping_to_sqs_timeout.py
+++ b/test/unit/rules/resources/lmbd/test_event_source_mapping_to_sqs_timeout.py
@@ -186,6 +186,35 @@ _template = {
                 ),
             ],
         ),
+        # Hardcoded EventSourceArn — no error
+        (
+            {
+                "Resources": {
+                    "Function": {
+                        "Type": "AWS::Lambda::Function",
+                        "Properties": {
+                            "Runtime": "python3.12",
+                            "Handler": "index.handler",
+                            "Code": {"ZipFile": "def handler(e, c): pass"},
+                            "Role": "arn:aws:iam::123456789012:role/role",
+                            "Timeout": 900,
+                        },
+                    },
+                    "Mapping": {
+                        "Type": "AWS::Lambda::EventSourceMapping",
+                        "Properties": {
+                            "EventSourceArn": (
+                                "arn:aws:sqs:us-east-1:123456789012:my-queue"
+                            ),
+                            "FunctionName": {"Ref": "Function"},
+                            "BatchSize": 10,
+                        },
+                    },
+                },
+            },
+            deque(["Resources", "Mapping", "Properties"]),
+            [],
+        ),
     ],
     indirect=["template"],
 )


### PR DESCRIPTION
When a cfnGather remote reference resolves to a plain string (e.g. a hardcoded ARN) instead of a Ref/GetAtt, the gathered object has no remote entry. Without 'required' in the if schema, JSON Schema's properties keyword vacuously passes on missing keys, causing the then schema to always apply.

This caused false positives like E3705 firing on DynamoDB/Kinesis EventSourceMappings with hardcoded ARNs.

Fix: add required at both levels (gather entry name and inner property) in all affected cfnGather if/then schemas.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
