### PR TITLE
Fix pytest 9.0+ marker expression in branch CI

### DIFF
--- a/.github/workflows/ci-branch.yaml
+++ b/.github/workflows/ci-branch.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Install Tox
         run: pip install tox tox-gh
       - name: Run Tox
-        run: tox -- -m "data or not data"
+        run: tox -- -m "data or (not data)"
         env:
           TOX_GH_MAJOR_MINOR: ${{ matrix.python }}
       - uses: codecov/codecov-action@v6


### PR DESCRIPTION
The `-m "data or not data"` expression broke with pytest 9.0+ which requires parentheses around `not` expressions. Changed to `-m "data or (not data)"` to fix the branch CI workflow.