### PR TITLE
Remove PyPI API token

### DIFF
--- a/.github/workflows/cd-pypi.yaml
+++ b/.github/workflows/cd-pypi.yaml
@@ -27,6 +27,3 @@ jobs:
           python -m build
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
*Description of changes:*

You don't need to configure an API token to publish packages to PyPI if you configure this repository at PyPI.

See: https://docs.pypi.org/trusted-publishers/adding-a-publisher/

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
