### PR TITLE
Move SSM Parameter Name prefix check from error to warning

### DIFF
--- a/src/cfnlint/data/schemas/patches/extensions/all/aws_ssm_parameter/manual.json
+++ b/src/cfnlint/data/schemas/patches/extensions/all/aws_ssm_parameter/manual.json
@@ -1,7 +1,1 @@
-[
- {
-  "op": "add",
-  "path": "/properties/Name/pattern",
-  "value": "^(?i)((?!aws|ssm)[\\w.-]+|\\/(?!aws|ssm)[\\w.-]+(\\/[\\w.-]+)*)$"
- }
-]
+[]

--- a/src/cfnlint/data/schemas/resources/88998b8e50aa846a.json
+++ b/src/cfnlint/data/schemas/resources/88998b8e50aa846a.json
@@ -29,7 +29,6 @@
   "Name": {
    "maxLength": 2048,
    "minLength": 1,
-   "pattern": "^(?i)((?!aws|ssm)[\\w.-]+|\\/(?!aws|ssm)[\\w.-]+(\\/[\\w.-]+)*)$",
    "type": "string"
   },
   "Policies": {

--- a/src/cfnlint/rules/resources/ssm/ParameterNamePrefix.py
+++ b/src/cfnlint/rules/resources/ssm/ParameterNamePrefix.py
@@ -1,0 +1,44 @@
+"""
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import regex as re
+
+from cfnlint.jsonschema import ValidationError, ValidationResult, Validator
+from cfnlint.rules.jsonschema.CfnLintKeyword import CfnLintKeyword
+
+
+class ParameterNamePrefix(CfnLintKeyword):
+    id = "W3701"
+    shortdesc = "SSM Parameter Name should not use /aws/ or /ssm/ prefix"
+    description = (
+        "SSM parameter names starting with /aws/ or /ssm/ (or aws/ssm "
+        "without a leading slash) are reserved. While some AWS services "
+        "can create parameters in this namespace, most users cannot."
+    )
+    source_url = "https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-paramstore-su-create.html"
+    tags = ["resources", "ssm"]
+
+    def __init__(self) -> None:
+        super().__init__(["Resources/AWS::SSM::Parameter/Properties/Name"])
+        self._pattern = re.compile(
+            r"^(?i)((?!aws|ssm)[\w.-]+|\/(?!aws|ssm)[\w.-]+(\/[\w.-]+)*)$"
+        )
+
+    def validate(
+        self, validator: Validator, _: Any, instance: Any, schema: dict[str, Any]
+    ) -> ValidationResult:
+        if not isinstance(instance, str):
+            return
+
+        if not self._pattern.match(instance):
+            yield ValidationError(
+                f"{instance!r} does not match the recommended pattern. "
+                "Parameter names beginning with 'aws' or 'ssm' are "
+                "reserved and may not be available for all users."
+            )

--- a/test/unit/rules/resources/ssm/test_parameter_name_prefix.py
+++ b/test/unit/rules/resources/ssm/test_parameter_name_prefix.py
@@ -1,0 +1,67 @@
+"""
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+"""
+
+import pytest
+
+from cfnlint.jsonschema import ValidationError
+from cfnlint.rules.resources.ssm.ParameterNamePrefix import ParameterNamePrefix
+
+
+@pytest.fixture(scope="module")
+def rule():
+    rule = ParameterNamePrefix()
+    yield rule
+
+
+@pytest.mark.parametrize(
+    "instance,expected",
+    [
+        ("/my/parameter/name", []),
+        ("/production/db/password", []),
+        ("myParameter", []),
+        ("my.parameter", []),
+        ("my-parameter", []),
+        ("/my/nested/deep/param", []),
+        (
+            "/aws/service/ami-amazon-linux-latest",
+            [
+                ValidationError(
+                    "'/aws/service/ami-amazon-linux-latest' does not match "
+                    "the recommended pattern. Parameter names beginning with "
+                    "'aws' or 'ssm' are reserved and may not be available "
+                    "for all users."
+                ),
+            ],
+        ),
+        (
+            "/ssm/managed/instance",
+            [
+                ValidationError(
+                    "'/ssm/managed/instance' does not match "
+                    "the recommended pattern. Parameter names beginning with "
+                    "'aws' or 'ssm' are reserved and may not be available "
+                    "for all users."
+                ),
+            ],
+        ),
+        (
+            "aws-param",
+            [
+                ValidationError(
+                    "'aws-param' does not match "
+                    "the recommended pattern. Parameter names beginning with "
+                    "'aws' or 'ssm' are reserved and may not be available "
+                    "for all users."
+                ),
+            ],
+        ),
+        ([], []),
+        ({}, []),
+    ],
+)
+def test_validate(instance, expected, rule, validator):
+    errs = list(rule.validate(validator, "", instance, {}))
+
+    assert errs == expected, f"Expected {expected} got {errs}"


### PR DESCRIPTION
## Summary

The pattern constraint on `AWS::SSM::Parameter` `Name` that prevents `/aws/` and `/ssm/` prefixes is now a warning (**W3701**) instead of an error (**E3031**).

Some users can legitimately create parameters in these namespaces, so this should not be a hard failure.

## Changes

- Removed the pattern from the base schema via the manual patch (changed from `add` to `remove`)
- Created new rule **W3701** (`ParameterNamePrefix`) that checks the same pattern as a warning
- Added unit tests for the new rule

## Testing

- All existing unit and integration tests pass
- Verified end-to-end that `/aws/` prefixed names produce W3701 (warning) not E3031 (error)
- Valid parameter names produce no warnings