### PR TITLE
Include usage path in W3034 parameter range error

### DIFF
--- a/src/cfnlint/rules/functions/_BaseFn.py
+++ b/src/cfnlint/rules/functions/_BaseFn.py
@@ -115,7 +115,13 @@ class BaseFn(CfnLintJsonSchema):
         if len(err.path) > 1:
             err.path = deque([err.path[0]])
         err.message = err.message.replace(f"{value!r}", f"{instance!r}")
-        err.message = f"{err.message} when {self.fn.name!r} is resolved"
+        if err.path_override and len(err.path_override) > 0:
+            usage_path = "/".join(str(p) for p in validator.context.path.path)
+            err.message = (
+                f"{err.message} when {self.fn.name!r} is resolved at {usage_path!r}"
+            )
+        else:
+            err.message = f"{err.message} when {self.fn.name!r} is resolved"
         if validator.context.parameter_sets:
             k, v = is_function(instance)
             if k == "Ref":

--- a/test/fixtures/results/quickstart/nist_application.json
+++ b/test/fixtures/results/quickstart/nist_application.json
@@ -89,7 +89,7 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/nist_application.yaml",
-        "Id": "c95357ae-6a84-2a52-5a04-fa9d9d6c2e4f",
+        "Id": "2faa6843-7a28-acb0-6d94-2f4b5bedddbb",
         "Level": "Warning",
         "Location": {
             "End": {
@@ -106,7 +106,7 @@
                 "LineNumber": 198
             }
         },
-        "Message": "{'Ref': 'pSecurityAlarmTopic'} does not match '^(arn:(aws[A-Za-z\\\\-]*?|\\\\*):[^:]+:[^:]*(:(?:\\\\d{12}|\\\\*|aws)?:.+|)|\\\\*)$' when 'Ref' is resolved",
+        "Message": "{'Ref': 'pSecurityAlarmTopic'} does not match '^(arn:(aws[A-Za-z\\\\-]*?|\\\\*):[^:]+:[^:]*(:(?:\\\\d{12}|\\\\*|aws)?:.+|)|\\\\*)$' when 'Ref' is resolved at 'Resources/rPostProcInstanceRole/Properties/Policies/0/PolicyDocument/Statement/2/Resource/0'",
         "ParentId": null,
         "Rule": {
             "Description": "Resolve the Ref and then validate the values against the schema",

--- a/test/fixtures/results/quickstart/non_strict/nist_application.json
+++ b/test/fixtures/results/quickstart/non_strict/nist_application.json
@@ -89,7 +89,7 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/nist_application.yaml",
-        "Id": "c95357ae-6a84-2a52-5a04-fa9d9d6c2e4f",
+        "Id": "2faa6843-7a28-acb0-6d94-2f4b5bedddbb",
         "Level": "Warning",
         "Location": {
             "End": {
@@ -106,7 +106,7 @@
                 "LineNumber": 198
             }
         },
-        "Message": "{'Ref': 'pSecurityAlarmTopic'} does not match '^(arn:(aws[A-Za-z\\\\-]*?|\\\\*):[^:]+:[^:]*(:(?:\\\\d{12}|\\\\*|aws)?:.+|)|\\\\*)$' when 'Ref' is resolved",
+        "Message": "{'Ref': 'pSecurityAlarmTopic'} does not match '^(arn:(aws[A-Za-z\\\\-]*?|\\\\*):[^:]+:[^:]*(:(?:\\\\d{12}|\\\\*|aws)?:.+|)|\\\\*)$' when 'Ref' is resolved at 'Resources/rPostProcInstanceRole/Properties/Policies/0/PolicyDocument/Statement/2/Resource/0'",
         "ParentId": null,
         "Rule": {
             "Description": "Resolve the Ref and then validate the values against the schema",

--- a/test/unit/rules/functions/test_basefn.py
+++ b/test/unit/rules/functions/test_basefn.py
@@ -255,3 +255,52 @@ def template():
 def test_resolve(name, instance, parameters, rule, expected, validator):
     errs = list(rule.resolve(validator, rule._schema, instance, {}))
     assert errs == expected, f"{name!r} failed and got errors {errs!r}"
+
+
+def test_clean_resolve_errors_with_path_override():
+    """Test that usage path is included in message when path_override is set."""
+    from unittest.mock import MagicMock
+
+    rule = BaseFn("Ref", resolved_rule="XXXXX")
+    rule.child_rules["XXXXX"] = _ChildRule()
+
+    err = ValidationError(
+        message="0 is less than the minimum of 1",
+        path=deque(["Ref"]),
+        validator="minimum",
+    )
+    err.path_override = deque(["Parameters", "MyParam", "MinValue"])
+
+    validator = MagicMock()
+    validator.context.path.path = deque(
+        ["Resources", "MyResource", "Properties", "Count"]
+    )
+    validator.context.parameter_sets = None
+
+    result = rule._clean_resolve_errors(err, 0, {"Ref": "MyParam"}, validator)
+    assert "at 'Resources/MyResource/Properties/Count'" in result.message
+    assert "when 'Ref' is resolved" in result.message
+
+
+def test_clean_resolve_errors_without_path_override():
+    """Test that usage path is NOT included when path_override is not set."""
+    from unittest.mock import MagicMock
+
+    rule = BaseFn("Ref", resolved_rule="XXXXX")
+    rule.child_rules["XXXXX"] = _ChildRule()
+
+    err = ValidationError(
+        message="0 is less than the minimum of 1",
+        path=deque(["Ref"]),
+        validator="minimum",
+    )
+
+    validator = MagicMock()
+    validator.context.path.path = deque(
+        ["Resources", "MyResource", "Properties", "Count"]
+    )
+    validator.context.parameter_sets = None
+
+    result = rule._clean_resolve_errors(err, 0, {"Ref": "MyParam"}, validator)
+    assert "at '" not in result.message
+    assert "when 'Ref' is resolved" in result.message


### PR DESCRIPTION
## Summary

When resolved function errors redirect to the parameter definition (via `path_override`), include the usage path in the error message. This applies to all parameter constraint rules (W3034, W2030, W2031) since the fix is in `_clean_resolve_errors` in `BaseFn`.

**Before:**
```
W1030 {'Ref': 'ExampleDesiredCount'} is less than the minimum of 1 when 'Ref' is resolved
local/issue/4446.yaml:5:5
```

**After:**
```
W1030 {'Ref': 'ExampleDesiredCount'} is less than the minimum of 1 when 'Ref' is resolved at 'Resources/ExampleServiceMissingTasksOverTimeAlarm/Properties/DatapointsToAlarm'
local/issue/4446.yaml:5:5
```

The error still points to the parameter definition (where the fix needs to happen), but now tells you which property usage triggered the constraint.

## What was tested

- Reproduction template from issue
- All 2549 unit tests pass

Fixes #4446