### PR TITLE
fix: Allow ProvisionedThroughput with 0 values when BillingMode is PAY_PER_REQUEST

### DIFF
--- a/scripts/smithy/_automated_patches.py
+++ b/scripts/smithy/_automated_patches.py
@@ -47,6 +47,10 @@ skip_resource_property_paths = {
     ],
     "AWS::Connect::RoutingProfile": ["/properties/QueueConfigs"],
     "AWS::Connect::User": ["/definitions/DeskPhoneNumber"],
+    "AWS::DynamoDB::Table": [
+        "/definitions/ProvisionedThroughput/properties/ReadCapacityUnits",
+        "/definitions/ProvisionedThroughput/properties/WriteCapacityUnits",
+    ],
     "AWS::ElasticLoadBalancingV2::LoadBalancer": ["/properties/Tags"],
     "AWS::ElasticLoadBalancingV2::TargetGroup": ["/properties/Tags"],
     "AWS::MSK::Cluster": ["/properties/NumberOfBrokerNodes"],

--- a/scripts/smithy/_automated_patches.py
+++ b/scripts/smithy/_automated_patches.py
@@ -48,6 +48,7 @@ skip_resource_property_paths = {
     "AWS::Connect::RoutingProfile": ["/properties/QueueConfigs"],
     "AWS::Connect::User": ["/definitions/DeskPhoneNumber"],
     "AWS::DynamoDB::Table": [
+        "/definitions/Projection/properties/NonKeyAttributes",
         "/definitions/ProvisionedThroughput/properties/ReadCapacityUnits",
         "/definitions/ProvisionedThroughput/properties/WriteCapacityUnits",
     ],

--- a/src/cfnlint/data/schemas/extensions/aws_dynamodb_table/billingmode_exclusive.json
+++ b/src/cfnlint/data/schemas/extensions/aws_dynamodb_table/billingmode_exclusive.json
@@ -1,5 +1,5 @@
 {
- "description": "When 'BillingMode' is 'PAY_PER_REQUEST' don't specify 'ProvisionedThroughput'",
+ "description": "When 'BillingMode' is 'PAY_PER_REQUEST' 'ProvisionedThroughput' values must be 0",
  "if": {
   "properties": {
    "BillingMode": {
@@ -13,7 +13,16 @@
  },
  "then": {
   "properties": {
-   "ProvisionedThroughput": false
+   "ProvisionedThroughput": {
+    "properties": {
+     "ReadCapacityUnits": {
+      "const": 0
+     },
+     "WriteCapacityUnits": {
+      "const": 0
+     }
+    }
+   }
   }
  }
 }

--- a/src/cfnlint/data/schemas/extensions/aws_dynamodb_table/billingmode_provisioned_dependent.json
+++ b/src/cfnlint/data/schemas/extensions/aws_dynamodb_table/billingmode_provisioned_dependent.json
@@ -10,6 +10,18 @@
   ]
  },
  "then": {
+  "properties": {
+   "ProvisionedThroughput": {
+    "properties": {
+     "ReadCapacityUnits": {
+      "minimum": 1
+     },
+     "WriteCapacityUnits": {
+      "minimum": 1
+     }
+    }
+   }
+  },
   "required": [
    "ProvisionedThroughput"
   ]

--- a/src/cfnlint/data/schemas/patches/extensions/all/aws_dynamodb_table/smithy.json
+++ b/src/cfnlint/data/schemas/patches/extensions/all/aws_dynamodb_table/smithy.json
@@ -122,16 +122,6 @@
  },
  {
   "op": "add",
-  "path": "/definitions/ProvisionedThroughput/properties/ReadCapacityUnits/minimum",
-  "value": 1
- },
- {
-  "op": "add",
-  "path": "/definitions/ProvisionedThroughput/properties/WriteCapacityUnits/minimum",
-  "value": 1
- },
- {
-  "op": "add",
   "path": "/properties/BillingMode/enum",
   "value": [
    "PAY_PER_REQUEST",

--- a/src/cfnlint/data/schemas/patches/extensions/all/aws_dynamodb_table/smithy.json
+++ b/src/cfnlint/data/schemas/patches/extensions/all/aws_dynamodb_table/smithy.json
@@ -92,11 +92,6 @@
  },
  {
   "op": "add",
-  "path": "/definitions/Projection/properties/NonKeyAttributes/minItems",
-  "value": 1
- },
- {
-  "op": "add",
   "path": "/definitions/Projection/properties/NonKeyAttributes/maxItems",
   "value": 20
  },

--- a/src/cfnlint/rules/resources/dynamodb/TableBillingModeExclusive.py
+++ b/src/cfnlint/rules/resources/dynamodb/TableBillingModeExclusive.py
@@ -16,7 +16,8 @@ class TableBillingModeExclusive(CfnLintJsonSchema):
     id = "E3638"
     shortdesc = "Validate DynamoDB BillingMode pay per request configuration"
     description = (
-        "When 'BillingMode' is 'PAY_PER_REQUEST' don't specify 'ProvisionedThroughput'"
+        "When 'BillingMode' is 'PAY_PER_REQUEST' "
+        "'ProvisionedThroughput' values must be 0"
     )
     tags = ["resources"]
 
@@ -30,4 +31,4 @@ class TableBillingModeExclusive(CfnLintJsonSchema):
         )
 
     def message(self, instance: Any, err: ValidationError) -> str:
-        return "Additional properties are not allowed ('ProvisionedThroughput')"
+        return err.message

--- a/src/cfnlint/rules/resources/dynamodb/TableBillingModeProvisioned.py
+++ b/src/cfnlint/rules/resources/dynamodb/TableBillingModeProvisioned.py
@@ -30,4 +30,4 @@ class TableBillingModeProvisioned(CfnLintJsonSchema):
         )
 
     def message(self, instance: Any, err: ValidationError) -> str:
-        return "'ProvisionedThroughput' is a required property"
+        return err.message

--- a/src/cfnlint/rules/resources/ecs/TaskDefinitionEssentialContainer.py
+++ b/src/cfnlint/rules/resources/ecs/TaskDefinitionEssentialContainer.py
@@ -29,7 +29,7 @@ class TaskDefinitionEssentialContainer(CfnLintJsonSchema):
     def __init__(self) -> None:
         super().__init__(
             keywords=[
-                "Resources/AWS::ECS::TaskDefinition/Properties/ContainerDefinitions/*"
+                "Resources/AWS::ECS::TaskDefinition/Properties/ContainerDefinitions"
             ],
             schema_details=SchemaDetails(
                 module=cfnlint.data.schemas.extensions.aws_ecs_taskdefinition,

--- a/test/fixtures/results/integration/cfn-gather.json
+++ b/test/fixtures/results/integration/cfn-gather.json
@@ -30,6 +30,64 @@
     },
     {
         "Filename": "test/fixtures/templates/integration/cfn-gather.yaml",
+        "Id": "acc87818-2ac9-fe6f-e0d3-e3569b26a50e",
+        "Level": "Error",
+        "Location": {
+            "End": {
+                "ColumnNumber": 27,
+                "LineNumber": 10
+            },
+            "Path": [
+                "Resources",
+                "TaskDef",
+                "Properties",
+                "ContainerDefinitions"
+            ],
+            "Start": {
+                "ColumnNumber": 7,
+                "LineNumber": 10
+            }
+        },
+        "Message": "At least one essential container is required",
+        "ParentId": null,
+        "Rule": {
+            "Description": "Check that every TaskDefinition specifies at least one essential container",
+            "Id": "E3042",
+            "ShortDescription": "Validate at least one essential container is specified",
+            "Source": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-containerdefinitions.html#cfn-ecs-taskdefinition-containerdefinition-essential"
+        }
+    },
+    {
+        "Filename": "test/fixtures/templates/integration/cfn-gather.yaml",
+        "Id": "a77ded42-cbf9-f285-c9dd-2fd6e16939fa",
+        "Level": "Error",
+        "Location": {
+            "End": {
+                "ColumnNumber": 27,
+                "LineNumber": 28
+            },
+            "Path": [
+                "Resources",
+                "AwsvpcTaskDef",
+                "Properties",
+                "ContainerDefinitions"
+            ],
+            "Start": {
+                "ColumnNumber": 7,
+                "LineNumber": 28
+            }
+        },
+        "Message": "At least one essential container is required",
+        "ParentId": null,
+        "Rule": {
+            "Description": "Check that every TaskDefinition specifies at least one essential container",
+            "Id": "E3042",
+            "ShortDescription": "Validate at least one essential container is specified",
+            "Source": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-containerdefinitions.html#cfn-ecs-taskdefinition-containerdefinition-essential"
+        }
+    },
+    {
+        "Filename": "test/fixtures/templates/integration/cfn-gather.yaml",
         "Id": "6a91d17b-fc37-91bb-e56c-14d1a635901c",
         "Level": "Error",
         "Location": {

--- a/test/fixtures/results/integration/getatt-types.json
+++ b/test/fixtures/results/integration/getatt-types.json
@@ -31,6 +31,35 @@
     },
     {
         "Filename": "test/fixtures/templates/integration/getatt-types.yaml",
+        "Id": "13ff56be-c12a-6f3e-5920-5b39a4261c50",
+        "Level": "Error",
+        "Location": {
+            "End": {
+                "ColumnNumber": 27,
+                "LineNumber": 57
+            },
+            "Path": [
+                "Resources",
+                "TestTaskDefinitionWithGetAtt",
+                "Properties",
+                "ContainerDefinitions"
+            ],
+            "Start": {
+                "ColumnNumber": 7,
+                "LineNumber": 57
+            }
+        },
+        "Message": "At least one essential container is required",
+        "ParentId": null,
+        "Rule": {
+            "Description": "Check that every TaskDefinition specifies at least one essential container",
+            "Id": "E3042",
+            "ShortDescription": "Validate at least one essential container is specified",
+            "Source": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-containerdefinitions.html#cfn-ecs-taskdefinition-containerdefinition-essential"
+        }
+    },
+    {
+        "Filename": "test/fixtures/templates/integration/getatt-types.yaml",
         "Id": "16620b40-6f3e-69eb-874f-34b5f51cedee",
         "Level": "Error",
         "Location": {

--- a/test/fixtures/results/integration/ref-types.json
+++ b/test/fixtures/results/integration/ref-types.json
@@ -30,6 +30,64 @@
     },
     {
         "Filename": "test/fixtures/templates/integration/ref-types.yaml",
+        "Id": "92bca04d-77b2-5585-7f87-4eafcf1a04e8",
+        "Level": "Error",
+        "Location": {
+            "End": {
+                "ColumnNumber": 27,
+                "LineNumber": 72
+            },
+            "Path": [
+                "Resources",
+                "TaskDefinitionWithRefToResource",
+                "Properties",
+                "ContainerDefinitions"
+            ],
+            "Start": {
+                "ColumnNumber": 7,
+                "LineNumber": 72
+            }
+        },
+        "Message": "At least one essential container is required",
+        "ParentId": null,
+        "Rule": {
+            "Description": "Check that every TaskDefinition specifies at least one essential container",
+            "Id": "E3042",
+            "ShortDescription": "Validate at least one essential container is specified",
+            "Source": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-containerdefinitions.html#cfn-ecs-taskdefinition-containerdefinition-essential"
+        }
+    },
+    {
+        "Filename": "test/fixtures/templates/integration/ref-types.yaml",
+        "Id": "e8ace095-2267-fcb9-0f63-98c085e5c3a3",
+        "Level": "Error",
+        "Location": {
+            "End": {
+                "ColumnNumber": 27,
+                "LineNumber": 93
+            },
+            "Path": [
+                "Resources",
+                "TaskDefinitionWithRefToParameter",
+                "Properties",
+                "ContainerDefinitions"
+            ],
+            "Start": {
+                "ColumnNumber": 7,
+                "LineNumber": 93
+            }
+        },
+        "Message": "At least one essential container is required",
+        "ParentId": null,
+        "Rule": {
+            "Description": "Check that every TaskDefinition specifies at least one essential container",
+            "Id": "E3042",
+            "ShortDescription": "Validate at least one essential container is specified",
+            "Source": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-containerdefinitions.html#cfn-ecs-taskdefinition-containerdefinition-essential"
+        }
+    },
+    {
+        "Filename": "test/fixtures/templates/integration/ref-types.yaml",
         "Id": "29af1a18-2b97-bb15-35f6-b5be8c36a2a7",
         "Level": "Warning",
         "Location": {

--- a/test/unit/rules/resources/dynamodb/test_table_billingmode_exclusive.py
+++ b/test/unit/rules/resources/dynamodb/test_table_billingmode_exclusive.py
@@ -45,16 +45,38 @@ def rule():
         (
             {
                 "BillingMode": "PAY_PER_REQUEST",
-                "ProvisionedThroughput": "FOO",
+                "ProvisionedThroughput": {
+                    "WriteCapacityUnits": 0,
+                    "ReadCapacityUnits": 0,
+                },
+            },
+            [],
+        ),
+        (
+            {
+                "BillingMode": "PAY_PER_REQUEST",
+                "ProvisionedThroughput": {
+                    "WriteCapacityUnits": 5,
+                    "ReadCapacityUnits": 5,
+                },
             },
             [
                 ValidationError(
-                    "Additional properties are not allowed ('ProvisionedThroughput')",
+                    "0 was expected",
                     rule=TableBillingModeExclusive(),
-                    path=deque(["ProvisionedThroughput"]),
-                    validator=None,
-                    schema_path=deque(["then", "properties", "ProvisionedThroughput"]),
-                )
+                    path=deque(["ProvisionedThroughput", "ReadCapacityUnits"]),
+                    validator="const",
+                    schema_path=deque(
+                        [
+                            "then",
+                            "properties",
+                            "ProvisionedThroughput",
+                            "properties",
+                            "ReadCapacityUnits",
+                            "const",
+                        ]
+                    ),
+                ),
             ],
         ),
     ],


### PR DESCRIPTION
## Summary
- CloudFormation accepts `ProvisionedThroughput` with `ReadCapacityUnits: 0` and `WriteCapacityUnits: 0` as dead config when `BillingMode` is `PAY_PER_REQUEST`. Non-zero values are still rejected.
- Previously cfn-lint blocked `ProvisionedThroughput` entirely with `PAY_PER_REQUEST`. Now it allows 0 values (matching CloudFormation behavior) while still erroring on non-zero values.
- Moved the `minimum: 1` constraint from the unconditional smithy patch into the `PROVISIONED`-mode extension so it only applies when `BillingMode` is `PROVISIONED`.
- Added exclusion in smithy auto-patch script to prevent regeneration of the unconditional minimum.

## Test plan
- [x] Validated with CloudFormation deployment that `PAY_PER_REQUEST` + PT(0,0) succeeds
- [x] Validated with CloudFormation deployment that `PAY_PER_REQUEST` + PT(1,1) fails
- [x] Validated with CloudFormation deployment that `PAY_PER_REQUEST` + PT(5,5) fails
- [x] Unit tests pass for E3638 and E3639
- [x] Integration tests pass