### PR TITLE
Update snapshots script and conditions yaml

### DIFF
--- a/scripts/update_snapshot_results.sh
+++ b/scripts/update_snapshot_results.sh
@@ -1,39 +1,142 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
+AUTO_DISCOVER=false
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --auto-discover) AUTO_DISCOVER=true; shift ;;
+        *) echo "Unknown option: $1" >&2; exit 1 ;;
+    esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+TEMPLATES_DIR="test/fixtures/templates"
+RESULTS_DIR="test/fixtures/results"
+
+# Use local source code
+export PYTHONPATH="$PROJECT_DIR/src${PYTHONPATH:+:$PYTHONPATH}"
+
+# Files to track handled templates and written results
+HANDLED=$(mktemp)
+WRITTEN=$(mktemp)
+trap 'rm -f "$HANDLED" "${HANDLED}.all" "$WRITTEN"' EXIT
+
+# Performance tracking
+TOTAL_START=$(python -c 'import time;print(time.time())')
+TEMPLATE_COUNT=0
+
+run_lint() {
+    local template="$1"
+    local result="$2"
+    shift 2
+
+    mkdir -p "$(dirname "$result")"
+
+    local start end elapsed
+    start=$(python -c 'import time;print(time.time())')
+    python -c "
+import sys
+from cfnlint.runner import main
+main()
+" "$template" -e -c I --format json "$@" > "$result" 2>/dev/null || true
+    end=$(python -c 'import time;print(time.time())')
+    elapsed=$(python -c "print(f'{($end-$start)*1000:.2f}')")
+
+    echo "[${elapsed}ms] $result"
+    echo "$template" >> "$HANDLED"
+    echo "$result" >> "$WRITTEN"
+    TEMPLATE_COUNT=$((TEMPLATE_COUNT + 1))
+}
+
+# ============================================================================
+# Manual entries: templates that need special flags or name mappings
+# ============================================================================
 
 # integration/
-cfn-lint test/fixtures/templates/integration/dynamic-references.yaml -e -c I --format json > test/fixtures/results/integration/dynamic-references.json
-cfn-lint test/fixtures/templates/integration/resources-cloudformation-init.yaml -e -c I --format json > test/fixtures/results/integration/resources-cloudformation-init.json
-cfn-lint test/fixtures/templates/integration/ref-no-value.yaml -e -c I --format json > test/fixtures/results/integration/ref-no-value.json
-cfn-lint test/fixtures/templates/integration/availability-zones.yaml -e -c I --format json > test/fixtures/results/integration/availability-zones.json
-cfn-lint test/fixtures/templates/integration/getatt-types.yaml -e -c I --format json > test/fixtures/results/integration/getatt-types.json
-cfn-lint test/fixtures/templates/integration/ref-types.yaml -e -c I --format json > test/fixtures/results/integration/ref-types.json
-cfn-lint test/fixtures/templates/integration/formats.yaml -e -c I --format json > test/fixtures/results/integration/formats.json
-cfn-lint test/fixtures/templates/integration/aws-ec2-networkinterface.yaml -e -c I --format json > test/fixtures/results/integration/aws-ec2-networkinterface.json
-cfn-lint test/fixtures/templates/integration/aws-ec2-instance.yaml -e -c I --format json > test/fixtures/results/integration/aws-ec2-instance.json
-cfn-lint test/fixtures/templates/integration/aws-ec2-launchtemplate.yaml -e -c I --format json > test/fixtures/results/integration/aws-ec2-launchtemplate.json
-cfn-lint test/fixtures/templates/integration/aws-ec2-subnet.yaml -e -c I --format json > test/fixtures/results/integration/aws-ec2-subnet.json
-cfn-lint test/fixtures/templates/integration/aws-dynamodb-table.yaml -e -c I --format json > test/fixtures/results/integration/aws-dynamodb-table.json
-cfn-lint test/fixtures/templates/integration/custom-resources.yaml -e -c I --format json > test/fixtures/results/integration/custom-resources.json
-cfn-lint test/fixtures/templates/integration/cfn-gather.yaml -e -c I --format json > test/fixtures/results/integration/cfn-gather.json
+run_lint "$TEMPLATES_DIR/integration/dynamic-references.yaml" "$RESULTS_DIR/integration/dynamic-references.json"
+run_lint "$TEMPLATES_DIR/integration/resources-cloudformation-init.yaml" "$RESULTS_DIR/integration/resources-cloudformation-init.json"
+run_lint "$TEMPLATES_DIR/integration/ref-no-value.yaml" "$RESULTS_DIR/integration/ref-no-value.json"
+run_lint "$TEMPLATES_DIR/integration/availability-zones.yaml" "$RESULTS_DIR/integration/availability-zones.json"
+run_lint "$TEMPLATES_DIR/integration/getatt-types.yaml" "$RESULTS_DIR/integration/getatt-types.json"
+run_lint "$TEMPLATES_DIR/integration/ref-types.yaml" "$RESULTS_DIR/integration/ref-types.json"
+run_lint "$TEMPLATES_DIR/integration/formats.yaml" "$RESULTS_DIR/integration/formats.json"
+run_lint "$TEMPLATES_DIR/integration/aws-ec2-networkinterface.yaml" "$RESULTS_DIR/integration/aws-ec2-networkinterface.json"
+run_lint "$TEMPLATES_DIR/integration/aws-ec2-instance.yaml" "$RESULTS_DIR/integration/aws-ec2-instance.json"
+run_lint "$TEMPLATES_DIR/integration/aws-ec2-launchtemplate.yaml" "$RESULTS_DIR/integration/aws-ec2-launchtemplate.json"
+run_lint "$TEMPLATES_DIR/integration/aws-ec2-subnet.yaml" "$RESULTS_DIR/integration/aws-ec2-subnet.json"
+run_lint "$TEMPLATES_DIR/integration/aws-dynamodb-table.yaml" "$RESULTS_DIR/integration/aws-dynamodb-table.json"
+run_lint "$TEMPLATES_DIR/integration/custom-resources.yaml" "$RESULTS_DIR/integration/custom-resources.json"
+run_lint "$TEMPLATES_DIR/integration/cfn-gather.yaml" "$RESULTS_DIR/integration/cfn-gather.json"
+run_lint "$TEMPLATES_DIR/integration/aws-lambda-function.yaml" "$RESULTS_DIR/integration/aws-lambda-function.json"
 
-# public/
-cfn-lint test/fixtures/templates/public/lambda-poller.yaml -e -c I --format json > test/fixtures/results/public/lambda-poller.json
-cfn-lint test/fixtures/templates/public/watchmaker.json -e -x E3012:strict=true -c I --format json > test/fixtures/results/public/watchmaker.json
+# integration/ special name mapping (template has typo: metdata)
+run_lint "$TEMPLATES_DIR/integration/metdata.yaml" "$RESULTS_DIR/integration/metadata.json"
+
+# public/ (watchmaker needs strict E3012)
+run_lint "$TEMPLATES_DIR/public/lambda-poller.yaml" "$RESULTS_DIR/public/lambda-poller.json"
+run_lint "$TEMPLATES_DIR/public/watchmaker.json" "$RESULTS_DIR/public/watchmaker.json" -x E3012:strict=true
 
 # quickstart/non_strict/
-cfn-lint test/fixtures/templates/quickstart/cis_benchmark.yaml -e -c I --format json > test/fixtures/results/quickstart/non_strict/cis_benchmark.json
-cfn-lint test/fixtures/templates/quickstart/nist_application.yaml -e -c I --format json > test/fixtures/results/quickstart/non_strict/nist_application.json
-cfn-lint test/fixtures/templates/quickstart/nist_high_main.yaml -e -c I --format json > test/fixtures/results/quickstart/non_strict/nist_high_main.json
-cfn-lint test/fixtures/templates/quickstart/openshift.yaml -e -c I --format json > test/fixtures/results/quickstart/non_strict/openshift.json
+run_lint "$TEMPLATES_DIR/quickstart/cis_benchmark.yaml" "$RESULTS_DIR/quickstart/non_strict/cis_benchmark.json"
+run_lint "$TEMPLATES_DIR/quickstart/nist_application.yaml" "$RESULTS_DIR/quickstart/non_strict/nist_application.json"
+run_lint "$TEMPLATES_DIR/quickstart/nist_high_main.yaml" "$RESULTS_DIR/quickstart/non_strict/nist_high_main.json"
+run_lint "$TEMPLATES_DIR/quickstart/openshift.yaml" "$RESULTS_DIR/quickstart/non_strict/openshift.json"
 
-# quickstart/
-cfn-lint test/fixtures/templates/quickstart/cis_benchmark.yaml -e -c I --format json -x E3012:strict=true > test/fixtures/results/quickstart/cis_benchmark.json
-cfn-lint test/fixtures/templates/quickstart/nist_application.yaml -e -c I --format json -x E3012:strict=true > test/fixtures/results/quickstart/nist_application.json
-cfn-lint test/fixtures/templates/quickstart/nist_config_rules.yaml -e -c I --format json -x E3012:strict=true > test/fixtures/results/quickstart/nist_config_rules.json
-cfn-lint test/fixtures/templates/quickstart/nist_high_main.yaml -e -c I --format json -x E3012:strict=true > test/fixtures/results/quickstart/nist_high_main.json
-cfn-lint test/fixtures/templates/quickstart/nist_iam.yaml -e -c I --format json -x E3012:strict=true > test/fixtures/results/quickstart/nist_iam.json
-cfn-lint test/fixtures/templates/quickstart/nist_logging.yaml -e -c I --format json -x E3012:strict=true > test/fixtures/results/quickstart/nist_logging.json
-cfn-lint test/fixtures/templates/quickstart/nist_vpc_management.yaml -e -c I --format json -x E3012:strict=true > test/fixtures/results/quickstart/nist_vpc_management.json
-cfn-lint test/fixtures/templates/quickstart/nist_vpc_production.yaml -e -c I --format json -x E3012:strict=true > test/fixtures/results/quickstart/nist_vpc_production.json
-cfn-lint test/fixtures/templates/quickstart/openshift.yaml -e -c I --format json -x E3012:strict=true > test/fixtures/results/quickstart/openshift.json
-cfn-lint test/fixtures/templates/quickstart/openshift_master.yaml -e -c I --format json -x E3012:strict=true > test/fixtures/results/quickstart/openshift_master.json
+# quickstart/ (strict E3012)
+run_lint "$TEMPLATES_DIR/quickstart/cis_benchmark.yaml" "$RESULTS_DIR/quickstart/cis_benchmark.json" -x E3012:strict=true
+run_lint "$TEMPLATES_DIR/quickstart/nist_application.yaml" "$RESULTS_DIR/quickstart/nist_application.json" -x E3012:strict=true
+run_lint "$TEMPLATES_DIR/quickstart/nist_config_rules.yaml" "$RESULTS_DIR/quickstart/nist_config_rules.json" -x E3012:strict=true
+run_lint "$TEMPLATES_DIR/quickstart/nist_high_main.yaml" "$RESULTS_DIR/quickstart/nist_high_main.json" -x E3012:strict=true
+run_lint "$TEMPLATES_DIR/quickstart/nist_iam.yaml" "$RESULTS_DIR/quickstart/nist_iam.json" -x E3012:strict=true
+run_lint "$TEMPLATES_DIR/quickstart/nist_logging.yaml" "$RESULTS_DIR/quickstart/nist_logging.json" -x E3012:strict=true
+run_lint "$TEMPLATES_DIR/quickstart/nist_vpc_management.yaml" "$RESULTS_DIR/quickstart/nist_vpc_management.json" -x E3012:strict=true
+run_lint "$TEMPLATES_DIR/quickstart/nist_vpc_production.yaml" "$RESULTS_DIR/quickstart/nist_vpc_production.json" -x E3012:strict=true
+run_lint "$TEMPLATES_DIR/quickstart/openshift.yaml" "$RESULTS_DIR/quickstart/openshift.json" -x E3012:strict=true
+run_lint "$TEMPLATES_DIR/quickstart/openshift_master.yaml" "$RESULTS_DIR/quickstart/openshift_master.json" -x E3012:strict=true
+
+# ============================================================================
+# Auto-discover remaining templates not handled above (requires --auto-discover)
+# ============================================================================
+
+if $AUTO_DISCOVER; then
+find "$TEMPLATES_DIR" -type f \( -name '*.yaml' -o -name '*.yml' -o -name '*.json' \) \
+    ! -path '*/override_spec/*' \
+    ! -path '*/bad/override/*' \
+    ! -name '__init__.py' \
+    ! -name 'README.md' \
+    | sort > "${HANDLED}.all"
+
+while read -r template; do
+    # Skip templates already handled by manual entries
+    if grep -qxF "$template" "$HANDLED"; then
+        continue
+    fi
+
+    # Compute result path: replace templates/ with results/, change extension to .json
+    relative="${template#$TEMPLATES_DIR/}"
+    result_file="$RESULTS_DIR/${relative%.*}.json"
+
+    # Skip if another template already wrote this result file during this run
+    if grep -qxF "$result_file" "$WRITTEN"; then
+        echo "[SKIP] $template -> $result_file already written by another template"
+        continue
+    fi
+
+    run_lint "$template" "$result_file"
+done < "${HANDLED}.all"
+rm -f "${HANDLED}.all"
+fi
+
+# ============================================================================
+# Performance summary
+# ============================================================================
+TOTAL_END=$(python -c 'import time;print(time.time())')
+WALL_TIME=$(python -c "print(f'{($TOTAL_END-$TOTAL_START)*1000:.2f}')")
+
+echo ""
+echo "=== Performance Summary ==="
+echo "Templates processed: $TEMPLATE_COUNT"
+echo "Wall clock time:     ${WALL_TIME}ms"
+echo "Done."

--- a/test/fixtures/templates/good/core/conditions.yaml
+++ b/test/fixtures/templates/good/core/conditions.yaml
@@ -23,27 +23,29 @@ Resources:
     Type: AWS::EC2::Subnet
     Properties:
       CidrBlock: 10.0.0.0/24
-      VpcId: vpc-123456
+      VpcId: vpc-12345678
   myInstance1:
     Type: AWS::EC2::Instance
     Properties:
-      SubnetId: !If [ isDevelopment, !Ref mySubnet, 'abc-123456']
-      ImageId: ami-123456
+      SubnetId: !If [ isDevelopment, !Ref mySubnet, 'subnet-12345678']
+      ImageId: ami-12345678
   myInstance2:
     Type: AWS::EC2::Instance
     Properties:
-      ImageId: ami-123456
+      ImageId: ami-12345678
       BlockDeviceMappings:
         Fn::If:
         - isPrimaryAndProduction
-        - - VirtualName:
+        - - DeviceName: /dev/sdb
+            VirtualName:
               Fn::If:
                 - isPrimary
-                - /dev/hda
-                - /dev/hdb
+                - ephemeral0
+                - ephemeral1
         - - Fn::If:
             - isDevelopment
-            - VirtualName: /dev/hda
+            - DeviceName: /dev/sdc
+              VirtualName: ephemeral0
               Ebs: {}
             - !Ref AWS::NoValue
   myInstance3:
@@ -51,18 +53,18 @@ Resources:
     Properties:
       Fn::If:
       - isPrimaryAndProduction
-      - ImageId: ami-1234567
+      - ImageId: ami-1234567a
         InstanceType: t2.medium
       - Fn::If:
         - isDevelopment
-        - ImageId: ami-abcdefg
+        - ImageId: ami-abcdef01
           InstanceType: t2.xlarge
-        - ImageId: ami-123abcd
+        - ImageId: ami-123abcde
           InstanceType: m3.medium
   myInstance4:
     Type: AWS::EC2::Instance
     Properties:
-      ImageId: !If [isProduction, 'ami-123456', 'ami-abcdef']
+      ImageId: !If [isProduction, 'ami-12345678', 'ami-abcdef01']
       InstanceType:
         Fn::If:
         - isPrimaryAndProduction
@@ -106,7 +108,7 @@ Resources:
       Code:
         S3Bucket: lambda-functions
         S3Key: amilookup.zip
-      Runtime: nodejs4.3
+      Runtime: nodejs18.x
       Timeout: 25
       TracingConfig:
         Mode: Active


### PR DESCRIPTION
# Summary
Refactors the snapshot generation script (scripts/update_snapshot_results.sh) from a flat list of raw cfn-lint commands into a structured script with:

   - A run_lint() helper that handles directory creation and per-template timing
   - --auto-discover flag to automatically find and snapshot templates not covered by manual entries
   - Duplicate detection to prevent two templates writing the same result file
   - set -euo pipefail for safer execution
   - Performance summary at the end
   - Two previously-untracked integration templates added to the manual list (aws-lambda-function.yaml, metdata.yaml)

Fixes test fixture values in conditions.yaml to use valid AWS resource ID formats (e.g. vpc-12345678, subnet-12345678, ami-12345678), correct BlockDeviceMappings virtual names (ephemeral0), adds missing DeviceName fields. No snapshot changes resulted.

