### PR TITLE
fix: Allow Fn::GetStackOutput in Output Values, Fn::Sub, and Fn::Base64

### DIFF
--- a/src/cfnlint/data/schemas/other/functions/base64.json
+++ b/src/cfnlint/data/schemas/other/functions/base64.json
@@ -7,6 +7,7 @@
    "Fn::FindInMap",
    "Fn::ForEach::[a-zA-Z0-9]+",
    "Fn::GetAtt",
+   "Fn::GetStackOutput",
    "Fn::If",
    "Fn::ImportValue",
    "Fn::Join",

--- a/src/cfnlint/data/schemas/other/functions/sub.json
+++ b/src/cfnlint/data/schemas/other/functions/sub.json
@@ -23,6 +23,7 @@
          "Fn::FindInMap",
          "Fn::GetAtt",
          "Fn::GetAZs",
+         "Fn::GetStackOutput",
          "Fn::If",
          "Fn::ImportValue",
          "Fn::Join",

--- a/src/cfnlint/rules/outputs/Value.py
+++ b/src/cfnlint/rules/outputs/Value.py
@@ -40,7 +40,7 @@ class Value(CfnLintJsonSchema):
 
         validator = validator.evolve(
             context=validator.context.evolve(
-                functions=[f for f in FUNCTIONS if f != "Fn::GetStackOutput"],
+                functions=list(FUNCTIONS),
                 conditions=validator.context.conditions.evolve(
                     conditions,
                 ),

--- a/test/fixtures/templates/good/functions/get_stack_output.yaml
+++ b/test/fixtures/templates/good/functions/get_stack_output.yaml
@@ -89,3 +89,30 @@ Resources:
               - - "my"
                 - "stack"
           OutputName: TopicName
+  # Inside Fn::Sub map
+  Topic9:
+    Type: AWS::SNS::Topic
+    Properties:
+      DisplayName:
+        Fn::Sub:
+          - "prefix-${Value}"
+          - Value:
+              Fn::GetStackOutput:
+                StackName: producer-stack
+                OutputName: TopicName
+  # Inside Fn::Base64
+  Topic10:
+    Type: AWS::SNS::Topic
+    Properties:
+      DisplayName:
+        Fn::Base64:
+          Fn::GetStackOutput:
+            StackName: producer-stack
+            OutputName: TopicName
+Outputs:
+  # Direct Output Value
+  DirectOutput:
+    Value:
+      Fn::GetStackOutput:
+        StackName: producer-stack
+        OutputName: TopicName


### PR DESCRIPTION
## Summary

- Allow `Fn::GetStackOutput` in Output Values (E6101 no longer blocks it)
- Allow `Fn::GetStackOutput` inside `Fn::Sub` map values
- Allow `Fn::GetStackOutput` inside `Fn::Base64`

CloudFormation now supports `Fn::GetStackOutput` in these positions (confirmed via `create-stack` deployments in us-east-1). The original PR #4495 excluded these based on testing at the time, but CFN has since added support.

Still correctly excluded from:
- Conditions (`Fn::Equals`) — CFN returns: `Cannot use Fn::GetStackOutput in Conditions`
- `Fn::ImportValue` — CFN returns: `the attribute in Fn::ImportValue must not depend on any resources, imported values, or Fn::GetAZs`
- Export Name (E6102) — CFN returns: `The Name field of Export must not depend on any resources, imported values, or Fn::GetAZs`

## Test plan

- [x] All 2568 unit tests pass
- [x] Good fixture template lints clean with new test cases for Fn::Sub, Fn::Base64, and Output Value
- [x] Bad fixture template still correctly flags E1033 errors
- [x] E6102 (Export) still rejects `Fn::GetStackOutput`
- [x] Conditions still reject `Fn::GetStackOutput`
- [x] Deployed test stacks to confirm CFN accepts the previously-failing positions