### PR TITLE
Fix pytest 9.0+ marker expression quoting in branch CI

### DIFF
--- a/.github/workflows/ci-branch.yaml
+++ b/.github/workflows/ci-branch.yaml
@@ -23,9 +23,10 @@ jobs:
       - name: Install Tox
         run: pip install tox tox-gh
       - name: Run Tox
-        run: tox -- -m "data or (not data)"
+        run: tox
         env:
           TOX_GH_MAJOR_MINOR: ${{ matrix.python }}
+          PYTEST_ADDOPTS: '-m "data or (not data)"'
       - uses: codecov/codecov-action@v6
         if: matrix.os == 'ubuntu-latest'
         with:


### PR DESCRIPTION
The previous fix added parentheses but tox posargs quoting still mangles the `-m` expression. Using `PYTEST_ADDOPTS` env var bypasses the tox/shell quoting issue entirely.