### PR TITLE
feat: Add rule W4002 for parameters missing from Metadata Interface

### DIFF
--- a/src/cfnlint/rules/metadata/InterfaceParameterInGroup.py
+++ b/src/cfnlint/rules/metadata/InterfaceParameterInGroup.py
@@ -1,0 +1,49 @@
+"""
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from cfnlint.jsonschema import ValidationError, ValidationResult, Validator
+from cfnlint.rules.jsonschema.CfnLintKeyword import CfnLintKeyword
+
+
+class InterfaceParameterInGroup(CfnLintKeyword):
+    """Check that all Parameters are listed in Metadata Interface ParameterGroups"""
+
+    id = "W4002"
+    shortdesc = "Parameter not listed in Metadata Interface ParameterGroups"
+    description = (
+        "All parameters should be listed in at least one "
+        "Metadata AWS::CloudFormation::Interface ParameterGroup so they appear "
+        "in the CloudFormation Console UI"
+    )
+    source_url = "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudformation-interface.html"
+    tags = ["metadata"]
+
+    def __init__(self) -> None:
+        super().__init__(keywords=["Metadata/AWS::CloudFormation::Interface"])
+
+    def validate(
+        self, validator: Validator, _, instance: Any, schema: Any
+    ) -> ValidationResult:
+        if not isinstance(instance, dict):
+            return
+
+        grouped: set[str] = set()
+        for group in instance.get("ParameterGroups", []):
+            if isinstance(group, dict):
+                for param in group.get("Parameters", []):
+                    if isinstance(param, str):
+                        grouped.add(param)
+
+        for param_name in validator.context.parameters:
+            if param_name not in grouped:
+                yield ValidationError(
+                    f"Parameter {param_name!r} is not listed in any "
+                    "Metadata AWS::CloudFormation::Interface ParameterGroup",
+                    rule=self,
+                )

--- a/test/fixtures/results/integration/metadata.json
+++ b/test/fixtures/results/integration/metadata.json
@@ -1,6 +1,33 @@
 [
     {
         "Filename": "test/fixtures/templates/integration/metdata.yaml",
+        "Id": "f45411ef-834f-db25-34e0-58115591a443",
+        "Level": "Warning",
+        "Location": {
+            "End": {
+                "ColumnNumber": 33,
+                "LineNumber": 4
+            },
+            "Path": [
+                "Metadata",
+                "AWS::CloudFormation::Interface"
+            ],
+            "Start": {
+                "ColumnNumber": 3,
+                "LineNumber": 4
+            }
+        },
+        "Message": "Parameter 'VpcId' is not listed in any Metadata AWS::CloudFormation::Interface ParameterGroup",
+        "ParentId": null,
+        "Rule": {
+            "Description": "All parameters should be listed in at least one Metadata AWS::CloudFormation::Interface ParameterGroup so they appear in the CloudFormation Console UI",
+            "Id": "W4002",
+            "ShortDescription": "Parameter not listed in Metadata Interface ParameterGroups",
+            "Source": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudformation-interface.html"
+        }
+    },
+    {
+        "Filename": "test/fixtures/templates/integration/metdata.yaml",
         "Id": "e020b5ec-4ab1-0eb4-b917-7729e96af1d2",
         "Level": "Warning",
         "Location": {

--- a/test/fixtures/results/quickstart/nist_application.json
+++ b/test/fixtures/results/quickstart/nist_application.json
@@ -1,6 +1,168 @@
 [
     {
         "Filename": "test/fixtures/templates/quickstart/nist_application.yaml",
+        "Id": "69398ef4-b979-fc98-ada2-4b0576e6a6e5",
+        "Level": "Warning",
+        "Location": {
+            "End": {
+                "ColumnNumber": 33,
+                "LineNumber": 38
+            },
+            "Path": [
+                "Metadata",
+                "AWS::CloudFormation::Interface"
+            ],
+            "Start": {
+                "ColumnNumber": 3,
+                "LineNumber": 38
+            }
+        },
+        "Message": "Parameter 'pEC2KeyPair' is not listed in any Metadata AWS::CloudFormation::Interface ParameterGroup",
+        "ParentId": null,
+        "Rule": {
+            "Description": "All parameters should be listed in at least one Metadata AWS::CloudFormation::Interface ParameterGroup so they appear in the CloudFormation Console UI",
+            "Id": "W4002",
+            "ShortDescription": "Parameter not listed in Metadata Interface ParameterGroups",
+            "Source": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudformation-interface.html"
+        }
+    },
+    {
+        "Filename": "test/fixtures/templates/quickstart/nist_application.yaml",
+        "Id": "6436fec7-d300-6347-83cb-6161089ccab2",
+        "Level": "Warning",
+        "Location": {
+            "End": {
+                "ColumnNumber": 33,
+                "LineNumber": 38
+            },
+            "Path": [
+                "Metadata",
+                "AWS::CloudFormation::Interface"
+            ],
+            "Start": {
+                "ColumnNumber": 3,
+                "LineNumber": 38
+            }
+        },
+        "Message": "Parameter 'pEnvironment' is not listed in any Metadata AWS::CloudFormation::Interface ParameterGroup",
+        "ParentId": null,
+        "Rule": {
+            "Description": "All parameters should be listed in at least one Metadata AWS::CloudFormation::Interface ParameterGroup so they appear in the CloudFormation Console UI",
+            "Id": "W4002",
+            "ShortDescription": "Parameter not listed in Metadata Interface ParameterGroups",
+            "Source": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudformation-interface.html"
+        }
+    },
+    {
+        "Filename": "test/fixtures/templates/quickstart/nist_application.yaml",
+        "Id": "73884139-4116-e6d0-81d8-457fecf314d6",
+        "Level": "Warning",
+        "Location": {
+            "End": {
+                "ColumnNumber": 33,
+                "LineNumber": 38
+            },
+            "Path": [
+                "Metadata",
+                "AWS::CloudFormation::Interface"
+            ],
+            "Start": {
+                "ColumnNumber": 3,
+                "LineNumber": 38
+            }
+        },
+        "Message": "Parameter 'pManagementCIDR' is not listed in any Metadata AWS::CloudFormation::Interface ParameterGroup",
+        "ParentId": null,
+        "Rule": {
+            "Description": "All parameters should be listed in at least one Metadata AWS::CloudFormation::Interface ParameterGroup so they appear in the CloudFormation Console UI",
+            "Id": "W4002",
+            "ShortDescription": "Parameter not listed in Metadata Interface ParameterGroups",
+            "Source": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudformation-interface.html"
+        }
+    },
+    {
+        "Filename": "test/fixtures/templates/quickstart/nist_application.yaml",
+        "Id": "49f69682-c405-d549-c002-a18a780d0cfd",
+        "Level": "Warning",
+        "Location": {
+            "End": {
+                "ColumnNumber": 33,
+                "LineNumber": 38
+            },
+            "Path": [
+                "Metadata",
+                "AWS::CloudFormation::Interface"
+            ],
+            "Start": {
+                "ColumnNumber": 3,
+                "LineNumber": 38
+            }
+        },
+        "Message": "Parameter 'pSecurityAlarmTopic' is not listed in any Metadata AWS::CloudFormation::Interface ParameterGroup",
+        "ParentId": null,
+        "Rule": {
+            "Description": "All parameters should be listed in at least one Metadata AWS::CloudFormation::Interface ParameterGroup so they appear in the CloudFormation Console UI",
+            "Id": "W4002",
+            "ShortDescription": "Parameter not listed in Metadata Interface ParameterGroups",
+            "Source": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudformation-interface.html"
+        }
+    },
+    {
+        "Filename": "test/fixtures/templates/quickstart/nist_application.yaml",
+        "Id": "6836fc89-240d-2b0e-3310-cc99ea717821",
+        "Level": "Warning",
+        "Location": {
+            "End": {
+                "ColumnNumber": 33,
+                "LineNumber": 38
+            },
+            "Path": [
+                "Metadata",
+                "AWS::CloudFormation::Interface"
+            ],
+            "Start": {
+                "ColumnNumber": 3,
+                "LineNumber": 38
+            }
+        },
+        "Message": "Parameter 'pSupportsGlacier' is not listed in any Metadata AWS::CloudFormation::Interface ParameterGroup",
+        "ParentId": null,
+        "Rule": {
+            "Description": "All parameters should be listed in at least one Metadata AWS::CloudFormation::Interface ParameterGroup so they appear in the CloudFormation Console UI",
+            "Id": "W4002",
+            "ShortDescription": "Parameter not listed in Metadata Interface ParameterGroups",
+            "Source": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudformation-interface.html"
+        }
+    },
+    {
+        "Filename": "test/fixtures/templates/quickstart/nist_application.yaml",
+        "Id": "2b5c0b7d-c358-0f34-f714-9864d53ab86d",
+        "Level": "Warning",
+        "Location": {
+            "End": {
+                "ColumnNumber": 33,
+                "LineNumber": 38
+            },
+            "Path": [
+                "Metadata",
+                "AWS::CloudFormation::Interface"
+            ],
+            "Start": {
+                "ColumnNumber": 3,
+                "LineNumber": 38
+            }
+        },
+        "Message": "Parameter 'pTemplateUrlPrefix' is not listed in any Metadata AWS::CloudFormation::Interface ParameterGroup",
+        "ParentId": null,
+        "Rule": {
+            "Description": "All parameters should be listed in at least one Metadata AWS::CloudFormation::Interface ParameterGroup so they appear in the CloudFormation Console UI",
+            "Id": "W4002",
+            "ShortDescription": "Parameter not listed in Metadata Interface ParameterGroups",
+            "Source": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudformation-interface.html"
+        }
+    },
+    {
+        "Filename": "test/fixtures/templates/quickstart/nist_application.yaml",
         "Id": "03ea7054-c827-0317-8bce-8e64baed02a0",
         "Level": "Informational",
         "Location": {

--- a/test/fixtures/results/quickstart/nist_vpc_management.json
+++ b/test/fixtures/results/quickstart/nist_vpc_management.json
@@ -55,6 +55,411 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/nist_vpc_management.yaml",
+        "Id": "cd8a66bc-257f-e75c-92ad-a83372f839cb",
+        "Level": "Warning",
+        "Location": {
+            "End": {
+                "ColumnNumber": 33,
+                "LineNumber": 107
+            },
+            "Path": [
+                "Metadata",
+                "AWS::CloudFormation::Interface"
+            ],
+            "Start": {
+                "ColumnNumber": 3,
+                "LineNumber": 107
+            }
+        },
+        "Message": "Parameter 'pBastionAmi' is not listed in any Metadata AWS::CloudFormation::Interface ParameterGroup",
+        "ParentId": null,
+        "Rule": {
+            "Description": "All parameters should be listed in at least one Metadata AWS::CloudFormation::Interface ParameterGroup so they appear in the CloudFormation Console UI",
+            "Id": "W4002",
+            "ShortDescription": "Parameter not listed in Metadata Interface ParameterGroups",
+            "Source": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudformation-interface.html"
+        }
+    },
+    {
+        "Filename": "test/fixtures/templates/quickstart/nist_vpc_management.yaml",
+        "Id": "8b1930b3-e3de-a519-a190-04997612ed78",
+        "Level": "Warning",
+        "Location": {
+            "End": {
+                "ColumnNumber": 33,
+                "LineNumber": 107
+            },
+            "Path": [
+                "Metadata",
+                "AWS::CloudFormation::Interface"
+            ],
+            "Start": {
+                "ColumnNumber": 3,
+                "LineNumber": 107
+            }
+        },
+        "Message": "Parameter 'pBastionInstanceType' is not listed in any Metadata AWS::CloudFormation::Interface ParameterGroup",
+        "ParentId": null,
+        "Rule": {
+            "Description": "All parameters should be listed in at least one Metadata AWS::CloudFormation::Interface ParameterGroup so they appear in the CloudFormation Console UI",
+            "Id": "W4002",
+            "ShortDescription": "Parameter not listed in Metadata Interface ParameterGroups",
+            "Source": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudformation-interface.html"
+        }
+    },
+    {
+        "Filename": "test/fixtures/templates/quickstart/nist_vpc_management.yaml",
+        "Id": "da991734-2f6c-0a4a-9a99-6952b964327a",
+        "Level": "Warning",
+        "Location": {
+            "End": {
+                "ColumnNumber": 33,
+                "LineNumber": 107
+            },
+            "Path": [
+                "Metadata",
+                "AWS::CloudFormation::Interface"
+            ],
+            "Start": {
+                "ColumnNumber": 3,
+                "LineNumber": 107
+            }
+        },
+        "Message": "Parameter 'pBastionSSHCIDR' is not listed in any Metadata AWS::CloudFormation::Interface ParameterGroup",
+        "ParentId": null,
+        "Rule": {
+            "Description": "All parameters should be listed in at least one Metadata AWS::CloudFormation::Interface ParameterGroup so they appear in the CloudFormation Console UI",
+            "Id": "W4002",
+            "ShortDescription": "Parameter not listed in Metadata Interface ParameterGroups",
+            "Source": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudformation-interface.html"
+        }
+    },
+    {
+        "Filename": "test/fixtures/templates/quickstart/nist_vpc_management.yaml",
+        "Id": "59a0c010-cb22-c7d4-dc55-26f2162f902c",
+        "Level": "Warning",
+        "Location": {
+            "End": {
+                "ColumnNumber": 33,
+                "LineNumber": 107
+            },
+            "Path": [
+                "Metadata",
+                "AWS::CloudFormation::Interface"
+            ],
+            "Start": {
+                "ColumnNumber": 3,
+                "LineNumber": 107
+            }
+        },
+        "Message": "Parameter 'pEC2KeyPair' is not listed in any Metadata AWS::CloudFormation::Interface ParameterGroup",
+        "ParentId": null,
+        "Rule": {
+            "Description": "All parameters should be listed in at least one Metadata AWS::CloudFormation::Interface ParameterGroup so they appear in the CloudFormation Console UI",
+            "Id": "W4002",
+            "ShortDescription": "Parameter not listed in Metadata Interface ParameterGroups",
+            "Source": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudformation-interface.html"
+        }
+    },
+    {
+        "Filename": "test/fixtures/templates/quickstart/nist_vpc_management.yaml",
+        "Id": "20c45041-237a-07e8-c05c-c2e4b7bd7992",
+        "Level": "Warning",
+        "Location": {
+            "End": {
+                "ColumnNumber": 33,
+                "LineNumber": 107
+            },
+            "Path": [
+                "Metadata",
+                "AWS::CloudFormation::Interface"
+            ],
+            "Start": {
+                "ColumnNumber": 3,
+                "LineNumber": 107
+            }
+        },
+        "Message": "Parameter 'pEC2KeyPairBastion' is not listed in any Metadata AWS::CloudFormation::Interface ParameterGroup",
+        "ParentId": null,
+        "Rule": {
+            "Description": "All parameters should be listed in at least one Metadata AWS::CloudFormation::Interface ParameterGroup so they appear in the CloudFormation Console UI",
+            "Id": "W4002",
+            "ShortDescription": "Parameter not listed in Metadata Interface ParameterGroups",
+            "Source": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudformation-interface.html"
+        }
+    },
+    {
+        "Filename": "test/fixtures/templates/quickstart/nist_vpc_management.yaml",
+        "Id": "7050f17b-0fb1-3019-fe3c-f3b4397ac03e",
+        "Level": "Warning",
+        "Location": {
+            "End": {
+                "ColumnNumber": 33,
+                "LineNumber": 107
+            },
+            "Path": [
+                "Metadata",
+                "AWS::CloudFormation::Interface"
+            ],
+            "Start": {
+                "ColumnNumber": 3,
+                "LineNumber": 107
+            }
+        },
+        "Message": "Parameter 'pManagementPrivateSubnetACIDR' is not listed in any Metadata AWS::CloudFormation::Interface ParameterGroup",
+        "ParentId": null,
+        "Rule": {
+            "Description": "All parameters should be listed in at least one Metadata AWS::CloudFormation::Interface ParameterGroup so they appear in the CloudFormation Console UI",
+            "Id": "W4002",
+            "ShortDescription": "Parameter not listed in Metadata Interface ParameterGroups",
+            "Source": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudformation-interface.html"
+        }
+    },
+    {
+        "Filename": "test/fixtures/templates/quickstart/nist_vpc_management.yaml",
+        "Id": "8bb99c34-8e4c-6f7a-bb54-4a88676d1948",
+        "Level": "Warning",
+        "Location": {
+            "End": {
+                "ColumnNumber": 33,
+                "LineNumber": 107
+            },
+            "Path": [
+                "Metadata",
+                "AWS::CloudFormation::Interface"
+            ],
+            "Start": {
+                "ColumnNumber": 3,
+                "LineNumber": 107
+            }
+        },
+        "Message": "Parameter 'pManagementPrivateSubnetBCIDR' is not listed in any Metadata AWS::CloudFormation::Interface ParameterGroup",
+        "ParentId": null,
+        "Rule": {
+            "Description": "All parameters should be listed in at least one Metadata AWS::CloudFormation::Interface ParameterGroup so they appear in the CloudFormation Console UI",
+            "Id": "W4002",
+            "ShortDescription": "Parameter not listed in Metadata Interface ParameterGroups",
+            "Source": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudformation-interface.html"
+        }
+    },
+    {
+        "Filename": "test/fixtures/templates/quickstart/nist_vpc_management.yaml",
+        "Id": "79a1b313-e40b-69dc-301f-5d5916bc1272",
+        "Level": "Warning",
+        "Location": {
+            "End": {
+                "ColumnNumber": 33,
+                "LineNumber": 107
+            },
+            "Path": [
+                "Metadata",
+                "AWS::CloudFormation::Interface"
+            ],
+            "Start": {
+                "ColumnNumber": 3,
+                "LineNumber": 107
+            }
+        },
+        "Message": "Parameter 'pNatAmi' is not listed in any Metadata AWS::CloudFormation::Interface ParameterGroup",
+        "ParentId": null,
+        "Rule": {
+            "Description": "All parameters should be listed in at least one Metadata AWS::CloudFormation::Interface ParameterGroup so they appear in the CloudFormation Console UI",
+            "Id": "W4002",
+            "ShortDescription": "Parameter not listed in Metadata Interface ParameterGroups",
+            "Source": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudformation-interface.html"
+        }
+    },
+    {
+        "Filename": "test/fixtures/templates/quickstart/nist_vpc_management.yaml",
+        "Id": "76fa7c32-72e8-b6f2-d079-48c1d1007731",
+        "Level": "Warning",
+        "Location": {
+            "End": {
+                "ColumnNumber": 33,
+                "LineNumber": 107
+            },
+            "Path": [
+                "Metadata",
+                "AWS::CloudFormation::Interface"
+            ],
+            "Start": {
+                "ColumnNumber": 3,
+                "LineNumber": 107
+            }
+        },
+        "Message": "Parameter 'pNatInstanceType' is not listed in any Metadata AWS::CloudFormation::Interface ParameterGroup",
+        "ParentId": null,
+        "Rule": {
+            "Description": "All parameters should be listed in at least one Metadata AWS::CloudFormation::Interface ParameterGroup so they appear in the CloudFormation Console UI",
+            "Id": "W4002",
+            "ShortDescription": "Parameter not listed in Metadata Interface ParameterGroups",
+            "Source": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudformation-interface.html"
+        }
+    },
+    {
+        "Filename": "test/fixtures/templates/quickstart/nist_vpc_management.yaml",
+        "Id": "03b02835-304a-2d63-49c6-c0f788951628",
+        "Level": "Warning",
+        "Location": {
+            "End": {
+                "ColumnNumber": 33,
+                "LineNumber": 107
+            },
+            "Path": [
+                "Metadata",
+                "AWS::CloudFormation::Interface"
+            ],
+            "Start": {
+                "ColumnNumber": 3,
+                "LineNumber": 107
+            }
+        },
+        "Message": "Parameter 'pProductionCIDR' is not listed in any Metadata AWS::CloudFormation::Interface ParameterGroup",
+        "ParentId": null,
+        "Rule": {
+            "Description": "All parameters should be listed in at least one Metadata AWS::CloudFormation::Interface ParameterGroup so they appear in the CloudFormation Console UI",
+            "Id": "W4002",
+            "ShortDescription": "Parameter not listed in Metadata Interface ParameterGroups",
+            "Source": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudformation-interface.html"
+        }
+    },
+    {
+        "Filename": "test/fixtures/templates/quickstart/nist_vpc_management.yaml",
+        "Id": "d00afc6d-d807-54d6-1e3e-f69401a0110e",
+        "Level": "Warning",
+        "Location": {
+            "End": {
+                "ColumnNumber": 33,
+                "LineNumber": 107
+            },
+            "Path": [
+                "Metadata",
+                "AWS::CloudFormation::Interface"
+            ],
+            "Start": {
+                "ColumnNumber": 3,
+                "LineNumber": 107
+            }
+        },
+        "Message": "Parameter 'pProductionVPC' is not listed in any Metadata AWS::CloudFormation::Interface ParameterGroup",
+        "ParentId": null,
+        "Rule": {
+            "Description": "All parameters should be listed in at least one Metadata AWS::CloudFormation::Interface ParameterGroup so they appear in the CloudFormation Console UI",
+            "Id": "W4002",
+            "ShortDescription": "Parameter not listed in Metadata Interface ParameterGroups",
+            "Source": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudformation-interface.html"
+        }
+    },
+    {
+        "Filename": "test/fixtures/templates/quickstart/nist_vpc_management.yaml",
+        "Id": "0e8e149f-44b7-34f7-7e1e-d1d584000f56",
+        "Level": "Warning",
+        "Location": {
+            "End": {
+                "ColumnNumber": 33,
+                "LineNumber": 107
+            },
+            "Path": [
+                "Metadata",
+                "AWS::CloudFormation::Interface"
+            ],
+            "Start": {
+                "ColumnNumber": 3,
+                "LineNumber": 107
+            }
+        },
+        "Message": "Parameter 'pRouteTableProdPrivate' is not listed in any Metadata AWS::CloudFormation::Interface ParameterGroup",
+        "ParentId": null,
+        "Rule": {
+            "Description": "All parameters should be listed in at least one Metadata AWS::CloudFormation::Interface ParameterGroup so they appear in the CloudFormation Console UI",
+            "Id": "W4002",
+            "ShortDescription": "Parameter not listed in Metadata Interface ParameterGroups",
+            "Source": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudformation-interface.html"
+        }
+    },
+    {
+        "Filename": "test/fixtures/templates/quickstart/nist_vpc_management.yaml",
+        "Id": "ac304c7a-b6be-6e20-fb1f-c2317c876546",
+        "Level": "Warning",
+        "Location": {
+            "End": {
+                "ColumnNumber": 33,
+                "LineNumber": 107
+            },
+            "Path": [
+                "Metadata",
+                "AWS::CloudFormation::Interface"
+            ],
+            "Start": {
+                "ColumnNumber": 3,
+                "LineNumber": 107
+            }
+        },
+        "Message": "Parameter 'pRouteTableProdPublic' is not listed in any Metadata AWS::CloudFormation::Interface ParameterGroup",
+        "ParentId": null,
+        "Rule": {
+            "Description": "All parameters should be listed in at least one Metadata AWS::CloudFormation::Interface ParameterGroup so they appear in the CloudFormation Console UI",
+            "Id": "W4002",
+            "ShortDescription": "Parameter not listed in Metadata Interface ParameterGroups",
+            "Source": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudformation-interface.html"
+        }
+    },
+    {
+        "Filename": "test/fixtures/templates/quickstart/nist_vpc_management.yaml",
+        "Id": "71f2b8c5-d3c1-7452-92f4-214ea9917f71",
+        "Level": "Warning",
+        "Location": {
+            "End": {
+                "ColumnNumber": 33,
+                "LineNumber": 107
+            },
+            "Path": [
+                "Metadata",
+                "AWS::CloudFormation::Interface"
+            ],
+            "Start": {
+                "ColumnNumber": 3,
+                "LineNumber": 107
+            }
+        },
+        "Message": "Parameter 'pSupportsNatGateway' is not listed in any Metadata AWS::CloudFormation::Interface ParameterGroup",
+        "ParentId": null,
+        "Rule": {
+            "Description": "All parameters should be listed in at least one Metadata AWS::CloudFormation::Interface ParameterGroup so they appear in the CloudFormation Console UI",
+            "Id": "W4002",
+            "ShortDescription": "Parameter not listed in Metadata Interface ParameterGroups",
+            "Source": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudformation-interface.html"
+        }
+    },
+    {
+        "Filename": "test/fixtures/templates/quickstart/nist_vpc_management.yaml",
+        "Id": "ebc5a37a-3d8e-c98c-3d5f-a15b0a8f07de",
+        "Level": "Warning",
+        "Location": {
+            "End": {
+                "ColumnNumber": 33,
+                "LineNumber": 107
+            },
+            "Path": [
+                "Metadata",
+                "AWS::CloudFormation::Interface"
+            ],
+            "Start": {
+                "ColumnNumber": 3,
+                "LineNumber": 107
+            }
+        },
+        "Message": "Parameter 'pTemplateUrlPrefix' is not listed in any Metadata AWS::CloudFormation::Interface ParameterGroup",
+        "ParentId": null,
+        "Rule": {
+            "Description": "All parameters should be listed in at least one Metadata AWS::CloudFormation::Interface ParameterGroup so they appear in the CloudFormation Console UI",
+            "Id": "W4002",
+            "ShortDescription": "Parameter not listed in Metadata Interface ParameterGroups",
+            "Source": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudformation-interface.html"
+        }
+    },
+    {
+        "Filename": "test/fixtures/templates/quickstart/nist_vpc_management.yaml",
         "Id": "43e12973-c7b5-0332-5ea9-c3b43d2aee34",
         "Level": "Warning",
         "Location": {

--- a/test/fixtures/results/quickstart/nist_vpc_production.json
+++ b/test/fixtures/results/quickstart/nist_vpc_production.json
@@ -1,6 +1,168 @@
 [
     {
         "Filename": "test/fixtures/templates/quickstart/nist_vpc_production.yaml",
+        "Id": "d3a0693d-8f9a-de9c-8d6e-c19e04fd75b2",
+        "Level": "Warning",
+        "Location": {
+            "End": {
+                "ColumnNumber": 33,
+                "LineNumber": 14
+            },
+            "Path": [
+                "Metadata",
+                "AWS::CloudFormation::Interface"
+            ],
+            "Start": {
+                "ColumnNumber": 3,
+                "LineNumber": 14
+            }
+        },
+        "Message": "Parameter 'pEnvironment' is not listed in any Metadata AWS::CloudFormation::Interface ParameterGroup",
+        "ParentId": null,
+        "Rule": {
+            "Description": "All parameters should be listed in at least one Metadata AWS::CloudFormation::Interface ParameterGroup so they appear in the CloudFormation Console UI",
+            "Id": "W4002",
+            "ShortDescription": "Parameter not listed in Metadata Interface ParameterGroups",
+            "Source": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudformation-interface.html"
+        }
+    },
+    {
+        "Filename": "test/fixtures/templates/quickstart/nist_vpc_production.yaml",
+        "Id": "260ded8c-4dbc-2f9c-55f5-f68305d12977",
+        "Level": "Warning",
+        "Location": {
+            "End": {
+                "ColumnNumber": 33,
+                "LineNumber": 14
+            },
+            "Path": [
+                "Metadata",
+                "AWS::CloudFormation::Interface"
+            ],
+            "Start": {
+                "ColumnNumber": 3,
+                "LineNumber": 14
+            }
+        },
+        "Message": "Parameter 'pManagementCIDR' is not listed in any Metadata AWS::CloudFormation::Interface ParameterGroup",
+        "ParentId": null,
+        "Rule": {
+            "Description": "All parameters should be listed in at least one Metadata AWS::CloudFormation::Interface ParameterGroup so they appear in the CloudFormation Console UI",
+            "Id": "W4002",
+            "ShortDescription": "Parameter not listed in Metadata Interface ParameterGroups",
+            "Source": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudformation-interface.html"
+        }
+    },
+    {
+        "Filename": "test/fixtures/templates/quickstart/nist_vpc_production.yaml",
+        "Id": "49205228-c1cd-0b4f-3f2f-18aab8597c2d",
+        "Level": "Warning",
+        "Location": {
+            "End": {
+                "ColumnNumber": 33,
+                "LineNumber": 14
+            },
+            "Path": [
+                "Metadata",
+                "AWS::CloudFormation::Interface"
+            ],
+            "Start": {
+                "ColumnNumber": 3,
+                "LineNumber": 14
+            }
+        },
+        "Message": "Parameter 'pNatAmi' is not listed in any Metadata AWS::CloudFormation::Interface ParameterGroup",
+        "ParentId": null,
+        "Rule": {
+            "Description": "All parameters should be listed in at least one Metadata AWS::CloudFormation::Interface ParameterGroup so they appear in the CloudFormation Console UI",
+            "Id": "W4002",
+            "ShortDescription": "Parameter not listed in Metadata Interface ParameterGroups",
+            "Source": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudformation-interface.html"
+        }
+    },
+    {
+        "Filename": "test/fixtures/templates/quickstart/nist_vpc_production.yaml",
+        "Id": "5ac832d1-9dbe-a5d1-884c-536b606e7e67",
+        "Level": "Warning",
+        "Location": {
+            "End": {
+                "ColumnNumber": 33,
+                "LineNumber": 14
+            },
+            "Path": [
+                "Metadata",
+                "AWS::CloudFormation::Interface"
+            ],
+            "Start": {
+                "ColumnNumber": 3,
+                "LineNumber": 14
+            }
+        },
+        "Message": "Parameter 'pNatInstanceType' is not listed in any Metadata AWS::CloudFormation::Interface ParameterGroup",
+        "ParentId": null,
+        "Rule": {
+            "Description": "All parameters should be listed in at least one Metadata AWS::CloudFormation::Interface ParameterGroup so they appear in the CloudFormation Console UI",
+            "Id": "W4002",
+            "ShortDescription": "Parameter not listed in Metadata Interface ParameterGroups",
+            "Source": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudformation-interface.html"
+        }
+    },
+    {
+        "Filename": "test/fixtures/templates/quickstart/nist_vpc_production.yaml",
+        "Id": "395dfd77-a254-dde5-edb7-017a2838cf23",
+        "Level": "Warning",
+        "Location": {
+            "End": {
+                "ColumnNumber": 33,
+                "LineNumber": 14
+            },
+            "Path": [
+                "Metadata",
+                "AWS::CloudFormation::Interface"
+            ],
+            "Start": {
+                "ColumnNumber": 3,
+                "LineNumber": 14
+            }
+        },
+        "Message": "Parameter 'pSupportsNatGateway' is not listed in any Metadata AWS::CloudFormation::Interface ParameterGroup",
+        "ParentId": null,
+        "Rule": {
+            "Description": "All parameters should be listed in at least one Metadata AWS::CloudFormation::Interface ParameterGroup so they appear in the CloudFormation Console UI",
+            "Id": "W4002",
+            "ShortDescription": "Parameter not listed in Metadata Interface ParameterGroups",
+            "Source": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudformation-interface.html"
+        }
+    },
+    {
+        "Filename": "test/fixtures/templates/quickstart/nist_vpc_production.yaml",
+        "Id": "a71d39ba-7b36-78b8-04ab-218bd5bcd46d",
+        "Level": "Warning",
+        "Location": {
+            "End": {
+                "ColumnNumber": 33,
+                "LineNumber": 14
+            },
+            "Path": [
+                "Metadata",
+                "AWS::CloudFormation::Interface"
+            ],
+            "Start": {
+                "ColumnNumber": 3,
+                "LineNumber": 14
+            }
+        },
+        "Message": "Parameter 'pTemplateUrlPrefix' is not listed in any Metadata AWS::CloudFormation::Interface ParameterGroup",
+        "ParentId": null,
+        "Rule": {
+            "Description": "All parameters should be listed in at least one Metadata AWS::CloudFormation::Interface ParameterGroup so they appear in the CloudFormation Console UI",
+            "Id": "W4002",
+            "ShortDescription": "Parameter not listed in Metadata Interface ParameterGroups",
+            "Source": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudformation-interface.html"
+        }
+    },
+    {
+        "Filename": "test/fixtures/templates/quickstart/nist_vpc_production.yaml",
         "Id": "57e9e8e5-de19-854d-73b6-69a87b935dde",
         "Level": "Warning",
         "Location": {

--- a/test/fixtures/results/quickstart/non_strict/nist_application.json
+++ b/test/fixtures/results/quickstart/non_strict/nist_application.json
@@ -1,6 +1,168 @@
 [
     {
         "Filename": "test/fixtures/templates/quickstart/nist_application.yaml",
+        "Id": "69398ef4-b979-fc98-ada2-4b0576e6a6e5",
+        "Level": "Warning",
+        "Location": {
+            "End": {
+                "ColumnNumber": 33,
+                "LineNumber": 38
+            },
+            "Path": [
+                "Metadata",
+                "AWS::CloudFormation::Interface"
+            ],
+            "Start": {
+                "ColumnNumber": 3,
+                "LineNumber": 38
+            }
+        },
+        "Message": "Parameter 'pEC2KeyPair' is not listed in any Metadata AWS::CloudFormation::Interface ParameterGroup",
+        "ParentId": null,
+        "Rule": {
+            "Description": "All parameters should be listed in at least one Metadata AWS::CloudFormation::Interface ParameterGroup so they appear in the CloudFormation Console UI",
+            "Id": "W4002",
+            "ShortDescription": "Parameter not listed in Metadata Interface ParameterGroups",
+            "Source": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudformation-interface.html"
+        }
+    },
+    {
+        "Filename": "test/fixtures/templates/quickstart/nist_application.yaml",
+        "Id": "6436fec7-d300-6347-83cb-6161089ccab2",
+        "Level": "Warning",
+        "Location": {
+            "End": {
+                "ColumnNumber": 33,
+                "LineNumber": 38
+            },
+            "Path": [
+                "Metadata",
+                "AWS::CloudFormation::Interface"
+            ],
+            "Start": {
+                "ColumnNumber": 3,
+                "LineNumber": 38
+            }
+        },
+        "Message": "Parameter 'pEnvironment' is not listed in any Metadata AWS::CloudFormation::Interface ParameterGroup",
+        "ParentId": null,
+        "Rule": {
+            "Description": "All parameters should be listed in at least one Metadata AWS::CloudFormation::Interface ParameterGroup so they appear in the CloudFormation Console UI",
+            "Id": "W4002",
+            "ShortDescription": "Parameter not listed in Metadata Interface ParameterGroups",
+            "Source": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudformation-interface.html"
+        }
+    },
+    {
+        "Filename": "test/fixtures/templates/quickstart/nist_application.yaml",
+        "Id": "73884139-4116-e6d0-81d8-457fecf314d6",
+        "Level": "Warning",
+        "Location": {
+            "End": {
+                "ColumnNumber": 33,
+                "LineNumber": 38
+            },
+            "Path": [
+                "Metadata",
+                "AWS::CloudFormation::Interface"
+            ],
+            "Start": {
+                "ColumnNumber": 3,
+                "LineNumber": 38
+            }
+        },
+        "Message": "Parameter 'pManagementCIDR' is not listed in any Metadata AWS::CloudFormation::Interface ParameterGroup",
+        "ParentId": null,
+        "Rule": {
+            "Description": "All parameters should be listed in at least one Metadata AWS::CloudFormation::Interface ParameterGroup so they appear in the CloudFormation Console UI",
+            "Id": "W4002",
+            "ShortDescription": "Parameter not listed in Metadata Interface ParameterGroups",
+            "Source": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudformation-interface.html"
+        }
+    },
+    {
+        "Filename": "test/fixtures/templates/quickstart/nist_application.yaml",
+        "Id": "49f69682-c405-d549-c002-a18a780d0cfd",
+        "Level": "Warning",
+        "Location": {
+            "End": {
+                "ColumnNumber": 33,
+                "LineNumber": 38
+            },
+            "Path": [
+                "Metadata",
+                "AWS::CloudFormation::Interface"
+            ],
+            "Start": {
+                "ColumnNumber": 3,
+                "LineNumber": 38
+            }
+        },
+        "Message": "Parameter 'pSecurityAlarmTopic' is not listed in any Metadata AWS::CloudFormation::Interface ParameterGroup",
+        "ParentId": null,
+        "Rule": {
+            "Description": "All parameters should be listed in at least one Metadata AWS::CloudFormation::Interface ParameterGroup so they appear in the CloudFormation Console UI",
+            "Id": "W4002",
+            "ShortDescription": "Parameter not listed in Metadata Interface ParameterGroups",
+            "Source": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudformation-interface.html"
+        }
+    },
+    {
+        "Filename": "test/fixtures/templates/quickstart/nist_application.yaml",
+        "Id": "6836fc89-240d-2b0e-3310-cc99ea717821",
+        "Level": "Warning",
+        "Location": {
+            "End": {
+                "ColumnNumber": 33,
+                "LineNumber": 38
+            },
+            "Path": [
+                "Metadata",
+                "AWS::CloudFormation::Interface"
+            ],
+            "Start": {
+                "ColumnNumber": 3,
+                "LineNumber": 38
+            }
+        },
+        "Message": "Parameter 'pSupportsGlacier' is not listed in any Metadata AWS::CloudFormation::Interface ParameterGroup",
+        "ParentId": null,
+        "Rule": {
+            "Description": "All parameters should be listed in at least one Metadata AWS::CloudFormation::Interface ParameterGroup so they appear in the CloudFormation Console UI",
+            "Id": "W4002",
+            "ShortDescription": "Parameter not listed in Metadata Interface ParameterGroups",
+            "Source": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudformation-interface.html"
+        }
+    },
+    {
+        "Filename": "test/fixtures/templates/quickstart/nist_application.yaml",
+        "Id": "2b5c0b7d-c358-0f34-f714-9864d53ab86d",
+        "Level": "Warning",
+        "Location": {
+            "End": {
+                "ColumnNumber": 33,
+                "LineNumber": 38
+            },
+            "Path": [
+                "Metadata",
+                "AWS::CloudFormation::Interface"
+            ],
+            "Start": {
+                "ColumnNumber": 3,
+                "LineNumber": 38
+            }
+        },
+        "Message": "Parameter 'pTemplateUrlPrefix' is not listed in any Metadata AWS::CloudFormation::Interface ParameterGroup",
+        "ParentId": null,
+        "Rule": {
+            "Description": "All parameters should be listed in at least one Metadata AWS::CloudFormation::Interface ParameterGroup so they appear in the CloudFormation Console UI",
+            "Id": "W4002",
+            "ShortDescription": "Parameter not listed in Metadata Interface ParameterGroups",
+            "Source": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudformation-interface.html"
+        }
+    },
+    {
+        "Filename": "test/fixtures/templates/quickstart/nist_application.yaml",
         "Id": "03ea7054-c827-0317-8bce-8e64baed02a0",
         "Level": "Informational",
         "Location": {

--- a/test/unit/module/cfn_json/test_cfn_json.py
+++ b/test/unit/module/cfn_json/test_cfn_json.py
@@ -39,7 +39,7 @@ class TestCfnJson(BaseTestCase):
             },
             "vpc_management": {
                 "filename": "test/fixtures/templates/quickstart/vpc-management.json",
-                "failures": 11,
+                "failures": 27,
             },
             "vpc": {
                 "filename": "test/fixtures/templates/quickstart/vpc.json",

--- a/test/unit/rules/metadata/test_interface_parameter_in_group.py
+++ b/test/unit/rules/metadata/test_interface_parameter_in_group.py
@@ -1,0 +1,83 @@
+"""
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+"""
+
+import pytest
+
+from cfnlint.jsonschema import ValidationError
+from cfnlint.rules.metadata.InterfaceParameterInGroup import InterfaceParameterInGroup
+
+
+@pytest.fixture(scope="module")
+def rule():
+    return InterfaceParameterInGroup()
+
+
+@pytest.fixture
+def template():
+    return {
+        "Parameters": {
+            "VpcId": {"Type": "String"},
+            "SubnetId": {"Type": "String"},
+        },
+    }
+
+
+@pytest.mark.parametrize(
+    "name,instance,expected_count",
+    [
+        (
+            "All parameters listed in ParameterGroups",
+            {
+                "ParameterGroups": [
+                    {
+                        "Label": {"default": "Network"},
+                        "Parameters": ["VpcId", "SubnetId"],
+                    }
+                ]
+            },
+            0,
+        ),
+        (
+            "One parameter missing from ParameterGroups",
+            {
+                "ParameterGroups": [
+                    {
+                        "Label": {"default": "Network"},
+                        "Parameters": ["VpcId"],
+                    }
+                ]
+            },
+            1,
+        ),
+        (
+            "No ParameterGroups defined",
+            {},
+            2,
+        ),
+        (
+            "Parameters spread across multiple groups",
+            {
+                "ParameterGroups": [
+                    {"Label": {"default": "Group A"}, "Parameters": ["VpcId"]},
+                    {"Label": {"default": "Group B"}, "Parameters": ["SubnetId"]},
+                ]
+            },
+            0,
+        ),
+        (
+            "Non-dict instance is skipped",
+            "invalid",
+            0,
+        ),
+    ],
+)
+def test_validate(name, instance, expected_count, rule, validator):
+    errs = list(rule.validate(validator, "", instance, {}))
+    assert len(errs) == expected_count, (
+        f"Test {name!r}: expected {expected_count} error(s), got {errs!r}"
+    )
+    for err in errs:
+        assert isinstance(err, ValidationError)
+        assert err.rule == rule

--- a/test/unit/rules/metadata/test_interface_parameter_in_group.py
+++ b/test/unit/rules/metadata/test_interface_parameter_in_group.py
@@ -71,6 +71,25 @@ def template():
             "invalid",
             0,
         ),
+        (
+            "Non-dict entries in ParameterGroups are skipped",
+            {
+                "ParameterGroups": [
+                    "not-a-dict",
+                    {"Parameters": ["VpcId", "SubnetId"]},
+                ]
+            },
+            0,
+        ),
+        (
+            "Non-string entries in Parameters are skipped",
+            {
+                "ParameterGroups": [
+                    {"Parameters": [{"Ref": "VpcId"}, "SubnetId"]},
+                ]
+            },
+            1,
+        ),
     ],
 )
 def test_validate(name, instance, expected_count, rule, validator):


### PR DESCRIPTION
*Issue #, if available:* Closes #4115

*Description of changes:*

Adds a new warning rule **W4002** that implements the inverse check of W4001.

- W4001 warns when a parameter referenced in `Metadata.AWS::CloudFormation::Interface` does not exist in the `Parameters` section.
- W4002 warns when a declared `Parameter` is not listed in any `ParameterGroup`, so it would not appear in the CloudFormation Console UI.

**Changes:**
- `src/cfnlint/rules/metadata/InterfaceParameterInGroup.py` — new rule (49 lines)
- `test/unit/rules/metadata/test_interface_parameter_in_group.py` — 5 parametrized unit tests covering the all-grouped, partial, no-groups, multi-group, and non-dict cases
- Updated snapshot results in `test/fixtures/results/integration/` and `test/fixtures/results/quickstart/` (pure additions of new W4002 entries; no existing entries modified)
- `test/unit/module/cfn_json/test_cfn_json.py` — updated expected failure count for `vpc-management.json` fixture (11 → 27)

**Verification:**
- `pre-commit run` passes (ruff, isort, bandit, mypy, file hygiene)
- `pytest test/unit/` — 2568 passed
- `pytest test/integration/` — 27 passed
- Smoke-tested end-to-end against a template missing a parameter from `ParameterGroups`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.