### PR TITLE
Fix TypeError in PipelineArtifactCounts when Provider is a Ref

### DIFF
--- a/src/cfnlint/rules/resources/codepipeline/PipelineArtifactCounts.py
+++ b/src/cfnlint/rules/resources/codepipeline/PipelineArtifactCounts.py
@@ -147,18 +147,24 @@ class PipelineArtifactCounts(CfnLintKeyword):
             for owner, owner_validator in get_value_from_path(
                 action_validator, action, path=deque(["Owner"])
             ):
+                if not owner_validator.is_type(owner, "string"):
+                    continue
                 owner_artifact_counts = self._artifact_counts.get(owner)
                 if not owner_artifact_counts:
                     continue
                 for category, categor_validator in get_value_from_path(
                     owner_validator, action, path=deque(["Category"])
                 ):
+                    if not categor_validator.is_type(category, "string"):
+                        continue
                     category_artifact_counts = owner_artifact_counts.get(category)
                     if not category_artifact_counts:
                         continue
                     for provider, provider_provider in get_value_from_path(
                         categor_validator, action, deque(["Provider"])
                     ):
+                        if not provider_provider.is_type(provider, "string"):
+                            continue
                         count_schema: dict[str, Any] = {
                             "properties": category_artifact_counts.get(provider),
                             "required": [],

--- a/test/unit/rules/resources/codepipeline/test_pipeline_artifact_counts.py
+++ b/test/unit/rules/resources/codepipeline/test_pipeline_artifact_counts.py
@@ -77,6 +77,45 @@ def rule():
         ),
         (
             {
+                "Name": "Source",
+                "ActionTypeId": {
+                    "Category": "Source",
+                    "Owner": "AWS",
+                    "Provider": {"Ref": "SourceCodeProvider"},
+                    "Version": "1",
+                },
+                "OutputArtifacts": [{"Name": "SourceCode"}],
+            },
+            [],
+        ),
+        (
+            {
+                "Name": "Source",
+                "ActionTypeId": {
+                    "Category": "Source",
+                    "Owner": {"Ref": "Owner"},
+                    "Provider": "CodeCommit",
+                    "Version": "1",
+                },
+                "OutputArtifacts": [{"Name": "SourceCode"}],
+            },
+            [],
+        ),
+        (
+            {
+                "Name": "Source",
+                "ActionTypeId": {
+                    "Category": {"Ref": "Category"},
+                    "Owner": "AWS",
+                    "Provider": "CodeCommit",
+                    "Version": "1",
+                },
+                "OutputArtifacts": [{"Name": "SourceCode"}],
+            },
+            [],
+        ),
+        (
+            {
                 "Name": "Github",
                 "ActionTypeId": {
                     "Category": "Source",


### PR DESCRIPTION
## Summary
- Fixes `TypeError: unhashable type: 'dict_node'` crash in rule E3702 when `ActionTypeId.Provider`, `Owner`, or `Category` is an unresolved intrinsic function (e.g. `!Ref`)
- Adds `is_type` string checks before using these values as dictionary keys, skipping validation when the value can't be resolved to a literal string
- Adds unit tests covering `!Ref` in Provider, Owner, and Category fields

Fixes #4511

## Test plan
- [x] Unit tests pass for all codepipeline rules
- [x] Reproduction template from the issue no longer crashes
- [x] Existing valid/invalid cases still produce correct results

🤖 Generated with [Claude Code](https://claude.com/claude-code)