### PR TITLE
fix: use TOML-native posargs syntax for multi-arg expansion

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,7 +136,7 @@ skip_install = true
 commands = [
   ["pip", "install", "-e", ".[full]"],
   ["pip", "install", "-r", "requirements/dev.txt"],
-  ["coverage", "run", "-m", "pytest", "{posargs:test}"],
+  ["coverage", "run", "-m", "pytest", {replace = "posargs", default = ["test"], extend = true}],
   ["coverage", "xml"],
 ]
 set_env = { LANG = "en_US.UTF-8", AWS_DEFAULT_REGION = "us-east-1" }


### PR DESCRIPTION
Fixes #4486

## Problem

The string-based `{posargs:test}` in TOML list-of-lists commands joins multiple positional arguments into a single string. For example:

```
tox -e py313 -- test/unit/rules/functions/test_sub.py -v
```

Would produce: `coverage run -m pytest 'test/unit/rules/functions/test_sub.py -v'` (single quoted arg)

## Fix

Replace the string-based `"{posargs:test}"` with the TOML-native dict syntax `{replace = "posargs", default = ["test"], extend = true}`. The `extend = true` tells tox to expand posargs as individual list elements rather than a single string.

## Verification

```
# Multiple args now work correctly
$ tox config -e py313 -- test/unit/rules/functions/test_sub.py -v
commands = coverage run -m pytest test/unit/rules/functions/test_sub.py -v

# Default still works
$ tox config -e py313
commands = coverage run -m pytest test

# CI-style -m flag still works
$ tox config -e py313 -- -m "data or not data"
commands = coverage run -m pytest -m 'data or not data'
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.