### PR TITLE
Fix E3719 false positive when BackupRetentionPeriod is omitted

### DIFF
--- a/src/cfnlint/data/schemas/extensions/aws_rds_dbinstance/aurora_exclusive.json
+++ b/src/cfnlint/data/schemas/extensions/aws_rds_dbinstance/aurora_exclusive.json
@@ -1,6 +1,6 @@
 {
  "additionalProperties": true,
- "description": "When creating an aurora DBInstance don't specify 'AllocatedStorage', 'BackupRetentionPeriod', 'CopyTagsToSnapshot', 'DeletionProtection', 'EnableIAMDatabaseAuthentication', 'MasterUserPassword', or 'StorageEncrypted'",
+ "description": "When creating an aurora DBInstance don't specify 'AllocatedStorage', 'CopyTagsToSnapshot', 'DeletionProtection', 'EnableIAMDatabaseAuthentication', 'MasterUserPassword', or 'StorageEncrypted'",
  "if": {
   "properties": {
    "Engine": {
@@ -19,11 +19,6 @@
     {
      "required": [
       "AllocatedStorage"
-     ]
-    },
-    {
-     "required": [
-      "BackupRetentionPeriod"
      ]
     },
     {
@@ -49,7 +44,6 @@
    ],
    "properties": {
     "AllocatedStorage": true,
-    "BackupRetentionPeriod": true,
     "CopyTagsToSnapshot": true,
     "DeletionProtection": true,
     "EnableIAMDatabaseAuthentication": true,

--- a/src/cfnlint/data/schemas/extensions/aws_rds_dbinstance/backupretentionperiod_maximum.json
+++ b/src/cfnlint/data/schemas/extensions/aws_rds_dbinstance/backupretentionperiod_maximum.json
@@ -1,0 +1,22 @@
+{
+ "if": {
+  "properties": {
+   "Engine": {
+    "pattern": "^(?!aurora).*$",
+    "type": "string"
+   },
+   "SourceDBInstanceIdentifier": false
+  },
+  "required": [
+   "Engine"
+  ],
+  "type": "object"
+ },
+ "then": {
+  "properties": {
+   "BackupRetentionPeriod": {
+    "maximum": 35
+   }
+  }
+ }
+}

--- a/src/cfnlint/data/schemas/extensions/aws_rds_dbinstance/backupretentionperiod_maximum.json
+++ b/src/cfnlint/data/schemas/extensions/aws_rds_dbinstance/backupretentionperiod_maximum.json
@@ -1,22 +1,40 @@
 {
- "if": {
-  "properties": {
-   "Engine": {
-    "pattern": "^(?!aurora).*$",
-    "type": "string"
+ "allOf": [
+  {
+   "if": {
+    "required": [
+     "DBClusterIdentifier"
+    ],
+    "type": "object"
    },
-   "SourceDBInstanceIdentifier": false
+   "then": {
+    "properties": {
+     "BackupRetentionPeriod": false
+    }
+   }
   },
-  "required": [
-   "Engine"
-  ],
-  "type": "object"
- },
- "then": {
-  "properties": {
-   "BackupRetentionPeriod": {
-    "maximum": 35
+  {
+   "if": {
+    "properties": {
+     "DBClusterIdentifier": false,
+     "Engine": {
+      "pattern": "^(?!aurora).*$",
+      "type": "string"
+     },
+     "SourceDBInstanceIdentifier": false
+    },
+    "required": [
+     "Engine"
+    ],
+    "type": "object"
+   },
+   "then": {
+    "properties": {
+     "BackupRetentionPeriod": {
+      "maximum": 35
+     }
+    }
    }
   }
- }
+ ]
 }

--- a/src/cfnlint/rules/resources/rds/DbInstanceBackupRetentionPeriod.py
+++ b/src/cfnlint/rules/resources/rds/DbInstanceBackupRetentionPeriod.py
@@ -8,17 +8,17 @@ from __future__ import annotations
 from typing import Any
 
 import cfnlint.data.schemas.extensions.aws_rds_dbinstance
-from cfnlint.jsonschema import ValidationError
+from cfnlint.jsonschema import ValidationResult, Validator
 from cfnlint.rules.jsonschema.CfnLintJsonSchema import CfnLintJsonSchema, SchemaDetails
 
 
 class DbInstanceBackupRetentionPeriod(CfnLintJsonSchema):
     id = "E3719"
-    shortdesc = "Validate RDS BackupRetentionPeriod based on instance configuration"
+    shortdesc = "Validate RDS BackupRetentionPeriod configuration"
     description = (
-        "BackupRetentionPeriod maximum of 35 applies to standalone "
-        "non-Aurora instances. Read replicas and Aurora instances "
-        "inherit backup settings and ignore this property."
+        "BackupRetentionPeriod is not allowed when DBClusterIdentifier "
+        "is specified. For standalone non-Aurora instances the maximum "
+        "is 35."
     )
     source_url = "https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWithAutomatedBackups.html"
     tags = ["resources", "rds"]
@@ -32,10 +32,17 @@ class DbInstanceBackupRetentionPeriod(CfnLintJsonSchema):
                 module=cfnlint.data.schemas.extensions.aws_rds_dbinstance,
                 filename="backupretentionperiod_maximum.json",
             ),
+            all_matches=True,
         )
 
-    def message(self, instance: Any, err: ValidationError) -> str:
-        return (
-            f"BackupRetentionPeriod {instance.get('BackupRetentionPeriod')} "
-            f"exceeds maximum of 35 for non-Aurora standalone instances"
-        )
+    def validate(
+        self, validator: Validator, keywords: Any, instance: Any, schema: dict[str, Any]
+    ) -> ValidationResult:
+        for err in super().validate(validator, keywords, instance, schema):
+            if err.schema is False:
+                err.message = (
+                    "'BackupRetentionPeriod' is not allowed when "
+                    "'DBClusterIdentifier' is specified. Set backup "
+                    "retention period on the DB cluster instead."
+                )
+            yield err

--- a/src/cfnlint/rules/resources/rds/DbInstanceBackupRetentionPeriod.py
+++ b/src/cfnlint/rules/resources/rds/DbInstanceBackupRetentionPeriod.py
@@ -30,7 +30,7 @@ class DbInstanceBackupRetentionPeriod(CfnLintJsonSchema):
             ],
             schema_details=SchemaDetails(
                 module=cfnlint.data.schemas.extensions.aws_rds_dbinstance,
-                filename="backupretentionperiod.json",
+                filename="backupretentionperiod_maximum.json",
             ),
         )
 

--- a/test/unit/rules/resources/rds/test_db_instance_backup_retention_period.py
+++ b/test/unit/rules/resources/rds/test_db_instance_backup_retention_period.py
@@ -47,19 +47,89 @@ def rule():
             [],
         ),
         (
+            {"Engine": "aurora-mysql", "DBClusterIdentifier": "my-cluster"},
+            [],
+        ),
+        (
             {"Engine": "postgres", "BackupRetentionPeriod": 36},
             [
                 ValidationError(
+                    "36 is greater than the maximum of 35",
+                    rule=DbInstanceBackupRetentionPeriod(),
+                    path=deque(["BackupRetentionPeriod"]),
+                    schema_path=deque(
+                        [
+                            "allOf",
+                            1,
+                            "then",
+                            "properties",
+                            "BackupRetentionPeriod",
+                            "maximum",
+                        ]
+                    ),
+                    validator="maximum",
+                    schema={"maximum": 35},
+                    instance=36,
+                ),
+            ],
+        ),
+        (
+            {
+                "Engine": "aurora-mysql",
+                "DBClusterIdentifier": "my-cluster",
+                "BackupRetentionPeriod": 14,
+            },
+            [
+                ValidationError(
                     (
-                        "BackupRetentionPeriod 36 exceeds maximum of 35"
-                        " for non-Aurora standalone instances"
+                        "'BackupRetentionPeriod' is not allowed when "
+                        "'DBClusterIdentifier' is specified. Set backup "
+                        "retention period on the DB cluster instead."
                     ),
                     rule=DbInstanceBackupRetentionPeriod(),
                     path=deque(["BackupRetentionPeriod"]),
-                    validator="maximum",
                     schema_path=deque(
-                        ["then", "properties", "BackupRetentionPeriod", "maximum"]
+                        [
+                            "allOf",
+                            0,
+                            "then",
+                            "properties",
+                            "BackupRetentionPeriod",
+                        ]
                     ),
+                    validator=None,
+                    schema=False,
+                    instance=14,
+                ),
+            ],
+        ),
+        (
+            {
+                "Engine": "mysql",
+                "DBClusterIdentifier": "my-maz-cluster",
+                "BackupRetentionPeriod": 7,
+            },
+            [
+                ValidationError(
+                    (
+                        "'BackupRetentionPeriod' is not allowed when "
+                        "'DBClusterIdentifier' is specified. Set backup "
+                        "retention period on the DB cluster instead."
+                    ),
+                    rule=DbInstanceBackupRetentionPeriod(),
+                    path=deque(["BackupRetentionPeriod"]),
+                    schema_path=deque(
+                        [
+                            "allOf",
+                            0,
+                            "then",
+                            "properties",
+                            "BackupRetentionPeriod",
+                        ]
+                    ),
+                    validator=None,
+                    schema=False,
+                    instance=7,
                 ),
             ],
         ),

--- a/test/unit/rules/resources/rds/test_db_instance_backup_retention_period.py
+++ b/test/unit/rules/resources/rds/test_db_instance_backup_retention_period.py
@@ -1,0 +1,71 @@
+"""
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+"""
+
+from collections import deque
+
+import pytest
+
+from cfnlint.jsonschema import ValidationError
+from cfnlint.rules.resources.rds.DbInstanceBackupRetentionPeriod import (
+    DbInstanceBackupRetentionPeriod,
+)
+
+
+@pytest.fixture(scope="module")
+def rule():
+    rule = DbInstanceBackupRetentionPeriod()
+    yield rule
+
+
+@pytest.mark.parametrize(
+    "instance,expected",
+    [
+        (
+            {"Engine": "postgres", "BackupRetentionPeriod": 7},
+            [],
+        ),
+        (
+            {"Engine": "postgres", "BackupRetentionPeriod": 35},
+            [],
+        ),
+        (
+            {"Engine": "aurora-mysql", "BackupRetentionPeriod": 36},
+            [],
+        ),
+        (
+            {"Engine": "postgres", "SourceDBInstanceIdentifier": "source-db"},
+            [],
+        ),
+        (
+            {"Engine": "postgres"},
+            [],
+        ),
+        (
+            {},
+            [],
+        ),
+        (
+            {"Engine": "postgres", "BackupRetentionPeriod": 36},
+            [
+                ValidationError(
+                    (
+                        "BackupRetentionPeriod 36 exceeds maximum of 35"
+                        " for non-Aurora standalone instances"
+                    ),
+                    rule=DbInstanceBackupRetentionPeriod(),
+                    path=deque(["BackupRetentionPeriod"]),
+                    validator="maximum",
+                    schema_path=deque(
+                        ["then", "properties", "BackupRetentionPeriod", "maximum"]
+                    ),
+                ),
+            ],
+        ),
+    ],
+)
+def test_validate(instance, expected, rule, validator):
+    errs = list(rule.validate(validator, "", instance, {}))
+
+    assert errs == expected, f"Expected {expected} got {errs}"


### PR DESCRIPTION
Fixes #4474

**Problem:** E3719 fires `BackupRetentionPeriod None exceeds maximum of 35` when the property is omitted from a non-Aurora `AWS::RDS::DBInstance`.

**Root cause:** The `then` clause in `backupretentionperiod.json` had `"required": ["BackupRetentionPeriod"]`, which forced validation even when the property was absent.

**Fix:** Remove the `required` constraint. The `maximum: 35` check now only applies when `BackupRetentionPeriod` is actually specified.