### PR TITLE
Add rule E3064: duplicate Interface VPC Endpoint with PrivateDnsEnabled

### DIFF
--- a/src/cfnlint/rules/resources/ectwo/VpcEndpointPrivateDnsDuplicate.py
+++ b/src/cfnlint/rules/resources/ectwo/VpcEndpointPrivateDnsDuplicate.py
@@ -1,0 +1,129 @@
+"""
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from typing import Any
+
+from cfnlint.context.conditions import Unsatisfiable
+from cfnlint.helpers import ensure_list, is_function
+from cfnlint.jsonschema import ValidationError, ValidationResult, Validator
+from cfnlint.rules.helpers import get_value_from_path
+from cfnlint.rules.jsonschema.CfnLintKeyword import CfnLintKeyword
+
+
+class VpcEndpointPrivateDnsDuplicate(CfnLintKeyword):
+    id = "E3064"
+    shortdesc = "Validate unique PrivateDnsEnabled per service per VPC"
+    description = (
+        "Only one Interface VPC Endpoint per service can have "
+        "PrivateDnsEnabled set to true in a VPC. A second endpoint "
+        "with the same service and PrivateDnsEnabled will fail to create "
+        "due to a conflicting DNS domain."
+    )
+    source_url = (
+        "https://docs.aws.amazon.com/vpc/latest/privatelink/manage-dns-names.html"
+    )
+    tags = ["resources", "ec2", "vpc"]
+
+    def __init__(self) -> None:
+        super().__init__(
+            keywords=[
+                "Resources/AWS::EC2::VPCEndpoint/Properties",
+            ],
+        )
+        self._endpoints: dict[
+            tuple[str, str], list[tuple[list[str | int], dict[str, bool]]]
+        ] = {}
+
+    def initialize(self, cfn):
+        self._endpoints = {}
+        return super().initialize(cfn)
+
+    @staticmethod
+    def _resolve_key(value: Any) -> str | None:
+        if isinstance(value, str):
+            return value
+        if not isinstance(value, dict):
+            return None
+        fn_k, fn_v = is_function(value)
+        if fn_k == "Ref":
+            return f"Ref:{fn_v}"
+        if fn_k == "Fn::GetAtt":
+            parts = ensure_list(fn_v)
+            return f"GetAtt:{parts[0]}"
+        if fn_k == "Fn::Sub":
+            if isinstance(fn_v, str):
+                return f"Sub:{fn_v}"
+            if isinstance(fn_v, list) and fn_v:
+                return f"Sub:{fn_v[0]}"
+        return None
+
+    def validate(
+        self,
+        validator: Validator,
+        keywords: Any,
+        instance: Any,
+        schema: dict[str, Any],
+    ) -> ValidationResult:
+        for endpoint_type, type_validator in get_value_from_path(
+            validator, instance, deque(["VpcEndpointType"])
+        ):
+            if endpoint_type != "Interface":
+                continue
+
+            for private_dns, dns_validator in get_value_from_path(
+                type_validator, instance, deque(["PrivateDnsEnabled"])
+            ):
+                if private_dns is not True:
+                    continue
+
+                for vpc_id, vpc_validator in get_value_from_path(
+                    dns_validator, instance, deque(["VpcId"])
+                ):
+                    vpc_key = self._resolve_key(vpc_id)
+                    if vpc_key is None:
+                        continue
+
+                    for service_name, svc_validator in get_value_from_path(
+                        vpc_validator, instance, deque(["ServiceName"])
+                    ):
+                        svc_key = self._resolve_key(service_name)
+                        if svc_key is None:
+                            continue
+
+                        group_key = (vpc_key, svc_key)
+                        if group_key not in self._endpoints:
+                            self._endpoints[group_key] = []
+
+                        conditions = svc_validator.context.conditions.status
+
+                        for _, saved_conditions in self._endpoints[group_key]:
+                            try:
+                                svc_validator.evolve(
+                                    context=svc_validator.context.evolve(
+                                        conditions=svc_validator.context.conditions.evolve(
+                                            saved_conditions
+                                        )
+                                    )
+                                )
+                            except Unsatisfiable:
+                                continue
+
+                            yield ValidationError(
+                                "Only one Interface VPC Endpoint per service "
+                                "can have 'PrivateDnsEnabled' set to true in "
+                                "a VPC. A second endpoint will fail to create "
+                                "due to a conflicting private DNS domain.",
+                                rule=self,
+                            )
+
+                        self._endpoints[group_key].append(
+                            (
+                                list(svc_validator.context.path.path),
+                                conditions,
+                            )
+                        )

--- a/test/unit/rules/resources/ec2/test_vpc_endpoint_private_dns_duplicate.py
+++ b/test/unit/rules/resources/ec2/test_vpc_endpoint_private_dns_duplicate.py
@@ -1,0 +1,346 @@
+"""
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+"""
+
+import pytest
+
+from cfnlint.jsonschema import ValidationError
+from cfnlint.rules.resources.ectwo.VpcEndpointPrivateDnsDuplicate import (
+    VpcEndpointPrivateDnsDuplicate,
+)
+
+
+@pytest.fixture(scope="module")
+def rule():
+    rule = VpcEndpointPrivateDnsDuplicate()
+    yield rule
+
+
+@pytest.fixture
+def template():
+    return {
+        "Conditions": {
+            "IsUsEast1": {"Fn::Equals": [{"Ref": "AWS::Region"}, "us-east-1"]},
+            "IsUsWest2": {"Fn::Equals": [{"Ref": "AWS::Region"}, "us-west-2"]},
+        },
+        "Resources": {},
+    }
+
+
+@pytest.mark.parametrize(
+    "name,instance,starting_endpoints,expected",
+    [
+        (
+            "Valid first endpoint in VPC",
+            {
+                "VpcId": {"Ref": "Vpc"},
+                "VpcEndpointType": "Interface",
+                "ServiceName": {"Fn::Sub": "com.amazonaws.${AWS::Region}.sqs"},
+                "PrivateDnsEnabled": True,
+            },
+            {},
+            [],
+        ),
+        (
+            "Valid with unresolvable VpcId function",
+            {
+                "VpcId": {"Fn::Select": [0, ["vpc-123"]]},
+                "VpcEndpointType": "Interface",
+                "ServiceName": {"Fn::Sub": "com.amazonaws.${AWS::Region}.sqs"},
+                "PrivateDnsEnabled": True,
+            },
+            {},
+            [],
+        ),
+        (
+            "Valid with unresolvable ServiceName function",
+            {
+                "VpcId": {"Ref": "Vpc"},
+                "VpcEndpointType": "Interface",
+                "ServiceName": {"Fn::Select": [0, ["svc"]]},
+                "PrivateDnsEnabled": True,
+            },
+            {},
+            [],
+        ),
+        (
+            "Valid with non-dict non-string VpcId",
+            {
+                "VpcId": 123,
+                "VpcEndpointType": "Interface",
+                "ServiceName": {"Fn::Sub": "com.amazonaws.${AWS::Region}.sqs"},
+                "PrivateDnsEnabled": True,
+            },
+            {},
+            [],
+        ),
+        (
+            "Valid with GetAtt VpcId",
+            {
+                "VpcId": {"Fn::GetAtt": ["MyResource", "VpcId"]},
+                "VpcEndpointType": "Interface",
+                "ServiceName": {"Fn::Sub": "com.amazonaws.${AWS::Region}.sqs"},
+                "PrivateDnsEnabled": True,
+            },
+            {},
+            [],
+        ),
+        (
+            "Valid with Fn::Sub list form ServiceName",
+            {
+                "VpcId": {"Ref": "Vpc"},
+                "VpcEndpointType": "Interface",
+                "ServiceName": {
+                    "Fn::Sub": ["com.amazonaws.${Region}.sqs", {"Region": "us-east-1"}]
+                },
+                "PrivateDnsEnabled": True,
+            },
+            {},
+            [],
+        ),
+        (
+            "Valid same service different VPC",
+            {
+                "VpcId": {"Ref": "Vpc2"},
+                "VpcEndpointType": "Interface",
+                "ServiceName": {"Fn::Sub": "com.amazonaws.${AWS::Region}.sqs"},
+                "PrivateDnsEnabled": True,
+            },
+            {
+                ("Ref:Vpc1", "Sub:com.amazonaws.${AWS::Region}.sqs"): [
+                    (["Resources", "Endpoint1"], {})
+                ],
+            },
+            [],
+        ),
+        (
+            "Valid different service same VPC",
+            {
+                "VpcId": {"Ref": "Vpc"},
+                "VpcEndpointType": "Interface",
+                "ServiceName": {"Fn::Sub": "com.amazonaws.${AWS::Region}.sns"},
+                "PrivateDnsEnabled": True,
+            },
+            {
+                ("Ref:Vpc", "Sub:com.amazonaws.${AWS::Region}.sqs"): [
+                    (["Resources", "Endpoint1"], {})
+                ],
+            },
+            [],
+        ),
+        (
+            "Valid PrivateDnsEnabled is false",
+            {
+                "VpcId": {"Ref": "Vpc"},
+                "VpcEndpointType": "Interface",
+                "ServiceName": {"Fn::Sub": "com.amazonaws.${AWS::Region}.sqs"},
+                "PrivateDnsEnabled": False,
+            },
+            {
+                ("Ref:Vpc", "Sub:com.amazonaws.${AWS::Region}.sqs"): [
+                    (["Resources", "Endpoint1"], {})
+                ],
+            },
+            [],
+        ),
+        (
+            "Valid Gateway type duplicate",
+            {
+                "VpcId": {"Ref": "Vpc"},
+                "VpcEndpointType": "Gateway",
+                "ServiceName": {"Fn::Sub": "com.amazonaws.${AWS::Region}.s3"},
+                "PrivateDnsEnabled": True,
+            },
+            {
+                ("Ref:Vpc", "Sub:com.amazonaws.${AWS::Region}.s3"): [
+                    (["Resources", "Endpoint1"], {})
+                ],
+            },
+            [],
+        ),
+        (
+            "Valid with mutually exclusive conditions via Fn::If on PrivateDns",
+            {
+                "VpcId": {"Ref": "Vpc"},
+                "VpcEndpointType": "Interface",
+                "ServiceName": {"Fn::Sub": "com.amazonaws.${AWS::Region}.sqs"},
+                "PrivateDnsEnabled": {"Fn::If": ["IsUsWest2", True, False]},
+            },
+            {
+                ("Ref:Vpc", "Sub:com.amazonaws.${AWS::Region}.sqs"): [
+                    (
+                        ["Resources", "Endpoint1"],
+                        {"IsUsEast1": True, "IsUsWest2": False},
+                    ),
+                ],
+            },
+            [],
+        ),
+        (
+            "Valid with Fn::If on VpcId resolving to different VPCs",
+            {
+                "VpcId": {"Fn::If": ["IsUsEast1", {"Ref": "Vpc1"}, {"Ref": "Vpc2"}]},
+                "VpcEndpointType": "Interface",
+                "ServiceName": {"Fn::Sub": "com.amazonaws.${AWS::Region}.sqs"},
+                "PrivateDnsEnabled": True,
+            },
+            {
+                ("Ref:Vpc1", "Sub:com.amazonaws.${AWS::Region}.sqs"): [
+                    (
+                        ["Resources", "Endpoint1"],
+                        {"IsUsEast1": True},
+                    ),
+                ],
+            },
+            [
+                ValidationError(
+                    (
+                        "Only one Interface VPC Endpoint per service "
+                        "can have 'PrivateDnsEnabled' set to true in "
+                        "a VPC. A second endpoint will fail to create "
+                        "due to a conflicting private DNS domain."
+                    ),
+                    rule=VpcEndpointPrivateDnsDuplicate(),
+                )
+            ],
+        ),
+        (
+            "Valid with PrivateDnsEnabled via Fn::If resolving to false",
+            {
+                "VpcId": {"Ref": "Vpc"},
+                "VpcEndpointType": "Interface",
+                "ServiceName": {"Fn::Sub": "com.amazonaws.${AWS::Region}.sqs"},
+                "PrivateDnsEnabled": {"Fn::If": ["IsUsEast1", False, True]},
+            },
+            {
+                ("Ref:Vpc", "Sub:com.amazonaws.${AWS::Region}.sqs"): [
+                    (
+                        ["Resources", "Endpoint1"],
+                        {"IsUsEast1": True},
+                    ),
+                ],
+            },
+            [],
+        ),
+        (
+            "Invalid with same conditions on both endpoints",
+            {
+                "VpcId": {"Ref": "Vpc"},
+                "VpcEndpointType": "Interface",
+                "ServiceName": {"Fn::Sub": "com.amazonaws.${AWS::Region}.sqs"},
+                "PrivateDnsEnabled": True,
+            },
+            {
+                ("Ref:Vpc", "Sub:com.amazonaws.${AWS::Region}.sqs"): [
+                    (
+                        ["Resources", "Endpoint1"],
+                        {"IsUsEast1": True},
+                    ),
+                ],
+            },
+            [
+                ValidationError(
+                    (
+                        "Only one Interface VPC Endpoint per service "
+                        "can have 'PrivateDnsEnabled' set to true in "
+                        "a VPC. A second endpoint will fail to create "
+                        "due to a conflicting private DNS domain."
+                    ),
+                    rule=VpcEndpointPrivateDnsDuplicate(),
+                )
+            ],
+        ),
+        (
+            "Invalid duplicate same service same VPC",
+            {
+                "VpcId": {"Ref": "Vpc"},
+                "VpcEndpointType": "Interface",
+                "ServiceName": {"Fn::Sub": "com.amazonaws.${AWS::Region}.sqs"},
+                "PrivateDnsEnabled": True,
+            },
+            {
+                ("Ref:Vpc", "Sub:com.amazonaws.${AWS::Region}.sqs"): [
+                    (["Resources", "Endpoint1"], {})
+                ],
+            },
+            [
+                ValidationError(
+                    (
+                        "Only one Interface VPC Endpoint per service "
+                        "can have 'PrivateDnsEnabled' set to true in "
+                        "a VPC. A second endpoint will fail to create "
+                        "due to a conflicting private DNS domain."
+                    ),
+                    rule=VpcEndpointPrivateDnsDuplicate(),
+                )
+            ],
+        ),
+        (
+            "Invalid with Fn::If on ServiceName matching saved in same condition",
+            {
+                "VpcId": {"Ref": "Vpc"},
+                "VpcEndpointType": "Interface",
+                "ServiceName": {
+                    "Fn::If": [
+                        "IsUsEast1",
+                        {"Fn::Sub": "com.amazonaws.${AWS::Region}.sqs"},
+                        {"Fn::Sub": "com.amazonaws.${AWS::Region}.sns"},
+                    ]
+                },
+                "PrivateDnsEnabled": True,
+            },
+            {
+                ("Ref:Vpc", "Sub:com.amazonaws.${AWS::Region}.sqs"): [
+                    (
+                        ["Resources", "Endpoint1"],
+                        {"IsUsEast1": True},
+                    ),
+                ],
+            },
+            [
+                ValidationError(
+                    (
+                        "Only one Interface VPC Endpoint per service "
+                        "can have 'PrivateDnsEnabled' set to true in "
+                        "a VPC. A second endpoint will fail to create "
+                        "due to a conflicting private DNS domain."
+                    ),
+                    rule=VpcEndpointPrivateDnsDuplicate(),
+                )
+            ],
+        ),
+        (
+            "Invalid duplicate with hardcoded VPC ID",
+            {
+                "VpcId": "vpc-12345678",
+                "VpcEndpointType": "Interface",
+                "ServiceName": "com.amazonaws.us-east-1.execute-api",
+                "PrivateDnsEnabled": True,
+            },
+            {
+                ("vpc-12345678", "com.amazonaws.us-east-1.execute-api"): [
+                    (["Resources", "Endpoint1"], {})
+                ],
+            },
+            [
+                ValidationError(
+                    (
+                        "Only one Interface VPC Endpoint per service "
+                        "can have 'PrivateDnsEnabled' set to true in "
+                        "a VPC. A second endpoint will fail to create "
+                        "due to a conflicting private DNS domain."
+                    ),
+                    rule=VpcEndpointPrivateDnsDuplicate(),
+                )
+            ],
+        ),
+    ],
+)
+def test_validate(name, instance, starting_endpoints, expected, rule, validator):
+    rule._endpoints = starting_endpoints
+    errs = list(rule.validate(validator, "", instance, {}))
+
+    assert errs == expected, (
+        f"Expected test {name!r} to have {expected!r} but got {errs!r}"
+    )


### PR DESCRIPTION
## Summary

Add rule **E3064** to detect when multiple `AWS::EC2::VPCEndpoint` resources in the same template have the same `VpcId`, `ServiceName`, `VpcEndpointType: Interface`, and `PrivateDnsEnabled: true`. AWS rejects the second endpoint at deploy time with a conflicting DNS domain error, causing a stack rollback.

## What was tested

- Deployed test stacks to AWS (us-east-1) confirming the EC2 API rejects duplicate Interface endpoints with Private DNS enabled in the same VPC — for any service, not just execute-api
- Verified edge cases: different VPCs (allowed), different services (allowed), mixed PrivateDnsEnabled (allowed), Gateway type duplicates (separate failure mode)

## Test cases (12)

- First endpoint in VPC (valid)
- Same service, different VPC (valid)
- Different service, same VPC (valid)
- PrivateDnsEnabled false (valid)
- Gateway type duplicate (valid — different failure mode)
- Mutually exclusive conditions via `Fn::If` on PrivateDnsEnabled (valid)
- `Fn::If` on VpcId matching saved in same condition (error)
- `Fn::If` on PrivateDnsEnabled resolving to false (valid)
- Same conditions on both endpoints (error)
- Plain duplicate, no conditions (error)
- `Fn::If` on ServiceName matching saved in same condition (error)
- Hardcoded VPC ID duplicate (error)

Fixes #4352