### PR TITLE
Allow uppercase S3 bucket names, warn instead of error

### DIFF
--- a/src/cfnlint/data/schemas/patches/extensions/all/aws_s3_bucket/manual.json
+++ b/src/cfnlint/data/schemas/patches/extensions/all/aws_s3_bucket/manual.json
@@ -42,10 +42,5 @@
   "op": "add",
   "path": "/properties/BucketName/maxLength",
   "value": 63
- },
- {
-  "op": "add",
-  "path": "/properties/BucketName/pattern",
-  "value": "^([a-z0-9][a-z0-9.-]*[a-z0-9])?$"
  }
 ]

--- a/src/cfnlint/data/schemas/resources/48d4aec56c00d69f.json
+++ b/src/cfnlint/data/schemas/resources/48d4aec56c00d69f.json
@@ -1555,7 +1555,6 @@
   "BucketName": {
    "format": "AWS::S3::Bucket.Name",
    "maxLength": 63,
-   "pattern": "^([a-z0-9][a-z0-9.-]*[a-z0-9])?$",
    "type": "string"
   },
   "BucketNamePrefix": {

--- a/src/cfnlint/rules/formats/S3BucketNameLowerCase.py
+++ b/src/cfnlint/rules/formats/S3BucketNameLowerCase.py
@@ -7,37 +7,30 @@ from __future__ import annotations
 
 from typing import Any
 
-import regex as re
-
 from cfnlint.jsonschema import Validator
 from cfnlint.rules.formats.FormatKeyword import FormatKeyword
 
 
-class S3BucketName(FormatKeyword):
-    id = "E1161"
-    shortdesc = "Validate S3 bucket name format"
-    description = "Validate S3 bucket name format for ref/getatt and string values"
-    tags = []
+class S3BucketNameLowerCase(FormatKeyword):
+    id = "W1161"
+    shortdesc = "S3 bucket names should use lowercase letters"
+    description = (
+        "S3 bucket names with uppercase letters were allowed before March 2018 "
+        "but are no longer recommended. New buckets must use lowercase only."
+    )
+    tags = ["resources", "s3"]
     source_url = "https://github.com/aws-cloudformation/cfn-lint/blob/main/docs/format_keyword.md#AWS::S3::Bucket.Name"
 
     def __init__(self):
         super().__init__(
             format="AWS::S3::Bucket.Name",
-            pattern=r"^(?![.\-])(?!.*\.\.)(?!.*\-\.)(?!.*\.\-)[a-zA-Z0-9.\-]{3,63}(?<![.\-])$",
         )
 
     def format(self, validator: Validator, instance: Any) -> bool:
         if not isinstance(instance, str):
             return True
 
-        if (
-            instance == ""
-            and validator.context.path.cfn_path_string
-            == "Resources/AWS::S3::Bucket/Properties/BucketName"
-        ):
-            return True
+        if instance != instance.lower():
+            return False
 
-        if re.match(self.pattern, instance):
-            return True
-
-        return False
+        return True

--- a/test/unit/rules/formats/test_s3_bucket_name.py
+++ b/test/unit/rules/formats/test_s3_bucket_name.py
@@ -33,9 +33,9 @@ def rule():
             True,
         ),
         (
-            "Invalid uppercase",
+            "Valid uppercase pre-2018",
             "My-Bucket",
-            False,
+            True,
         ),
         (
             "Invalid too short",

--- a/test/unit/rules/formats/test_s3_bucket_name_lower_case.py
+++ b/test/unit/rules/formats/test_s3_bucket_name_lower_case.py
@@ -1,0 +1,49 @@
+"""
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+"""
+
+import pytest
+
+from cfnlint.rules.formats.S3BucketNameLowerCase import S3BucketNameLowerCase
+
+
+@pytest.fixture(scope="module")
+def rule():
+    rule = S3BucketNameLowerCase()
+    yield rule
+
+
+@pytest.mark.parametrize(
+    "name,instance,expected",
+    [
+        (
+            "Valid lowercase bucket name",
+            "my-bucket-name",
+            True,
+        ),
+        (
+            "Valid lowercase with dots",
+            "my.bucket.name",
+            True,
+        ),
+        (
+            "Invalid uppercase letters",
+            "My-Bucket",
+            False,
+        ),
+        (
+            "Invalid all uppercase",
+            "MY-BUCKET",
+            False,
+        ),
+        (
+            "Not a string",
+            123,
+            True,
+        ),
+    ],
+)
+def test_validate(name, instance, expected, rule, validator):
+    result = rule.format(validator, instance)
+    assert result == expected, f"Test {name!r} got {result!r}"


### PR DESCRIPTION
## Summary
- S3 bucket names with uppercase letters were valid before March 2018 and still exist in customer accounts
- Changed E3031 pattern and E1161 format rule to allow uppercase (no longer errors)
- Added new W1161 warning rule that flags uppercase bucket names as not recommended for new buckets

## Test plan
- [x] Unit tests pass for E1161 (updated to expect uppercase as valid)
- [x] Unit tests pass for new W1161 rule
- [x] All 1678 unit rule tests pass
- [x] All integration tests pass