### PR TITLE
feat: Add rule E3065 for maxUniqueItems validation

### DIFF
--- a/src/cfnlint/rules/resources/properties/MaxUniqueItems.py
+++ b/src/cfnlint/rules/resources/properties/MaxUniqueItems.py
@@ -1,0 +1,19 @@
+"""
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+"""
+
+from cfnlint.rules import CloudFormationLintRule
+
+
+class MaxUniqueItems(CloudFormationLintRule):
+    """Check if a list has too many unique values"""
+
+    id = "E3065"
+    shortdesc = "Check if a list has more unique values than allowed"
+    description = (
+        "Some lists have a maximum number of unique items allowed. "
+        "Validate that the number of unique items does not exceed the limit."
+    )
+    source_url = "https://github.com/aws-cloudformation/cfn-lint/blob/main/docs/cfn-schema-specification.md#maxuniqueitems"
+    tags = ["resources", "property", "array", "length"]

--- a/src/cfnlint/rules/resources/properties/Properties.py
+++ b/src/cfnlint/rules/resources/properties/Properties.py
@@ -50,6 +50,7 @@ class Properties(CfnLintJsonSchema):
             "exclusiveMaximum": "E3034",
             "exclusiveMinimum": "E3034",
             "maxItems": "E3032",
+            "maxUniqueItems": "E3065",
             "minItems": "E3032",
             "pattern": "E3031",
             "prefixItems": "E3008",


### PR DESCRIPTION
## Summary

- Add rule **E3065** for the `maxUniqueItems` keyword validator
- Register it in the `Properties` rule_set so errors are properly attributed

The `maxUniqueItems` keyword was being validated but errors weren't associated with a rule ID, making it impossible to suppress or configure. Now users can use `--ignore-checks E3065` or add it to their `.cfnlintrc`.

Currently used by `AWS::CloudWatch::Alarm` for `AlarmActions`, `InsufficientDataActions`, and `OKActions` (max 5 unique items each).

## Test plan

- [x] All 2568 unit tests pass
- [x] Verified E3065 fires on a CloudWatch Alarm template with 6 unique alarm actions
- [x] Verified `--ignore-checks E3065` suppresses the error