### PR TITLE
fix: Support additional functions inside Fn::GetAZs

### DIFF
--- a/src/cfnlint/data/schemas/other/functions/getazs.json
+++ b/src/cfnlint/data/schemas/other/functions/getazs.json
@@ -1,0 +1,15 @@
+{
+ "cfnContext": {
+  "functions": [
+   "Fn::GetAtt",
+   "Fn::If",
+   "Fn::Join",
+   "Fn::Select",
+   "Fn::Sub",
+   "Ref"
+  ],
+  "schema": {
+   "type": "string"
+  }
+ }
+}

--- a/src/cfnlint/rules/functions/GetAz.py
+++ b/src/cfnlint/rules/functions/GetAz.py
@@ -26,7 +26,12 @@ class GetAz(BaseFn):
         self.fn_getazs = self.validate
 
     def schema(self, validator: Validator, instance: Any) -> dict[str, Any]:
-        return {
-            "type": ["string"],
-            "enum": [""] + REGIONS,
+        schema = self._schema.copy()
+        schema["cfnContext"] = {
+            **schema["cfnContext"],
+            "schema": {
+                "type": ["string"],
+                "enum": [""] + REGIONS,
+            },
         }
+        return schema

--- a/src/cfnlint/rules/functions/_BaseFn.py
+++ b/src/cfnlint/rules/functions/_BaseFn.py
@@ -81,7 +81,7 @@ class BaseFn(CfnLintJsonSchema):
         self.functions = functions or tuple([])
         self.resolved_rule = resolved_rule
         self.child_rules[self.resolved_rule] = None
-        if name and name != "Fn::GetAZs":
+        if name:
             self._schema = OTHER_SCHEMA_MANAGER.get_schema(
                 f"other.functions.{name.replace('Fn::', '').lower()}"
             )

--- a/test/unit/rules/functions/test_getaz.py
+++ b/test/unit/rules/functions/test_getaz.py
@@ -54,13 +54,13 @@ def rule():
                 ValidationError(
                     "['foo'] is not of type 'string'",
                     path=deque(["Fn::GetAZs"]),
-                    schema_path=deque(["type"]),
+                    schema_path=deque(["cfnContext", "schema", "type"]),
                     validator="fn_getazs",
                 ),
                 ValidationError(
                     f"['foo'] is not one of {[''] + REGIONS!r}",
                     path=deque(["Fn::GetAZs"]),
-                    schema_path=deque(["enum"]),
+                    schema_path=deque(["cfnContext", "schema", "enum"]),
                     validator="fn_getazs",
                 ),
             ],


### PR DESCRIPTION
## Summary

- Add `getazs.json` schema file for `Fn::GetAZs` (like other intrinsic functions have)
- Remove the `Fn::GetAZs` special-casing in `_BaseFn.py` that skipped schema file loading
- Allow `Ref`, `Fn::Join`, `Fn::Sub`, `Fn::If`, `Fn::Select`, and `Fn::GetAtt` inside `Fn::GetAZs`

Previously only `Ref` was effectively allowed because `GetAZs` was special-cased to not load an external schema file, so there was no `cfnContext.functions` list to control inner function support.

## Test plan

- [x] All 2568 unit tests pass
- [x] All 27 integration tests pass
- [x] Valid template with `Fn::Sub`, `Fn::If`, `Fn::Join`, `Fn::Select`, and `Ref` inside `Fn::GetAZs` lints clean
- [x] Invalid functions (`Fn::Base64`, `Fn::Split`) inside `Fn::GetAZs` are correctly rejected
- [x] Region enum validation still works (invalid regions are flagged)