### PR TITLE
Fix E1041 false positive: add Lambda::Function.Arn format to Lambda Alias

### DIFF
--- a/scripts/update_schemas_format.py
+++ b/scripts/update_schemas_format.py
@@ -354,6 +354,12 @@ _manual_patches = {
             path="/properties/AliasName",
         ),
     ],
+    "AWS::Lambda::Alias": [
+        Patch(
+            values={"format": "AWS::Lambda::Function.Arn"},
+            path="/properties/AliasArn",
+        ),
+    ],
     "AWS::CertificateManager::Certificate": [
         Patch(
             values={"format": "AWS::ACM::Certificate.Arn"},

--- a/src/cfnlint/data/schemas/patches/extensions/all/aws_gammadilithium_jobdefinition/format.json
+++ b/src/cfnlint/data/schemas/patches/extensions/all/aws_gammadilithium_jobdefinition/format.json
@@ -8,5 +8,15 @@
   "op": "add",
   "path": "/definitions/ContainerProperties/properties/JobRoleArn/format",
   "value": "AWS::IAM::Role.Arn"
+ },
+ {
+  "op": "add",
+  "path": "/definitions/EcsTaskProperties/properties/ExecutionRoleArn/format",
+  "value": "AWS::IAM::Role.Arn"
+ },
+ {
+  "op": "add",
+  "path": "/definitions/EcsTaskProperties/properties/TaskRoleArn/format",
+  "value": "AWS::IAM::Role.Arn"
  }
 ]

--- a/src/cfnlint/data/schemas/patches/extensions/all/aws_glue_securityconfiguration/format.json
+++ b/src/cfnlint/data/schemas/patches/extensions/all/aws_glue_securityconfiguration/format.json
@@ -11,7 +11,7 @@
  },
  {
   "op": "add",
-  "path": "/definitions/S3Encryption/properties/KmsKeyArn/format",
+  "path": "/definitions/S3Encryptions/items/properties/KmsKeyArn/format",
   "value": "AWS::KMS::Key.Arn"
  }
 ]

--- a/src/cfnlint/data/schemas/patches/extensions/all/aws_lambda_alias/format.json
+++ b/src/cfnlint/data/schemas/patches/extensions/all/aws_lambda_alias/format.json
@@ -1,0 +1,7 @@
+[
+ {
+  "op": "add",
+  "path": "/properties/AliasArn/format",
+  "value": "AWS::Lambda::Function.Arn"
+ }
+]

--- a/src/cfnlint/data/schemas/resources/330cfa7e67eefadc.json
+++ b/src/cfnlint/data/schemas/resources/330cfa7e67eefadc.json
@@ -26,9 +26,9 @@
    "additionalProperties": false,
    "properties": {
     "Action": {
-     "enum": [
-      "CANCEL",
-      "TERMINATE"
+     "enumCaseInsensitive": [
+      "cancel",
+      "terminate"
      ],
      "type": "string"
     },

--- a/src/cfnlint/data/schemas/resources/3385669f1c48cc6c.json
+++ b/src/cfnlint/data/schemas/resources/3385669f1c48cc6c.json
@@ -115,15 +115,6 @@
    "type": "integer"
   },
   "VolumeType": {
-   "enum": [
-    "gp2",
-    "gp3",
-    "io1",
-    "io2",
-    "sc1",
-    "st1",
-    "standard"
-   ],
    "enumCaseInsensitive": [
     "gp2",
     "gp3",

--- a/src/cfnlint/data/schemas/resources/3f0cf52ee9079950.json
+++ b/src/cfnlint/data/schemas/resources/3f0cf52ee9079950.json
@@ -53,6 +53,7 @@
  ],
  "properties": {
   "AliasArn": {
+   "format": "AWS::Lambda::Function.Arn",
    "type": "string"
   },
   "Description": {

--- a/src/cfnlint/data/schemas/resources/455bd6c59c07fb7b.json
+++ b/src/cfnlint/data/schemas/resources/455bd6c59c07fb7b.json
@@ -48,9 +48,9 @@
      "type": "string"
     },
     "Protocol": {
-     "enum": [
-      "Do53",
-      "DoH"
+     "enumCaseInsensitive": [
+      "do53",
+      "doh"
      ],
      "type": "string"
     },
@@ -95,11 +95,11 @@
    "type": "string"
   },
   "RuleType": {
-   "enum": [
-    "FORWARD",
-    "SYSTEM",
-    "RECURSIVE",
-    "DELEGATE"
+   "enumCaseInsensitive": [
+    "delegate",
+    "forward",
+    "recursive",
+    "system"
    ],
    "type": "string"
   },

--- a/src/cfnlint/data/schemas/resources/9a9a64561c801ccb.json
+++ b/src/cfnlint/data/schemas/resources/9a9a64561c801ccb.json
@@ -37,6 +37,11 @@
     "LDAP",
     "SIMPLE"
    ],
+   "enumCaseInsensitive": [
+    "config_managed",
+    "ldap",
+    "simple"
+   ],
    "type": "string"
   },
   "Data": {
@@ -49,6 +54,10 @@
    "enum": [
     "ACTIVEMQ",
     "RABBITMQ"
+   ],
+   "enumCaseInsensitive": [
+    "activemq",
+    "rabbitmq"
    ],
    "type": "string"
   },

--- a/src/cfnlint/data/schemas/resources/bf112578857056db.json
+++ b/src/cfnlint/data/schemas/resources/bf112578857056db.json
@@ -49,6 +49,7 @@
    "items": {
     "properties": {
      "KmsKeyArn": {
+      "format": "AWS::KMS::Key.Arn",
       "type": "string"
      },
      "S3EncryptionMode": {

--- a/src/cfnlint/data/schemas/resources/c04685284080736b.json
+++ b/src/cfnlint/data/schemas/resources/c04685284080736b.json
@@ -197,9 +197,9 @@
      "uniqueItems": false
     },
     "UserdataType": {
-     "enum": [
-      "EKS_BOOTSTRAP_SH",
-      "EKS_NODEADM"
+     "enumCaseInsensitive": [
+      "eks_bootstrap_sh",
+      "eks_nodeadm"
      ],
      "type": "string"
     },
@@ -227,9 +227,9 @@
      "uniqueItems": false
     },
     "UserdataType": {
-     "enum": [
-      "EKS_BOOTSTRAP_SH",
-      "EKS_NODEADM"
+     "enumCaseInsensitive": [
+      "eks_bootstrap_sh",
+      "eks_nodeadm"
      ],
      "type": "string"
     },

--- a/src/cfnlint/data/schemas/resources/c7ad1fe2fbeb2d1b.json
+++ b/src/cfnlint/data/schemas/resources/c7ad1fe2fbeb2d1b.json
@@ -156,23 +156,14 @@
        "pattern": "^[Ss][Uu][Nn][Dd][Aa][Yy]$"
       }
      ],
-     "enum": [
-      "FRIDAY",
-      "MONDAY",
-      "SATURDAY",
-      "SUNDAY",
-      "THURSDAY",
-      "TUESDAY",
-      "WEDNESDAY"
-     ],
      "enumCaseInsensitive": [
-      "FRIDAY",
-      "MONDAY",
-      "SATURDAY",
-      "SUNDAY",
-      "THURSDAY",
-      "TUESDAY",
-      "WEDNESDAY"
+      "friday",
+      "monday",
+      "saturday",
+      "sunday",
+      "thursday",
+      "tuesday",
+      "wednesday"
      ],
      "type": "string"
     },
@@ -260,15 +251,10 @@
    "type": "string"
   },
   "AuthenticationStrategy": {
-   "enum": [
-    "CONFIG_MANAGED",
-    "LDAP",
-    "SIMPLE"
-   ],
    "enumCaseInsensitive": [
-    "CONFIG_MANAGED",
-    "LDAP",
-    "SIMPLE"
+    "config_managed",
+    "ldap",
+    "simple"
    ],
    "type": "string"
   },
@@ -316,6 +302,10 @@
     "CRDR",
     "NONE"
    ],
+   "enumCaseInsensitive": [
+    "crdr",
+    "none"
+   ],
    "type": "string"
   },
   "DataReplicationPrimaryBrokerArn": {
@@ -342,15 +332,10 @@
      "pattern": "^[Cc][Ll][Uu][Ss][Tt][Ee][Rr]_[Mm][Uu][Ll][Tt][Ii][__][Aa][Zz]$"
     }
    ],
-   "enum": [
-    "ACTIVE_STANDBY_MULTI_AZ",
-    "CLUSTER_MULTI_AZ",
-    "SINGLE_INSTANCE"
-   ],
    "enumCaseInsensitive": [
-    "ACTIVE_STANDBY_MULTI_AZ",
-    "CLUSTER_MULTI_AZ",
-    "SINGLE_INSTANCE"
+    "active_standby_multi_az",
+    "cluster_multi_az",
+    "single_instance"
    ],
    "type": "string"
   },
@@ -373,13 +358,9 @@
      "pattern": "^[Rr][Aa][Bb][Bb][Ii][Tt][Mm][Qq]$"
     }
    ],
-   "enum": [
-    "ACTIVEMQ",
-    "RABBITMQ"
-   ],
    "enumCaseInsensitive": [
-    "ACTIVEMQ",
-    "RABBITMQ"
+    "activemq",
+    "rabbitmq"
    ],
    "type": "string"
   },

--- a/src/cfnlint/data/schemas/resources/cc42df82cdc81e9c.json
+++ b/src/cfnlint/data/schemas/resources/cc42df82cdc81e9c.json
@@ -37,10 +37,6 @@
    "type": "string"
   },
   "Domain": {
-   "enum": [
-    "standard",
-    "vpc"
-   ],
    "enumCaseInsensitive": [
     "standard",
     "vpc"

--- a/src/cfnlint/data/schemas/resources/d429b14cb8987b7d.json
+++ b/src/cfnlint/data/schemas/resources/d429b14cb8987b7d.json
@@ -173,6 +173,7 @@
      "$ref": "#/definitions/EphemeralStorage"
     },
     "ExecutionRoleArn": {
+     "format": "AWS::IAM::Role.Arn",
      "type": "string"
     },
     "IpcMode": {
@@ -191,6 +192,7 @@
      "$ref": "#/definitions/RuntimePlatform"
     },
     "TaskRoleArn": {
+     "format": "AWS::IAM::Role.Arn",
      "type": "string"
     },
     "Volumes": {

--- a/src/cfnlint/data/schemas/resources/d4fc9ce8669023f0.json
+++ b/src/cfnlint/data/schemas/resources/d4fc9ce8669023f0.json
@@ -62,10 +62,6 @@
    "type": "integer"
   },
   "RuleAction": {
-   "enum": [
-    "allow",
-    "deny"
-   ],
    "enumCaseInsensitive": [
     "allow",
     "deny"

--- a/src/cfnlint/data/schemas/resources/f8632a39914b3366.json
+++ b/src/cfnlint/data/schemas/resources/f8632a39914b3366.json
@@ -50,6 +50,9 @@
      "enum": [
       "vpc"
      ],
+     "enumCaseInsensitive": [
+      "vpc"
+     ],
      "type": "string"
     }
    },
@@ -87,10 +90,6 @@
  ],
  "properties": {
   "AddressFamily": {
-   "enum": [
-    "ipv4",
-    "ipv6"
-   ],
    "enumCaseInsensitive": [
     "ipv4",
     "ipv6"
@@ -127,7 +126,7 @@
    "type": "boolean"
   },
   "AwsService": {
-   "enum": [
+   "enumCaseInsensitive": [
     "ec2",
     "global-services"
    ],
@@ -170,9 +169,9 @@
    "uniqueItems": true
   },
   "PublicIpSource": {
-   "enum": [
-    "byoip",
-    "amazon"
+   "enumCaseInsensitive": [
+    "amazon",
+    "byoip"
    ],
    "type": "string"
   },

--- a/src/cfnlint/data/schemas/resources/fc74be0ae84138f0.json
+++ b/src/cfnlint/data/schemas/resources/fc74be0ae84138f0.json
@@ -61,15 +61,10 @@
    "type": "string"
   },
   "Direction": {
-   "enum": [
-    "INBOUND",
-    "INBOUND_DELEGATION",
-    "OUTBOUND"
-   ],
    "enumCaseInsensitive": [
-    "INBOUND",
-    "INBOUND_DELEGATION",
-    "OUTBOUND"
+    "inbound",
+    "inbound_delegation",
+    "outbound"
    ],
    "type": "string"
   },
@@ -114,6 +109,11 @@
      "DoH",
      "DoH-FIPS"
     ],
+    "enumCaseInsensitive": [
+     "do53",
+     "doh",
+     "doh-fips"
+    ],
     "type": "string"
    },
    "maxItems": 2,
@@ -125,10 +125,10 @@
    "type": "string"
   },
   "ResolverEndpointType": {
-   "enum": [
-    "IPV6",
-    "IPV4",
-    "DUALSTACK"
+   "enumCaseInsensitive": [
+    "dualstack",
+    "ipv4",
+    "ipv6"
    ],
    "type": "string"
   },


### PR DESCRIPTION
Fixes #4468

**Problem:** E1041 false positive when `Ref` to `AWS::Lambda::Alias` is used where `AWS::Lambda::Function.Arn` format is expected. The alias ARN is a qualified Lambda function ARN and should be accepted.

**Root cause:** `scripts/update_schemas_format.py` auto-scans for property names like `FunctionArn`/`LambdaArn` but `AliasArn` on `AWS::Lambda::Alias` was not matched.

**Fix:** Add `AWS::Lambda::Alias` to `_manual_patches` with `AliasArn` → `AWS::Lambda::Function.Arn`, then re-ran the script and `--patch-specs`.