### PR TITLE
Fix `ResultWriter` schema of step functions

### DIFF
--- a/src/cfnlint/data/schemas/other/step_functions/statemachine.json
+++ b/src/cfnlint/data/schemas/other/step_functions/statemachine.json
@@ -614,7 +614,7 @@
      "type": "object"
     },
     "ResultWriter": {
-     "type": "string"
+     "type": "object"
     },
     "Retry": {
      "items": {


### PR DESCRIPTION
*Issue , if available:*
fixes #4496

*Description of changes:*
According to [documentation](https://docs.aws.amazon.com/step-functions/latest/dg/input-output-resultwriter.html), `ResultWriter` should be an object - that's how (successfully) we use it as well but `cfn-lint` fails, claiming it should be a string:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
