### PR TITLE
Add lock file to release

### DIFF
--- a/.github/workflows/cd-pypi.yaml
+++ b/.github/workflows/cd-pypi.yaml
@@ -13,18 +13,22 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'aws-cloudformation/cfn-lint'
     steps:
-      - uses: actions/checkout@v6
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
           python-version: "3.13"
-      - name: Install dependencies
+      - name: Get version
+        id: getversion
         run: |
-          pip install --upgrade pip
-          pip install --upgrade setuptools build wheel twine
-      - name: Build and publish
+          echo -n "version=" >> "$GITHUB_OUTPUT"
+          echo ${{ github.ref_name }}|cut -c2- >> "$GITHUB_OUTPUT"
+      - name: Download release
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          python -m build
+          gh release download ${{ github.ref_name }} -p 'cfn_lint-*' -R ${{ github.repository }}
+          mkdir -p dist
+          cp cfn_lint-${{ steps.getversion.outputs.version }}.tar.gz cfn_lint-${{ steps.getversion.outputs.version }}-py3-none-any.whl dist/
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/.github/workflows/cd-release.yaml
+++ b/.github/workflows/cd-release.yaml
@@ -18,11 +18,22 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.13"
+      - name: Get version
+        id: getversion
+        run: |
+          echo -n "version=" >> "$GITHUB_OUTPUT"
+          echo ${{ github.ref_name }}|cut -c2- >> "$GITHUB_OUTPUT"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
       - name: Build
         run: |
+          pip install --upgrade pip
+          pip install --upgrade setuptools build wheel twine
+          python -m build
           pip install -e .
           scripts/release/generator.py
           scripts/release/changelog.py --version ${{ github.ref_name }}
+          scripts/release/pipcompile.py ${{ steps.getversion.outputs.version }}
       - name: Release
         uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/v1')
@@ -33,3 +44,6 @@ jobs:
           files: |
             build/schemas-cfnlint.zip
             build/schemas-draft7.zip
+            dist/cfn_lint-${{ steps.getversion.outputs.version }}.tar.gz
+            dist/cfn_lint-${{ steps.getversion.outputs.version }}-py3-none-any.whl
+            requirements.txt

--- a/scripts/release/pipcompile.py
+++ b/scripts/release/pipcompile.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+import tempfile
+import subprocess
+import hashlib
+import re
+import sys
+
+version = sys.argv[1]
+
+with open(f"dist/cfn_lint-{version}.tar.gz", "rb") as f:
+    sha256_cfn_lint = hashlib.file_digest(f, "sha256").hexdigest()
+
+with open(f"dist/cfn_lint-{version}-py3-none-any.whl", "rb") as f:
+    sha256_cfn_lint_whl = hashlib.file_digest(f, "sha256").hexdigest()
+
+with tempfile.NamedTemporaryFile(suffix="-requirements.txt") as requirements_txt:
+    p = subprocess.Popen(
+        ["uv", "pip", "compile", "requirements/base.txt", "--generate-hashes"],
+        stdout=requirements_txt,
+    )
+    p.communicate()
+    result = [
+        f"cfn-lint=={version} \\\n".encode("utf8"),
+        f"    --hash=sha256:{sha256_cfn_lint} \\\n".encode("utf8"),
+        f"    --hash=sha256:{sha256_cfn_lint_whl}\n".encode("utf8"),
+    ]
+    requirements_txt.seek(0)
+    for line in requirements_txt.readlines():
+        if not re.match(rb"^ *#.*", line):
+            result.append(line)
+    result = b"".join(result)
+    with open("requirements.txt", "wb") as f:
+        f.write(result)


### PR DESCRIPTION
*Description of changes:*

Lock the dependencies of cfn-lint for every release with a hash. This gives a recommended set which can be used to install cfn-lint and allow people to stick to a known, reproducible state.

The requirements.txt can be used to download wheels using:

```
pip wheel --require-hashes -r requirements.txt
```

And these can be installed using:

```
pip install *.whl
```

This can be seen as a poor mans container image (or used to create reproducible docker image).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.