### PR TITLE
feat: Add rule W3046 for Route53 AliasTarget HostedZoneId references

### DIFF
--- a/src/cfnlint/rules/resources/route53/RecordSetAliasTargetHostedZoneId.py
+++ b/src/cfnlint/rules/resources/route53/RecordSetAliasTargetHostedZoneId.py
@@ -1,0 +1,117 @@
+"""
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from typing import Any, Iterator
+
+from cfnlint.helpers import ensure_list, is_function
+from cfnlint.jsonschema import ValidationError, ValidationResult, Validator
+from cfnlint.rules.helpers import get_value_from_path
+from cfnlint.rules.jsonschema.CfnLintKeyword import CfnLintKeyword
+
+# Known resource attributes that return a HostedZoneId suitable for use as a
+# Route53 AliasTarget.HostedZoneId. When a user references a different
+# attribute on one of these resources, or uses Ref on an
+# AWS::Route53::HostedZone, the value will not be a valid alias target zone.
+_VALID_ALIAS_TARGET_ATTRIBUTES: dict[str, set[str]] = {
+    "AWS::ElasticLoadBalancing::LoadBalancer": {"CanonicalHostedZoneNameID"},
+    "AWS::ElasticLoadBalancingV2::LoadBalancer": {"CanonicalHostedZoneID"},
+    "AWS::ApiGateway::DomainName": {
+        "DistributionHostedZoneId",
+        "RegionalHostedZoneId",
+    },
+    "AWS::ApiGatewayV2::DomainName": {"RegionalHostedZoneId"},
+}
+
+
+class RecordSetAliasTargetHostedZoneId(CfnLintKeyword):
+    """Warn on suspicious AliasTarget.HostedZoneId references"""
+
+    id = "W3046"
+    shortdesc = "Validate Route53 AliasTarget HostedZoneId references"
+    description = (
+        "An AliasTarget HostedZoneId should reference the canonical hosted zone "
+        "of the alias target (for example !GetAtt LoadBalancer.CanonicalHostedZoneID), "
+        "not the hosted zone the record is being created in"
+    )
+    source_url = "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-aliastarget.html"
+    tags = ["resources", "route53", "record_set"]
+
+    def __init__(self) -> None:
+        super().__init__(
+            keywords=[
+                "Resources/AWS::Route53::RecordSet/Properties",
+                "Resources/AWS::Route53::RecordSetGroup/Properties/RecordSets/*",
+            ],
+        )
+
+    def _check_value(
+        self, validator: Validator, value: Any
+    ) -> Iterator[ValidationError]:
+        fn_k, fn_v = is_function(value)
+        if fn_k is None:
+            return
+
+        if fn_k == "Ref":
+            if not isinstance(fn_v, str):
+                return
+            resource = validator.context.resources.get(fn_v)
+            if resource is not None and resource.type == "AWS::Route53::HostedZone":
+                yield ValidationError(
+                    (
+                        f"{{'Ref': {fn_v!r}}} returns the Id of an "
+                        "AWS::Route53::HostedZone, which is the hosted zone the "
+                        "record is created in, not the alias target's canonical "
+                        "hosted zone. Use !GetAtt on the alias target resource "
+                        "instead (for example "
+                        "!GetAtt LoadBalancer.CanonicalHostedZoneID)"
+                    ),
+                    rule=self,
+                )
+            return
+
+        if fn_k == "Fn::GetAtt":
+            parts = ensure_list(fn_v)
+            if len(parts) == 1 and isinstance(parts[0], str):
+                logical_id, _, attribute = parts[0].partition(".")
+            elif len(parts) >= 2 and all(isinstance(p, str) for p in parts[:2]):
+                logical_id, attribute = parts[0], parts[1]
+            else:
+                return
+
+            if not attribute:
+                return
+
+            resource = validator.context.resources.get(logical_id)
+            if resource is None:
+                return
+
+            valid_attrs = _VALID_ALIAS_TARGET_ATTRIBUTES.get(resource.type)
+            if valid_attrs is None:
+                return
+
+            if attribute not in valid_attrs:
+                expected = ", ".join(sorted(valid_attrs))
+                yield ValidationError(
+                    (
+                        f"{{'Fn::GetAtt': [{logical_id!r}, {attribute!r}]}} "
+                        f"does not return a HostedZoneId for {resource.type!r}. "
+                        f"Expected one of: {expected}"
+                    ),
+                    rule=self,
+                )
+
+    def validate(
+        self, validator: Validator, _, instance: Any, schema: Any
+    ) -> ValidationResult:
+        for hosted_zone_id, hosted_zone_id_validator in get_value_from_path(
+            validator, instance, deque(["AliasTarget", "HostedZoneId"])
+        ):
+            if hosted_zone_id is None:
+                continue
+            for err in self._check_value(hosted_zone_id_validator, hosted_zone_id):
+                yield err

--- a/test/unit/rules/resources/route53/test_recordset_alias_target_hosted_zone_id.py
+++ b/test/unit/rules/resources/route53/test_recordset_alias_target_hosted_zone_id.py
@@ -1,0 +1,141 @@
+"""
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+"""
+
+import pytest
+
+from cfnlint.jsonschema import ValidationError
+from cfnlint.rules.resources.route53.RecordSetAliasTargetHostedZoneId import (
+    RecordSetAliasTargetHostedZoneId,
+)
+
+
+@pytest.fixture(scope="module")
+def rule():
+    return RecordSetAliasTargetHostedZoneId()
+
+
+@pytest.fixture
+def template():
+    return {
+        "Resources": {
+            "MyHostedZone": {"Type": "AWS::Route53::HostedZone"},
+            "MyClassicElb": {"Type": "AWS::ElasticLoadBalancing::LoadBalancer"},
+            "MyAlb": {"Type": "AWS::ElasticLoadBalancingV2::LoadBalancer"},
+            "MyApiDomain": {"Type": "AWS::ApiGateway::DomainName"},
+            "MyHttpApiDomain": {"Type": "AWS::ApiGatewayV2::DomainName"},
+            "MyBucket": {"Type": "AWS::S3::Bucket"},
+        },
+    }
+
+
+def _props(hosted_zone_id):
+    return {
+        "AliasTarget": {
+            "DNSName": "example.com",
+            "HostedZoneId": hosted_zone_id,
+        },
+    }
+
+
+@pytest.mark.parametrize(
+    "name,instance,expect_error",
+    [
+        ("Static string is not flagged", _props("Z2FDTNDATAQYW2"), False),
+        (
+            "Ref to AWS::Route53::HostedZone is flagged",
+            _props({"Ref": "MyHostedZone"}),
+            True,
+        ),
+        (
+            "Ref to an unrelated resource is not flagged",
+            _props({"Ref": "MyBucket"}),
+            False,
+        ),
+        (
+            "Ref to a parameter or unknown name is not flagged",
+            _props({"Ref": "SomeParameter"}),
+            False,
+        ),
+        (
+            "GetAtt classic ELB CanonicalHostedZoneNameID is not flagged",
+            _props({"Fn::GetAtt": ["MyClassicElb", "CanonicalHostedZoneNameID"]}),
+            False,
+        ),
+        (
+            "GetAtt classic ELB DNSName is flagged (wrong attribute)",
+            _props({"Fn::GetAtt": ["MyClassicElb", "DNSName"]}),
+            True,
+        ),
+        (
+            "GetAtt ALB CanonicalHostedZoneID is not flagged",
+            _props({"Fn::GetAtt": ["MyAlb", "CanonicalHostedZoneID"]}),
+            False,
+        ),
+        (
+            "GetAtt ALB DNSName is flagged (wrong attribute)",
+            _props({"Fn::GetAtt": ["MyAlb", "DNSName"]}),
+            True,
+        ),
+        (
+            "GetAtt API Gateway DistributionHostedZoneId is not flagged",
+            _props({"Fn::GetAtt": ["MyApiDomain", "DistributionHostedZoneId"]}),
+            False,
+        ),
+        (
+            "GetAtt API Gateway RegionalHostedZoneId is not flagged",
+            _props({"Fn::GetAtt": ["MyApiDomain", "RegionalHostedZoneId"]}),
+            False,
+        ),
+        (
+            "GetAtt API Gateway DistributionDomainName is flagged",
+            _props({"Fn::GetAtt": ["MyApiDomain", "DistributionDomainName"]}),
+            True,
+        ),
+        (
+            "GetAtt HTTP API RegionalHostedZoneId is not flagged",
+            _props({"Fn::GetAtt": ["MyHttpApiDomain", "RegionalHostedZoneId"]}),
+            False,
+        ),
+        (
+            "GetAtt to an unrelated resource is not flagged",
+            _props({"Fn::GetAtt": ["MyBucket", "DomainName"]}),
+            False,
+        ),
+        (
+            "GetAtt to an unknown resource is not flagged",
+            _props({"Fn::GetAtt": ["Missing", "CanonicalHostedZoneID"]}),
+            False,
+        ),
+        (
+            "GetAtt with dotted string form is supported",
+            _props({"Fn::GetAtt": "MyAlb.CanonicalHostedZoneID"}),
+            False,
+        ),
+        (
+            "GetAtt with dotted string form catches wrong attribute",
+            _props({"Fn::GetAtt": "MyAlb.DNSName"}),
+            True,
+        ),
+        (
+            "Fn::ImportValue is not flagged",
+            _props({"Fn::ImportValue": "SomeExport"}),
+            False,
+        ),
+        (
+            "Properties without AliasTarget is not flagged",
+            {"HostedZoneId": {"Ref": "MyHostedZone"}, "Name": "foo", "Type": "A"},
+            False,
+        ),
+    ],
+)
+def test_validate(name, instance, expect_error, rule, validator):
+    errs = list(rule.validate(validator, "", instance, {}))
+
+    if expect_error:
+        assert len(errs) == 1, f"Test {name!r}: expected 1 error, got {errs!r}"
+        assert isinstance(errs[0], ValidationError)
+        assert errs[0].rule == rule
+    else:
+        assert errs == [], f"Test {name!r}: expected no errors, got {errs!r}"

--- a/test/unit/rules/resources/route53/test_recordset_alias_target_hosted_zone_id.py
+++ b/test/unit/rules/resources/route53/test_recordset_alias_target_hosted_zone_id.py
@@ -128,6 +128,21 @@ def _props(hosted_zone_id):
             {"HostedZoneId": {"Ref": "MyHostedZone"}, "Name": "foo", "Type": "A"},
             False,
         ),
+        (
+            "Ref with non-string value is not flagged",
+            _props({"Ref": ["MyHostedZone"]}),
+            False,
+        ),
+        (
+            "GetAtt with malformed parts is not flagged",
+            _props({"Fn::GetAtt": [123, 456]}),
+            False,
+        ),
+        (
+            "GetAtt single string without dot is not flagged",
+            _props({"Fn::GetAtt": "MyAlb"}),
+            False,
+        ),
     ],
 )
 def test_validate(name, instance, expect_error, rule, validator):


### PR DESCRIPTION
*Issue #, if available:* Closes #642

*Description of changes:*

Adds a new warning rule **W3046** that catches a common copy-paste mistake in `AWS::Route53::RecordSet` and `AWS::Route53::RecordSetGroup`: setting `AliasTarget.HostedZoneId` to the same hosted zone the record is created in, instead of the alias target's canonical hosted zone.

**What it flags:**
- `!Ref` to an `AWS::Route53::HostedZone` resource at `AliasTarget.HostedZoneId` — that returns the record's own zone, not the alias target's zone.
- `!GetAtt` to a wrong attribute on a known hosted-zone-providing resource:
  - `AWS::ElasticLoadBalancing::LoadBalancer` → expects `CanonicalHostedZoneNameID`
  - `AWS::ElasticLoadBalancingV2::LoadBalancer` → expects `CanonicalHostedZoneID`
  - `AWS::ApiGateway::DomainName` → expects `DistributionHostedZoneId` or `RegionalHostedZoneId`
  - `AWS::ApiGatewayV2::DomainName` → expects `RegionalHostedZoneId`

**What it leaves alone (to avoid false positives):**
- Static strings (e.g. CloudFront's `Z2FDTNDATAQYW2`)
- Refs to parameters or to resources unrelated to hosted zones
- `Fn::ImportValue` and other intrinsics
- Properties that don't define an `AliasTarget`

**Approach:**
Per @kddejong's [2024 comment](https://github.com/aws-cloudformation/cfn-lint/issues/642#issuecomment-2179511387) on the issue, the validation needs the list of resources that provide a hosted zone ID. This rule encodes that list directly and inspects raw `Ref` / `Fn::GetAtt` intrinsics under `AliasTarget.HostedZoneId`, mirroring the pattern used in `ServiceDynamicPorts` (E3049).

**Files:**
- `src/cfnlint/rules/resources/route53/RecordSetAliasTargetHostedZoneId.py` — new rule (117 lines)
- `test/unit/rules/resources/route53/test_recordset_alias_target_hosted_zone_id.py` — 18 parametrized unit tests covering Ref/GetAtt, all 4 provider resources, wrong-attribute cases, dotted-string GetAtt form, and various no-warn paths

**Verification:**
- `pre-commit run` passes (ruff, isort, bandit, mypy, file hygiene)
- `pytest test/unit/` — 2614 passed
- `pytest test/integration/` — 27 passed
- No snapshot changes needed (no committed fixture currently triggers W3046)
- Smoke-tested end-to-end on a template that mirrors the issue's example

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.