### PR TITLE
Fix W3664 false positive for regional CWL principal

### DIFF
--- a/src/cfnlint/data/schemas/extensions/aws_lambda_permission/permission_principal.json
+++ b/src/cfnlint/data/schemas/extensions/aws_lambda_permission/permission_principal.json
@@ -24,22 +24,22 @@
      "permission": {
       "properties": {
        "principal": {
-        "const": {
+        "pattern": {
          "$lookup": {
           "key": {
            "$data": "/target/resourceType"
           },
           "map": {
-           "AWS::ApiGateway::RestApi": "apigateway.amazonaws.com",
-           "AWS::ApiGatewayV2::Api": "apigateway.amazonaws.com",
-           "AWS::Cognito::UserPool": "cognito-idp.amazonaws.com",
-           "AWS::Config::ConfigRule": "config.amazonaws.com",
-           "AWS::ElasticLoadBalancingV2::TargetGroup": "elasticloadbalancing.amazonaws.com",
-           "AWS::Events::Rule": "events.amazonaws.com",
-           "AWS::IoT::TopicRule": "iot.amazonaws.com",
-           "AWS::Logs::LogGroup": "logs.amazonaws.com",
-           "AWS::S3::Bucket": "s3.amazonaws.com",
-           "AWS::SNS::Topic": "sns.amazonaws.com"
+           "AWS::ApiGateway::RestApi": "^apigateway\\.amazonaws\\.com$",
+           "AWS::ApiGatewayV2::Api": "^apigateway\\.amazonaws\\.com$",
+           "AWS::Cognito::UserPool": "^cognito-idp\\.amazonaws\\.com$",
+           "AWS::Config::ConfigRule": "^config\\.amazonaws\\.com$",
+           "AWS::ElasticLoadBalancingV2::TargetGroup": "^elasticloadbalancing\\.amazonaws\\.com$",
+           "AWS::Events::Rule": "^events\\.amazonaws\\.com$",
+           "AWS::IoT::TopicRule": "^iot\\.amazonaws\\.com$",
+           "AWS::Logs::LogGroup": "^logs(\\.[a-z]{2}(-gov|-iso[a-z]?)?-[a-z]+-[0-9]+)?\\.amazonaws\\.com$",
+           "AWS::S3::Bucket": "^s3\\.amazonaws\\.com$",
+           "AWS::SNS::Topic": "^sns\\.amazonaws\\.com$"
           }
          }
         }

--- a/src/cfnlint/jsonschema/_keywords_cfn.py
+++ b/src/cfnlint/jsonschema/_keywords_cfn.py
@@ -131,6 +131,8 @@ def resolve_data_in_schema(schema: Any, root_instance: Any) -> Any:
                         resolved = int(resolved)
                     except (ValueError, TypeError):
                         continue
+                if k == "pattern" and not isinstance(resolved, str):
+                    continue
                 result[k] = resolved
             else:
                 result[k] = resolve_data_in_schema(v, root_instance)

--- a/src/cfnlint/rules/resources/lmbd/PermissionPrincipal.py
+++ b/src/cfnlint/rules/resources/lmbd/PermissionPrincipal.py
@@ -47,5 +47,29 @@ class PermissionPrincipal(CfnLintJsonSchema):
             ),
         )
 
+    # Map from pattern back to friendly service name for error messages
+    _pattern_to_friendly: dict[str, str] = {
+        "^apigateway\\.amazonaws\\.com$": "apigateway.amazonaws.com",
+        "^cognito-idp\\.amazonaws\\.com$": "cognito-idp.amazonaws.com",
+        "^config\\.amazonaws\\.com$": "config.amazonaws.com",
+        "^elasticloadbalancing\\.amazonaws\\.com$": (
+            "elasticloadbalancing.amazonaws.com"
+        ),
+        "^events\\.amazonaws\\.com$": "events.amazonaws.com",
+        "^iot\\.amazonaws\\.com$": "iot.amazonaws.com",
+        "^logs(\\.[a-z]{2}(-gov|-iso[a-z]?)?-[a-z]+-[0-9]+)?\\.amazonaws\\.com$": (
+            "logs.amazonaws.com or logs.<region>.amazonaws.com"
+        ),
+        "^s3\\.amazonaws\\.com$": "s3.amazonaws.com",
+        "^sns\\.amazonaws\\.com$": "sns.amazonaws.com",
+    }
+
     def message(self, instance: Any, err: ValidationError) -> str:
+        pattern = err.validator_value if err.validator == "pattern" else ""
+        friendly = self._pattern_to_friendly.get(pattern, "")
+        if friendly:
+            return (
+                f"Principal {err.instance!r} does not match expected "
+                f"service principal {friendly!r}"
+            )
         return err.message

--- a/test/fixtures/schemas/providers/cfnlint.schema.v1.json
+++ b/test/fixtures/schemas/providers/cfnlint.schema.v1.json
@@ -337,8 +337,15 @@
    "$ref": "#/definitions/schemaArray"
   },
   "pattern": {
-   "format": "regex",
-   "type": "string"
+   "oneOf": [
+    {
+     "format": "regex",
+     "type": "string"
+    },
+    {
+     "type": "object"
+    }
+   ]
   },
   "patternProperties": {
    "additionalProperties": {

--- a/test/unit/module/jsonschema/test_keywords_cfn.py
+++ b/test/unit/module/jsonschema/test_keywords_cfn.py
@@ -496,3 +496,24 @@ def test_cfn_type_function(instance, type_value, strict_types, expected, validat
     )
     errs = list(cfn_type(validator, type_value, instance, {}))
     assert errs == expected
+
+
+def test_resolve_data_in_schema_pattern_non_string():
+    """Test that pattern is skipped when resolved value is not a string."""
+    from cfnlint.jsonschema._keywords_cfn import resolve_data_in_schema
+
+    schema = {
+        "pattern": {
+            "$data": "/target/value",
+        }
+    }
+
+    # When $data resolves to a non-string, pattern should be skipped
+    instance = {"target": {"value": 123}}
+    result = resolve_data_in_schema(schema, instance)
+    assert "pattern" not in result
+
+    # When $data resolves to a string, pattern is kept
+    instance = {"target": {"value": "^s3\\.amazonaws\\.com$"}}
+    result = resolve_data_in_schema(schema, instance)
+    assert result["pattern"] == "^s3\\.amazonaws\\.com$"

--- a/test/unit/rules/resources/lmbd/test_permission_principal.py
+++ b/test/unit/rules/resources/lmbd/test_permission_principal.py
@@ -48,7 +48,7 @@ _schema_path = deque(
         "permission",
         "properties",
         "principal",
-        "const",
+        "pattern",
     ]
 )
 
@@ -77,8 +77,9 @@ _schema_path = deque(
             deque(["Resources", "Permission", "Properties"]),
             [
                 ValidationError(
-                    "'s3.amazonaws.com' was expected",
-                    validator="const",
+                    "Principal 'sns.amazonaws.com' does not match expected "
+                    "service principal 's3.amazonaws.com'",
+                    validator="pattern",
                     rule=PermissionPrincipal(),
                     path=deque(["Principal"]),
                     schema_path=_schema_path,
@@ -125,8 +126,9 @@ _schema_path = deque(
             deque(["Resources", "Permission", "Properties"]),
             [
                 ValidationError(
-                    "'sns.amazonaws.com' was expected",
-                    validator="const",
+                    "Principal 's3.amazonaws.com' does not match expected "
+                    "service principal 'sns.amazonaws.com'",
+                    validator="pattern",
                     rule=PermissionPrincipal(),
                     path=deque(["Principal"]),
                     schema_path=_schema_path,
@@ -193,6 +195,26 @@ _schema_path = deque(
             deque(["Resources", "Permission", "Properties"]),
             [],
         ),
+        # CloudWatch Logs LogGroup with regional principal — valid
+        (
+            jsonpatch.apply_patch(
+                _template,
+                [
+                    {
+                        "op": "replace",
+                        "path": "/Resources/Permission/Properties/SourceArn",
+                        "value": {"Fn::GetAtt": ["LogGroup", "Arn"]},
+                    },
+                    {
+                        "op": "replace",
+                        "path": "/Resources/Permission/Properties/Principal",
+                        "value": "logs.eu-west-1.amazonaws.com",
+                    },
+                ],
+            ),
+            deque(["Resources", "Permission", "Properties"]),
+            [],
+        ),
         # CloudWatch Logs LogGroup with wrong principal — error
         (
             jsonpatch.apply_patch(
@@ -213,8 +235,10 @@ _schema_path = deque(
             deque(["Resources", "Permission", "Properties"]),
             [
                 ValidationError(
-                    "'logs.amazonaws.com' was expected",
-                    validator="const",
+                    "Principal 's3.amazonaws.com' does not match expected "
+                    "service principal "
+                    "'logs.amazonaws.com or logs.<region>.amazonaws.com'",
+                    validator="pattern",
                     rule=PermissionPrincipal(),
                     path=deque(["Principal"]),
                     schema_path=_schema_path,
@@ -301,8 +325,9 @@ _schema_path = deque(
             deque(["Resources", "Permission", "Properties"]),
             [
                 ValidationError(
-                    "'iot.amazonaws.com' was expected",
-                    validator="const",
+                    "Principal 's3.amazonaws.com' does not match expected "
+                    "service principal 'iot.amazonaws.com'",
+                    validator="pattern",
                     rule=PermissionPrincipal(),
                     path=deque(["Principal"]),
                     schema_path=_schema_path,
@@ -369,3 +394,14 @@ def test_validate(template, start_path, expected, rule, validator):
     ):
         errs = list(rule.validate(instance_validator, "", instance, {}))
         assert errs == expected, f"Expected {expected} got {errs}"
+
+
+def test_message_fallback(rule):
+    """Test message method falls back to err.message for non-pattern validators."""
+    err = ValidationError(
+        "some other error",
+        validator="const",
+        validator_value="something",
+        instance="test",
+    )
+    assert rule.message({}, err) == "some other error"


### PR DESCRIPTION
## Summary

Fix W3664 false positive when using regional CloudWatch Logs principal (`logs.<region>.amazonaws.com`) with `AWS::Lambda::Permission`.

## Changes

- Changed `permission_principal.json` schema from `const` to `pattern`-based matching
- `AWS::Logs::LogGroup` now accepts both `logs.amazonaws.com` and `logs.<region>.amazonaws.com`
- Added friendly error messages instead of raw regex in validation output
- Added test case for regional principal

## What was tested

- Reproduction template from issue passes (both global and regional forms)
- Invalid principals still caught with clear error messages
- All 16 unit tests pass

Fixes #4504