### PR TITLE
Fix E3039 crash when Fn::Transform used at list properties

### DIFF
--- a/src/cfnlint/rules/resources/dynamodb/AttributeMismatch.py
+++ b/src/cfnlint/rules/resources/dynamodb/AttributeMismatch.py
@@ -55,25 +55,30 @@ class AttributeMismatch(CloudFormationLintRule):
         matches = []
         properties = property_set.get("Object")
 
+        attribute_definitions = properties.get("AttributeDefinitions", [])
+        key_schema = properties.get("KeySchema", [])
+        gsi = properties.get("GlobalSecondaryIndexes", [])
+        lsi = properties.get("LocalSecondaryIndexes", [])
+
+        if not all(
+            isinstance(p, list) for p in [attribute_definitions, key_schema, gsi, lsi]
+        ):
+            return matches
+
         keys = set()
         attributes = set()
 
-        for attribute in properties.get("AttributeDefinitions", []):
+        for attribute in attribute_definitions:
             attribute_name = attribute.get("AttributeName")
             if isinstance(attribute_name, str):
-                attributes.add(attribute.get("AttributeName"))
+                attributes.add(attribute_name)
             else:
                 self.logger.info("attribute definitions is not using just strings")
                 return matches
-        keys = keys.union(
-            self._get_key_schema_attributes(properties.get("KeySchema", []))
-        )
-        keys = keys.union(
-            self._get_attribute_secondary(properties.get("GlobalSecondaryIndexes", []))
-        )
-        keys = keys.union(
-            self._get_attribute_secondary(properties.get("LocalSecondaryIndexes", []))
-        )
+
+        keys = keys.union(self._get_key_schema_attributes(key_schema))
+        keys = keys.union(self._get_attribute_secondary(gsi))
+        keys = keys.union(self._get_attribute_secondary(lsi))
 
         if attributes != keys:
             message = (

--- a/test/fixtures/templates/good/resources/dynamodb/attributes_transform.yaml
+++ b/test/fixtures/templates/good/resources/dynamodb/attributes_transform.yaml
@@ -1,0 +1,41 @@
+---
+AWSTemplateFormatVersion: "2010-09-09"
+Parameters:
+  IncludeBaseUrl:
+    Type: String
+Resources:
+  DDBTableTransformAttributeDefinitions:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      AttributeDefinitions:
+        Fn::Transform:
+          - Name: AWS::Include
+            Parameters:
+              Location: !Sub "${IncludeBaseUrl}/attribute-definitions.yaml"
+      KeySchema:
+        - AttributeName: "pk"
+          KeyType: "HASH"
+  DDBTableTransformKeySchema:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      AttributeDefinitions:
+        - AttributeName: "pk"
+          AttributeType: "S"
+      KeySchema:
+        Fn::Transform:
+          - Name: AWS::Include
+            Parameters:
+              Location: !Sub "${IncludeBaseUrl}/key-schema.yaml"
+  DDBTableTransformBoth:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      AttributeDefinitions:
+        Fn::Transform:
+          - Name: AWS::Include
+            Parameters:
+              Location: !Sub "${IncludeBaseUrl}/attribute-definitions.yaml"
+      KeySchema:
+        Fn::Transform:
+          - Name: AWS::Include
+            Parameters:
+              Location: !Sub "${IncludeBaseUrl}/key-schema.yaml"

--- a/test/unit/rules/resources/dynamodb/test_attribute_mismatch.py
+++ b/test/unit/rules/resources/dynamodb/test_attribute_mismatch.py
@@ -45,3 +45,9 @@ class TestAttributeMismatch(BaseRuleTestCase):
             "test/fixtures/templates/bad/resources/dynamodb/undefined_attribute_definition.yaml",
             1,
         )
+
+    def test_file_positive_transform(self):
+        """Test no crash when Fn::Transform is used at list property positions"""
+        self.helper_file_positive_template(
+            "test/fixtures/templates/good/resources/dynamodb/attributes_transform.yaml"
+        )


### PR DESCRIPTION
## Summary

Fixes #4493

Rule E3039 crashes with `'str_node' object has no attribute 'get'` when `Fn::Transform` (e.g., `AWS::Include`) is used at list property positions like `AttributeDefinitions` or `KeySchema` on `AWS::DynamoDB::Table`.

## Root Cause

When `Fn::Transform` is used, the property value is a dict rather than a list. The rule iterated over the dict (yielding string keys) and called `.get()` on them, causing the crash.

## Fix

Added an upfront check: if any of the four relevant properties (`AttributeDefinitions`, `KeySchema`, `GlobalSecondaryIndexes`, `LocalSecondaryIndexes`) is not a list, skip the entire validation since the actual values are only known at deploy time.

## Testing

- Added fixture template covering `Fn::Transform` at each list property position
- Added test case `test_file_positive_transform`
- All existing tests continue to pass