### PR TITLE
fix: Update Lambda runtime lifecycle dates from AWS docs

### DIFF
--- a/src/cfnlint/data/AdditionalSpecs/LmbdRuntimeLifecycle.json
+++ b/src/cfnlint/data/AdditionalSpecs/LmbdRuntimeLifecycle.json
@@ -1,57 +1,69 @@
 {
+ "dotnet10": {
+  "create-block": "2028-12-14",
+  "deprecated": "2028-11-14",
+  "successor": null,
+  "update-block": "2029-01-15"
+ },
  "dotnet6": {
-  "create-block": "2026-06-01",
+  "create-block": "2027-02-01",
   "deprecated": "2024-12-20",
-  "successor": "dotnet9",
-  "update-block": "2026-07-01"
+  "successor": "dotnet10",
+  "update-block": "2027-03-03"
  },
  "dotnet8": {
-  "create-block": "2026-12-10",
+  "create-block": "2027-02-01",
   "deprecated": "2026-11-10",
-  "successor": "dotnet9",
-  "update-block": "2027-01-11"
+  "successor": "dotnet10",
+  "update-block": "2027-03-03"
+ },
+ "dotnet9": {
+  "create-block": null,
+  "deprecated": "2026-11-10",
+  "successor": "dotnet10",
+  "update-block": null
  },
  "dotnetcore1.0": {
   "create-block": "2019-06-30",
   "deprecated": "2019-06-27",
-  "successor": "dotnet9",
+  "successor": "dotnet10",
   "update-block": "2019-07-30"
  },
  "dotnetcore2.0": {
   "create-block": "2019-04-30",
   "deprecated": "2019-05-30",
-  "successor": "dotnet9",
+  "successor": "dotnet10",
   "update-block": "2019-05-30"
  },
  "dotnetcore2.1": {
   "create-block": "2022-01-05",
   "deprecated": "2022-01-05",
-  "successor": "dotnet9",
+  "successor": "dotnet10",
   "update-block": "2022-04-13"
  },
  "dotnetcore3.1": {
   "create-block": "2023-04-03",
   "deprecated": "2023-04-03",
-  "successor": "dotnet9",
+  "successor": "dotnet10",
   "update-block": "2023-05-03"
  },
  "go1.x": {
   "create-block": "2024-02-08",
   "deprecated": "2024-01-08",
   "successor": "provided.al2023",
-  "update-block": "2026-07-01"
+  "update-block": "2027-03-03"
  },
  "java11": {
-  "create-block": "2026-07-31",
-  "deprecated": "2026-06-30",
+  "create-block": "2027-07-31",
+  "deprecated": "2027-06-30",
   "successor": "java25",
-  "update-block": "2026-08-31"
+  "update-block": "2027-08-31"
  },
  "java17": {
-  "create-block": "2026-07-31",
-  "deprecated": "2026-06-30",
+  "create-block": "2027-07-31",
+  "deprecated": "2027-06-30",
   "successor": "java25",
-  "update-block": "2026-08-31"
+  "update-block": "2027-08-31"
  },
  "java21": {
   "create-block": "2029-07-31",
@@ -69,13 +81,13 @@
   "create-block": "2024-02-08",
   "deprecated": "2024-01-08",
   "successor": "java25",
-  "update-block": "2026-07-01"
+  "update-block": "2027-03-03"
  },
  "java8.al2": {
-  "create-block": "2026-07-31",
-  "deprecated": "2026-06-30",
+  "create-block": "2027-07-31",
+  "deprecated": "2027-06-30",
   "successor": "java25",
-  "update-block": "2026-08-31"
+  "update-block": "2027-08-31"
  },
  "nodejs": {
   "create-block": "2016-09-30",
@@ -99,25 +111,25 @@
   "create-block": "2024-01-09",
   "deprecated": "2023-12-04",
   "successor": "nodejs24.x",
-  "update-block": "2026-07-01"
+  "update-block": "2027-03-03"
  },
  "nodejs16.x": {
-  "create-block": "2026-06-01",
+  "create-block": "2027-02-01",
   "deprecated": "2024-06-12",
   "successor": "nodejs24.x",
-  "update-block": "2026-07-01"
+  "update-block": "2027-03-03"
  },
  "nodejs18.x": {
-  "create-block": "2026-06-01",
+  "create-block": "2027-02-01",
   "deprecated": "2025-09-01",
   "successor": "nodejs24.x",
-  "update-block": "2026-07-01"
+  "update-block": "2027-03-03"
  },
  "nodejs20.x": {
-  "create-block": "2026-06-01",
+  "create-block": "2027-02-01",
   "deprecated": "2026-04-30",
   "successor": "nodejs24.x",
-  "update-block": "2026-07-01"
+  "update-block": "2027-03-03"
  },
  "nodejs22.x": {
   "create-block": "2027-06-01",
@@ -159,13 +171,13 @@
   "create-block": "2024-02-08",
   "deprecated": "2024-01-08",
   "successor": "provided.al2023",
-  "update-block": "2026-07-01"
+  "update-block": "2027-03-03"
  },
  "provided.al2": {
-  "create-block": "2026-07-31",
-  "deprecated": "2026-06-30",
+  "create-block": "2027-02-01",
+  "deprecated": "2026-07-31",
   "successor": "provided.al2023",
-  "update-block": "2026-08-31"
+  "update-block": "2027-03-03"
  },
  "provided.al2023": {
   "create-block": "2029-07-31",
@@ -180,16 +192,16 @@
   "update-block": "2022-05-30"
  },
  "python3.10": {
-  "create-block": "2026-07-31",
-  "deprecated": "2026-06-30",
+  "create-block": "2027-02-01",
+  "deprecated": "2026-10-31",
   "successor": "python3.14",
-  "update-block": "2026-08-31"
+  "update-block": "2027-03-03"
  },
  "python3.11": {
-  "create-block": "2026-07-31",
-  "deprecated": "2026-06-30",
+  "create-block": "2027-07-31",
+  "deprecated": "2027-06-30",
   "successor": "python3.14",
-  "update-block": "2026-08-31"
+  "update-block": "2027-08-31"
  },
  "python3.12": {
   "create-block": "2028-11-30",
@@ -219,48 +231,54 @@
   "create-block": "2024-01-09",
   "deprecated": "2023-12-04",
   "successor": "python3.14",
-  "update-block": "2026-03-09"
+  "update-block": "2027-03-03"
  },
  "python3.8": {
-  "create-block": "2026-06-01",
+  "create-block": "2027-02-01",
   "deprecated": "2024-10-14",
   "successor": "python3.14",
-  "update-block": "2026-07-01"
+  "update-block": "2027-03-03"
  },
  "python3.9": {
-  "create-block": "2026-06-01",
+  "create-block": "2027-02-01",
   "deprecated": "2025-12-15",
   "successor": "python3.14",
-  "update-block": "2026-07-01"
+  "update-block": "2027-03-03"
  },
  "ruby2.5": {
   "create-block": "2021-07-30",
   "deprecated": "2021-07-30",
-  "successor": "ruby3.4",
+  "successor": "ruby4.0",
   "update-block": "2022-03-31"
  },
  "ruby2.7": {
   "create-block": "2024-01-09",
   "deprecated": "2023-12-07",
-  "successor": "ruby3.4",
-  "update-block": "2026-07-01"
+  "successor": "ruby4.0",
+  "update-block": "2027-03-03"
  },
  "ruby3.2": {
-  "create-block": "2026-06-01",
+  "create-block": "2027-02-01",
   "deprecated": "2026-03-31",
-  "successor": "ruby3.4",
-  "update-block": "2026-07-01"
+  "successor": "ruby4.0",
+  "update-block": "2027-03-03"
  },
  "ruby3.3": {
   "create-block": "2027-04-30",
   "deprecated": "2027-03-31",
-  "successor": "ruby3.4",
+  "successor": "ruby4.0",
   "update-block": "2027-05-31"
  },
  "ruby3.4": {
   "create-block": "2028-04-30",
   "deprecated": "2028-03-31",
-  "successor": null,
+  "successor": "ruby4.0",
   "update-block": "2028-05-31"
+ },
+ "ruby4.0": {
+  "create-block": "2029-04-30",
+  "deprecated": "2029-03-31",
+  "successor": null,
+  "update-block": "2029-05-31"
  }
 }

--- a/test/fixtures/results/integration/custom-resources.json
+++ b/test/fixtures/results/integration/custom-resources.json
@@ -1,7 +1,7 @@
 [
     {
         "Filename": "test/fixtures/templates/integration/custom-resources.yaml",
-        "Id": "1ef937c5-12bc-def9-c4fa-841c2ba96309",
+        "Id": "8beb84d0-7cba-9d1d-8455-7646435abda6",
         "Level": "Error",
         "Location": {
             "End": {
@@ -21,7 +21,7 @@
                 "LineNumber": 12
             }
         },
-        "Message": "'ArnA' is not one of ['Arn', 'KeyId'] in ['us-west-2']",
+        "Message": "'ArnA' is not one of ['Arn', 'KeyId'] in ['us-east-1']",
         "ParentId": null,
         "Rule": {
             "Description": "Validates that GetAtt parameters are to valid resources and properties of those resources",

--- a/test/fixtures/results/quickstart/cis_benchmark.json
+++ b/test/fixtures/results/quickstart/cis_benchmark.json
@@ -30,8 +30,8 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/cis_benchmark.yaml",
-        "Id": "e72922fb-2e43-5ff5-66c2-89f658d69f91",
-        "Level": "Error",
+        "Id": "5a65b948-e50c-80e9-4ffc-52bb4f27ee5a",
+        "Level": "Warning",
         "Location": {
             "End": {
                 "ColumnNumber": 16,
@@ -48,13 +48,13 @@
                 "LineNumber": 176
             }
         },
-        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2026-06-01' and update on '2026-07-01'. Please consider updating to 'python3.14'",
+        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2027-02-01' and update on '2027-03-03'. Please consider updating to 'python3.14'",
         "ParentId": null,
         "Rule": {
-            "Description": "Check the lambda runtime has reached the end of life",
-            "Id": "E2531",
-            "ShortDescription": "Validate if lambda runtime is deprecated",
-            "Source": "https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html"
+            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Id": "W2531",
+            "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
+            "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
         }
     },
     {
@@ -116,8 +116,8 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/cis_benchmark.yaml",
-        "Id": "b55917d9-21df-ba16-6c45-afafc8fd4225",
-        "Level": "Error",
+        "Id": "7fb9d895-5f49-a01c-e6e9-25e4fee97c87",
+        "Level": "Warning",
         "Location": {
             "End": {
                 "ColumnNumber": 16,
@@ -134,13 +134,13 @@
                 "LineNumber": 309
             }
         },
-        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2026-06-01' and update on '2026-07-01'. Please consider updating to 'python3.14'",
+        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2027-02-01' and update on '2027-03-03'. Please consider updating to 'python3.14'",
         "ParentId": null,
         "Rule": {
-            "Description": "Check the lambda runtime has reached the end of life",
-            "Id": "E2531",
-            "ShortDescription": "Validate if lambda runtime is deprecated",
-            "Source": "https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html"
+            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Id": "W2531",
+            "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
+            "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
         }
     },
     {
@@ -202,8 +202,8 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/cis_benchmark.yaml",
-        "Id": "253087c2-3a7b-2d20-09f6-8de9ac0d6a2f",
-        "Level": "Error",
+        "Id": "4e4de0b0-e381-7524-4d7d-c1d1a2b741c8",
+        "Level": "Warning",
         "Location": {
             "End": {
                 "ColumnNumber": 16,
@@ -220,13 +220,13 @@
                 "LineNumber": 481
             }
         },
-        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2026-06-01' and update on '2026-07-01'. Please consider updating to 'python3.14'",
+        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2027-02-01' and update on '2027-03-03'. Please consider updating to 'python3.14'",
         "ParentId": null,
         "Rule": {
-            "Description": "Check the lambda runtime has reached the end of life",
-            "Id": "E2531",
-            "ShortDescription": "Validate if lambda runtime is deprecated",
-            "Source": "https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html"
+            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Id": "W2531",
+            "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
+            "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
         }
     },
     {
@@ -288,8 +288,8 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/cis_benchmark.yaml",
-        "Id": "7e7799cb-63a5-cdd5-dc63-af619441c1d3",
-        "Level": "Error",
+        "Id": "ebda5c20-7112-d614-c39d-820b15110ea6",
+        "Level": "Warning",
         "Location": {
             "End": {
                 "ColumnNumber": 16,
@@ -306,13 +306,13 @@
                 "LineNumber": 551
             }
         },
-        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2026-06-01' and update on '2026-07-01'. Please consider updating to 'python3.14'",
+        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2027-02-01' and update on '2027-03-03'. Please consider updating to 'python3.14'",
         "ParentId": null,
         "Rule": {
-            "Description": "Check the lambda runtime has reached the end of life",
-            "Id": "E2531",
-            "ShortDescription": "Validate if lambda runtime is deprecated",
-            "Source": "https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html"
+            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Id": "W2531",
+            "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
+            "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
         }
     },
     {
@@ -432,8 +432,8 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/cis_benchmark.yaml",
-        "Id": "194e4194-1187-1b92-68ce-f8ee71d11771",
-        "Level": "Error",
+        "Id": "ca8cc9f0-3ce9-c795-4474-c9de70375b6e",
+        "Level": "Warning",
         "Location": {
             "End": {
                 "ColumnNumber": 16,
@@ -450,13 +450,13 @@
                 "LineNumber": 666
             }
         },
-        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2026-06-01' and update on '2026-07-01'. Please consider updating to 'python3.14'",
+        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2027-02-01' and update on '2027-03-03'. Please consider updating to 'python3.14'",
         "ParentId": null,
         "Rule": {
-            "Description": "Check the lambda runtime has reached the end of life",
-            "Id": "E2531",
-            "ShortDescription": "Validate if lambda runtime is deprecated",
-            "Source": "https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html"
+            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Id": "W2531",
+            "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
+            "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
         }
     },
     {
@@ -518,8 +518,8 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/cis_benchmark.yaml",
-        "Id": "57cce27c-d2fd-a7e3-58e0-c65de9aeea8f",
-        "Level": "Error",
+        "Id": "f1d09997-0daf-ae9b-2761-34c36aed1682",
+        "Level": "Warning",
         "Location": {
             "End": {
                 "ColumnNumber": 16,
@@ -536,13 +536,13 @@
                 "LineNumber": 760
             }
         },
-        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2026-06-01' and update on '2026-07-01'. Please consider updating to 'python3.14'",
+        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2027-02-01' and update on '2027-03-03'. Please consider updating to 'python3.14'",
         "ParentId": null,
         "Rule": {
-            "Description": "Check the lambda runtime has reached the end of life",
-            "Id": "E2531",
-            "ShortDescription": "Validate if lambda runtime is deprecated",
-            "Source": "https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html"
+            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Id": "W2531",
+            "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
+            "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
         }
     },
     {
@@ -633,8 +633,8 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/cis_benchmark.yaml",
-        "Id": "4dd8f31f-da51-3017-6923-40a3151c0468",
-        "Level": "Error",
+        "Id": "e60290e5-c3d9-07e4-8fc0-924508ebcee1",
+        "Level": "Warning",
         "Location": {
             "End": {
                 "ColumnNumber": 16,
@@ -651,13 +651,13 @@
                 "LineNumber": 850
             }
         },
-        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2026-06-01' and update on '2026-07-01'. Please consider updating to 'python3.14'",
+        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2027-02-01' and update on '2027-03-03'. Please consider updating to 'python3.14'",
         "ParentId": null,
         "Rule": {
-            "Description": "Check the lambda runtime has reached the end of life",
-            "Id": "E2531",
-            "ShortDescription": "Validate if lambda runtime is deprecated",
-            "Source": "https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html"
+            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Id": "W2531",
+            "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
+            "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
         }
     },
     {
@@ -748,8 +748,8 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/cis_benchmark.yaml",
-        "Id": "f5ac6da1-4ba4-12c5-6ead-113eaf4da1ba",
-        "Level": "Error",
+        "Id": "0cdc169e-554c-05af-8357-497b50a2e37b",
+        "Level": "Warning",
         "Location": {
             "End": {
                 "ColumnNumber": 16,
@@ -766,13 +766,13 @@
                 "LineNumber": 966
             }
         },
-        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2026-06-01' and update on '2026-07-01'. Please consider updating to 'python3.14'",
+        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2027-02-01' and update on '2027-03-03'. Please consider updating to 'python3.14'",
         "ParentId": null,
         "Rule": {
-            "Description": "Check the lambda runtime has reached the end of life",
-            "Id": "E2531",
-            "ShortDescription": "Validate if lambda runtime is deprecated",
-            "Source": "https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html"
+            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Id": "W2531",
+            "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
+            "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
         }
     },
     {
@@ -863,8 +863,8 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/cis_benchmark.yaml",
-        "Id": "0c6d284e-ca3f-d44c-5464-fd31c30a1802",
-        "Level": "Error",
+        "Id": "670a0c28-26d5-b0eb-68cb-8aec5718f22c",
+        "Level": "Warning",
         "Location": {
             "End": {
                 "ColumnNumber": 16,
@@ -881,13 +881,13 @@
                 "LineNumber": 1082
             }
         },
-        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2026-06-01' and update on '2026-07-01'. Please consider updating to 'python3.14'",
+        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2027-02-01' and update on '2027-03-03'. Please consider updating to 'python3.14'",
         "ParentId": null,
         "Rule": {
-            "Description": "Check the lambda runtime has reached the end of life",
-            "Id": "E2531",
-            "ShortDescription": "Validate if lambda runtime is deprecated",
-            "Source": "https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html"
+            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Id": "W2531",
+            "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
+            "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
         }
     },
     {
@@ -978,8 +978,8 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/cis_benchmark.yaml",
-        "Id": "481ea424-3844-5667-9094-c6f72a73a3a5",
-        "Level": "Error",
+        "Id": "3dea542b-c177-89e9-03e7-5d68ba5f25fc",
+        "Level": "Warning",
         "Location": {
             "End": {
                 "ColumnNumber": 16,
@@ -996,13 +996,13 @@
                 "LineNumber": 1178
             }
         },
-        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2026-06-01' and update on '2026-07-01'. Please consider updating to 'python3.14'",
+        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2027-02-01' and update on '2027-03-03'. Please consider updating to 'python3.14'",
         "ParentId": null,
         "Rule": {
-            "Description": "Check the lambda runtime has reached the end of life",
-            "Id": "E2531",
-            "ShortDescription": "Validate if lambda runtime is deprecated",
-            "Source": "https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html"
+            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Id": "W2531",
+            "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
+            "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
         }
     },
     {
@@ -1093,8 +1093,8 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/cis_benchmark.yaml",
-        "Id": "ec83566a-bf6f-870a-c807-d5f5fa6001d6",
-        "Level": "Error",
+        "Id": "fe2b95d2-2bb2-0530-587c-c4244ae576c2",
+        "Level": "Warning",
         "Location": {
             "End": {
                 "ColumnNumber": 16,
@@ -1111,13 +1111,13 @@
                 "LineNumber": 1260
             }
         },
-        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2026-06-01' and update on '2026-07-01'. Please consider updating to 'python3.14'",
+        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2027-02-01' and update on '2027-03-03'. Please consider updating to 'python3.14'",
         "ParentId": null,
         "Rule": {
-            "Description": "Check the lambda runtime has reached the end of life",
-            "Id": "E2531",
-            "ShortDescription": "Validate if lambda runtime is deprecated",
-            "Source": "https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html"
+            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Id": "W2531",
+            "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
+            "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
         }
     },
     {
@@ -1208,8 +1208,8 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/cis_benchmark.yaml",
-        "Id": "97b695f8-394d-513b-0c35-9185e72d439c",
-        "Level": "Error",
+        "Id": "02703fcb-8bbf-8e8f-3727-bf85632a2c76",
+        "Level": "Warning",
         "Location": {
             "End": {
                 "ColumnNumber": 16,
@@ -1226,13 +1226,13 @@
                 "LineNumber": 1357
             }
         },
-        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2026-06-01' and update on '2026-07-01'. Please consider updating to 'python3.14'",
+        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2027-02-01' and update on '2027-03-03'. Please consider updating to 'python3.14'",
         "ParentId": null,
         "Rule": {
-            "Description": "Check the lambda runtime has reached the end of life",
-            "Id": "E2531",
-            "ShortDescription": "Validate if lambda runtime is deprecated",
-            "Source": "https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html"
+            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Id": "W2531",
+            "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
+            "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
         }
     },
     {
@@ -1323,8 +1323,8 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/cis_benchmark.yaml",
-        "Id": "0067a724-40d8-aeae-ed87-0b9c7c150717",
-        "Level": "Error",
+        "Id": "cb5b1c2e-64ac-7532-7c6a-c24254f80c86",
+        "Level": "Warning",
         "Location": {
             "End": {
                 "ColumnNumber": 16,
@@ -1341,13 +1341,13 @@
                 "LineNumber": 1465
             }
         },
-        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2026-06-01' and update on '2026-07-01'. Please consider updating to 'python3.14'",
+        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2027-02-01' and update on '2027-03-03'. Please consider updating to 'python3.14'",
         "ParentId": null,
         "Rule": {
-            "Description": "Check the lambda runtime has reached the end of life",
-            "Id": "E2531",
-            "ShortDescription": "Validate if lambda runtime is deprecated",
-            "Source": "https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html"
+            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Id": "W2531",
+            "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
+            "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
         }
     },
     {
@@ -1409,8 +1409,8 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/cis_benchmark.yaml",
-        "Id": "a6e1576b-29b5-522f-0040-342559cf40f9",
-        "Level": "Error",
+        "Id": "86581c61-ad65-65b3-512c-7a881e324fa2",
+        "Level": "Warning",
         "Location": {
             "End": {
                 "ColumnNumber": 16,
@@ -1427,13 +1427,13 @@
                 "LineNumber": 1550
             }
         },
-        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2026-06-01' and update on '2026-07-01'. Please consider updating to 'python3.14'",
+        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2027-02-01' and update on '2027-03-03'. Please consider updating to 'python3.14'",
         "ParentId": null,
         "Rule": {
-            "Description": "Check the lambda runtime has reached the end of life",
-            "Id": "E2531",
-            "ShortDescription": "Validate if lambda runtime is deprecated",
-            "Source": "https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html"
+            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Id": "W2531",
+            "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
+            "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
         }
     },
     {
@@ -1523,8 +1523,8 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/cis_benchmark.yaml",
-        "Id": "486401d7-d428-1ca5-ac8e-780080e5b5c1",
-        "Level": "Error",
+        "Id": "e54ea23d-7e06-9cfc-6cb0-09bea7e402ed",
+        "Level": "Warning",
         "Location": {
             "End": {
                 "ColumnNumber": 16,
@@ -1541,13 +1541,13 @@
                 "LineNumber": 1633
             }
         },
-        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2026-06-01' and update on '2026-07-01'. Please consider updating to 'python3.14'",
+        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2027-02-01' and update on '2027-03-03'. Please consider updating to 'python3.14'",
         "ParentId": null,
         "Rule": {
-            "Description": "Check the lambda runtime has reached the end of life",
-            "Id": "E2531",
-            "ShortDescription": "Validate if lambda runtime is deprecated",
-            "Source": "https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html"
+            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Id": "W2531",
+            "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
+            "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
         }
     },
     {
@@ -1966,8 +1966,8 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/cis_benchmark.yaml",
-        "Id": "5f8eb2d3-13a5-9564-75ab-44f8bb8b327a",
-        "Level": "Error",
+        "Id": "55db5449-3d01-c32f-2f13-2842ea9c8fe1",
+        "Level": "Warning",
         "Location": {
             "End": {
                 "ColumnNumber": 16,
@@ -1984,13 +1984,13 @@
                 "LineNumber": 1889
             }
         },
-        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2026-06-01' and update on '2026-07-01'. Please consider updating to 'python3.14'",
+        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2027-02-01' and update on '2027-03-03'. Please consider updating to 'python3.14'",
         "ParentId": null,
         "Rule": {
-            "Description": "Check the lambda runtime has reached the end of life",
-            "Id": "E2531",
-            "ShortDescription": "Validate if lambda runtime is deprecated",
-            "Source": "https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html"
+            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Id": "W2531",
+            "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
+            "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
         }
     },
     {
@@ -2112,8 +2112,8 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/cis_benchmark.yaml",
-        "Id": "11757704-6a62-c597-8f5d-022cd1dff615",
-        "Level": "Error",
+        "Id": "baf5cbbd-e551-22d7-6372-c4f4ed574669",
+        "Level": "Warning",
         "Location": {
             "End": {
                 "ColumnNumber": 16,
@@ -2130,13 +2130,13 @@
                 "LineNumber": 2334
             }
         },
-        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2026-06-01' and update on '2026-07-01'. Please consider updating to 'python3.14'",
+        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2027-02-01' and update on '2027-03-03'. Please consider updating to 'python3.14'",
         "ParentId": null,
         "Rule": {
-            "Description": "Check the lambda runtime has reached the end of life",
-            "Id": "E2531",
-            "ShortDescription": "Validate if lambda runtime is deprecated",
-            "Source": "https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html"
+            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Id": "W2531",
+            "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
+            "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
         }
     },
     {

--- a/test/fixtures/results/quickstart/non_strict/cis_benchmark.json
+++ b/test/fixtures/results/quickstart/non_strict/cis_benchmark.json
@@ -30,8 +30,8 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/cis_benchmark.yaml",
-        "Id": "e72922fb-2e43-5ff5-66c2-89f658d69f91",
-        "Level": "Error",
+        "Id": "5a65b948-e50c-80e9-4ffc-52bb4f27ee5a",
+        "Level": "Warning",
         "Location": {
             "End": {
                 "ColumnNumber": 16,
@@ -48,13 +48,13 @@
                 "LineNumber": 176
             }
         },
-        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2026-06-01' and update on '2026-07-01'. Please consider updating to 'python3.14'",
+        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2027-02-01' and update on '2027-03-03'. Please consider updating to 'python3.14'",
         "ParentId": null,
         "Rule": {
-            "Description": "Check the lambda runtime has reached the end of life",
-            "Id": "E2531",
-            "ShortDescription": "Validate if lambda runtime is deprecated",
-            "Source": "https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html"
+            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Id": "W2531",
+            "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
+            "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
         }
     },
     {
@@ -116,8 +116,8 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/cis_benchmark.yaml",
-        "Id": "b55917d9-21df-ba16-6c45-afafc8fd4225",
-        "Level": "Error",
+        "Id": "7fb9d895-5f49-a01c-e6e9-25e4fee97c87",
+        "Level": "Warning",
         "Location": {
             "End": {
                 "ColumnNumber": 16,
@@ -134,13 +134,13 @@
                 "LineNumber": 309
             }
         },
-        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2026-06-01' and update on '2026-07-01'. Please consider updating to 'python3.14'",
+        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2027-02-01' and update on '2027-03-03'. Please consider updating to 'python3.14'",
         "ParentId": null,
         "Rule": {
-            "Description": "Check the lambda runtime has reached the end of life",
-            "Id": "E2531",
-            "ShortDescription": "Validate if lambda runtime is deprecated",
-            "Source": "https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html"
+            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Id": "W2531",
+            "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
+            "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
         }
     },
     {
@@ -202,8 +202,8 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/cis_benchmark.yaml",
-        "Id": "253087c2-3a7b-2d20-09f6-8de9ac0d6a2f",
-        "Level": "Error",
+        "Id": "4e4de0b0-e381-7524-4d7d-c1d1a2b741c8",
+        "Level": "Warning",
         "Location": {
             "End": {
                 "ColumnNumber": 16,
@@ -220,13 +220,13 @@
                 "LineNumber": 481
             }
         },
-        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2026-06-01' and update on '2026-07-01'. Please consider updating to 'python3.14'",
+        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2027-02-01' and update on '2027-03-03'. Please consider updating to 'python3.14'",
         "ParentId": null,
         "Rule": {
-            "Description": "Check the lambda runtime has reached the end of life",
-            "Id": "E2531",
-            "ShortDescription": "Validate if lambda runtime is deprecated",
-            "Source": "https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html"
+            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Id": "W2531",
+            "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
+            "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
         }
     },
     {
@@ -288,8 +288,8 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/cis_benchmark.yaml",
-        "Id": "7e7799cb-63a5-cdd5-dc63-af619441c1d3",
-        "Level": "Error",
+        "Id": "ebda5c20-7112-d614-c39d-820b15110ea6",
+        "Level": "Warning",
         "Location": {
             "End": {
                 "ColumnNumber": 16,
@@ -306,13 +306,13 @@
                 "LineNumber": 551
             }
         },
-        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2026-06-01' and update on '2026-07-01'. Please consider updating to 'python3.14'",
+        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2027-02-01' and update on '2027-03-03'. Please consider updating to 'python3.14'",
         "ParentId": null,
         "Rule": {
-            "Description": "Check the lambda runtime has reached the end of life",
-            "Id": "E2531",
-            "ShortDescription": "Validate if lambda runtime is deprecated",
-            "Source": "https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html"
+            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Id": "W2531",
+            "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
+            "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
         }
     },
     {
@@ -432,8 +432,8 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/cis_benchmark.yaml",
-        "Id": "194e4194-1187-1b92-68ce-f8ee71d11771",
-        "Level": "Error",
+        "Id": "ca8cc9f0-3ce9-c795-4474-c9de70375b6e",
+        "Level": "Warning",
         "Location": {
             "End": {
                 "ColumnNumber": 16,
@@ -450,13 +450,13 @@
                 "LineNumber": 666
             }
         },
-        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2026-06-01' and update on '2026-07-01'. Please consider updating to 'python3.14'",
+        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2027-02-01' and update on '2027-03-03'. Please consider updating to 'python3.14'",
         "ParentId": null,
         "Rule": {
-            "Description": "Check the lambda runtime has reached the end of life",
-            "Id": "E2531",
-            "ShortDescription": "Validate if lambda runtime is deprecated",
-            "Source": "https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html"
+            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Id": "W2531",
+            "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
+            "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
         }
     },
     {
@@ -518,8 +518,8 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/cis_benchmark.yaml",
-        "Id": "57cce27c-d2fd-a7e3-58e0-c65de9aeea8f",
-        "Level": "Error",
+        "Id": "f1d09997-0daf-ae9b-2761-34c36aed1682",
+        "Level": "Warning",
         "Location": {
             "End": {
                 "ColumnNumber": 16,
@@ -536,13 +536,13 @@
                 "LineNumber": 760
             }
         },
-        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2026-06-01' and update on '2026-07-01'. Please consider updating to 'python3.14'",
+        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2027-02-01' and update on '2027-03-03'. Please consider updating to 'python3.14'",
         "ParentId": null,
         "Rule": {
-            "Description": "Check the lambda runtime has reached the end of life",
-            "Id": "E2531",
-            "ShortDescription": "Validate if lambda runtime is deprecated",
-            "Source": "https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html"
+            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Id": "W2531",
+            "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
+            "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
         }
     },
     {
@@ -633,8 +633,8 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/cis_benchmark.yaml",
-        "Id": "4dd8f31f-da51-3017-6923-40a3151c0468",
-        "Level": "Error",
+        "Id": "e60290e5-c3d9-07e4-8fc0-924508ebcee1",
+        "Level": "Warning",
         "Location": {
             "End": {
                 "ColumnNumber": 16,
@@ -651,13 +651,13 @@
                 "LineNumber": 850
             }
         },
-        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2026-06-01' and update on '2026-07-01'. Please consider updating to 'python3.14'",
+        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2027-02-01' and update on '2027-03-03'. Please consider updating to 'python3.14'",
         "ParentId": null,
         "Rule": {
-            "Description": "Check the lambda runtime has reached the end of life",
-            "Id": "E2531",
-            "ShortDescription": "Validate if lambda runtime is deprecated",
-            "Source": "https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html"
+            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Id": "W2531",
+            "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
+            "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
         }
     },
     {
@@ -748,8 +748,8 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/cis_benchmark.yaml",
-        "Id": "f5ac6da1-4ba4-12c5-6ead-113eaf4da1ba",
-        "Level": "Error",
+        "Id": "0cdc169e-554c-05af-8357-497b50a2e37b",
+        "Level": "Warning",
         "Location": {
             "End": {
                 "ColumnNumber": 16,
@@ -766,13 +766,13 @@
                 "LineNumber": 966
             }
         },
-        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2026-06-01' and update on '2026-07-01'. Please consider updating to 'python3.14'",
+        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2027-02-01' and update on '2027-03-03'. Please consider updating to 'python3.14'",
         "ParentId": null,
         "Rule": {
-            "Description": "Check the lambda runtime has reached the end of life",
-            "Id": "E2531",
-            "ShortDescription": "Validate if lambda runtime is deprecated",
-            "Source": "https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html"
+            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Id": "W2531",
+            "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
+            "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
         }
     },
     {
@@ -863,8 +863,8 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/cis_benchmark.yaml",
-        "Id": "0c6d284e-ca3f-d44c-5464-fd31c30a1802",
-        "Level": "Error",
+        "Id": "670a0c28-26d5-b0eb-68cb-8aec5718f22c",
+        "Level": "Warning",
         "Location": {
             "End": {
                 "ColumnNumber": 16,
@@ -881,13 +881,13 @@
                 "LineNumber": 1082
             }
         },
-        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2026-06-01' and update on '2026-07-01'. Please consider updating to 'python3.14'",
+        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2027-02-01' and update on '2027-03-03'. Please consider updating to 'python3.14'",
         "ParentId": null,
         "Rule": {
-            "Description": "Check the lambda runtime has reached the end of life",
-            "Id": "E2531",
-            "ShortDescription": "Validate if lambda runtime is deprecated",
-            "Source": "https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html"
+            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Id": "W2531",
+            "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
+            "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
         }
     },
     {
@@ -978,8 +978,8 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/cis_benchmark.yaml",
-        "Id": "481ea424-3844-5667-9094-c6f72a73a3a5",
-        "Level": "Error",
+        "Id": "3dea542b-c177-89e9-03e7-5d68ba5f25fc",
+        "Level": "Warning",
         "Location": {
             "End": {
                 "ColumnNumber": 16,
@@ -996,13 +996,13 @@
                 "LineNumber": 1178
             }
         },
-        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2026-06-01' and update on '2026-07-01'. Please consider updating to 'python3.14'",
+        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2027-02-01' and update on '2027-03-03'. Please consider updating to 'python3.14'",
         "ParentId": null,
         "Rule": {
-            "Description": "Check the lambda runtime has reached the end of life",
-            "Id": "E2531",
-            "ShortDescription": "Validate if lambda runtime is deprecated",
-            "Source": "https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html"
+            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Id": "W2531",
+            "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
+            "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
         }
     },
     {
@@ -1093,8 +1093,8 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/cis_benchmark.yaml",
-        "Id": "ec83566a-bf6f-870a-c807-d5f5fa6001d6",
-        "Level": "Error",
+        "Id": "fe2b95d2-2bb2-0530-587c-c4244ae576c2",
+        "Level": "Warning",
         "Location": {
             "End": {
                 "ColumnNumber": 16,
@@ -1111,13 +1111,13 @@
                 "LineNumber": 1260
             }
         },
-        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2026-06-01' and update on '2026-07-01'. Please consider updating to 'python3.14'",
+        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2027-02-01' and update on '2027-03-03'. Please consider updating to 'python3.14'",
         "ParentId": null,
         "Rule": {
-            "Description": "Check the lambda runtime has reached the end of life",
-            "Id": "E2531",
-            "ShortDescription": "Validate if lambda runtime is deprecated",
-            "Source": "https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html"
+            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Id": "W2531",
+            "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
+            "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
         }
     },
     {
@@ -1208,8 +1208,8 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/cis_benchmark.yaml",
-        "Id": "97b695f8-394d-513b-0c35-9185e72d439c",
-        "Level": "Error",
+        "Id": "02703fcb-8bbf-8e8f-3727-bf85632a2c76",
+        "Level": "Warning",
         "Location": {
             "End": {
                 "ColumnNumber": 16,
@@ -1226,13 +1226,13 @@
                 "LineNumber": 1357
             }
         },
-        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2026-06-01' and update on '2026-07-01'. Please consider updating to 'python3.14'",
+        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2027-02-01' and update on '2027-03-03'. Please consider updating to 'python3.14'",
         "ParentId": null,
         "Rule": {
-            "Description": "Check the lambda runtime has reached the end of life",
-            "Id": "E2531",
-            "ShortDescription": "Validate if lambda runtime is deprecated",
-            "Source": "https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html"
+            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Id": "W2531",
+            "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
+            "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
         }
     },
     {
@@ -1323,8 +1323,8 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/cis_benchmark.yaml",
-        "Id": "0067a724-40d8-aeae-ed87-0b9c7c150717",
-        "Level": "Error",
+        "Id": "cb5b1c2e-64ac-7532-7c6a-c24254f80c86",
+        "Level": "Warning",
         "Location": {
             "End": {
                 "ColumnNumber": 16,
@@ -1341,13 +1341,13 @@
                 "LineNumber": 1465
             }
         },
-        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2026-06-01' and update on '2026-07-01'. Please consider updating to 'python3.14'",
+        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2027-02-01' and update on '2027-03-03'. Please consider updating to 'python3.14'",
         "ParentId": null,
         "Rule": {
-            "Description": "Check the lambda runtime has reached the end of life",
-            "Id": "E2531",
-            "ShortDescription": "Validate if lambda runtime is deprecated",
-            "Source": "https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html"
+            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Id": "W2531",
+            "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
+            "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
         }
     },
     {
@@ -1409,8 +1409,8 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/cis_benchmark.yaml",
-        "Id": "a6e1576b-29b5-522f-0040-342559cf40f9",
-        "Level": "Error",
+        "Id": "86581c61-ad65-65b3-512c-7a881e324fa2",
+        "Level": "Warning",
         "Location": {
             "End": {
                 "ColumnNumber": 16,
@@ -1427,13 +1427,13 @@
                 "LineNumber": 1550
             }
         },
-        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2026-06-01' and update on '2026-07-01'. Please consider updating to 'python3.14'",
+        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2027-02-01' and update on '2027-03-03'. Please consider updating to 'python3.14'",
         "ParentId": null,
         "Rule": {
-            "Description": "Check the lambda runtime has reached the end of life",
-            "Id": "E2531",
-            "ShortDescription": "Validate if lambda runtime is deprecated",
-            "Source": "https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html"
+            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Id": "W2531",
+            "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
+            "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
         }
     },
     {
@@ -1523,8 +1523,8 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/cis_benchmark.yaml",
-        "Id": "486401d7-d428-1ca5-ac8e-780080e5b5c1",
-        "Level": "Error",
+        "Id": "e54ea23d-7e06-9cfc-6cb0-09bea7e402ed",
+        "Level": "Warning",
         "Location": {
             "End": {
                 "ColumnNumber": 16,
@@ -1541,13 +1541,13 @@
                 "LineNumber": 1633
             }
         },
-        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2026-06-01' and update on '2026-07-01'. Please consider updating to 'python3.14'",
+        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2027-02-01' and update on '2027-03-03'. Please consider updating to 'python3.14'",
         "ParentId": null,
         "Rule": {
-            "Description": "Check the lambda runtime has reached the end of life",
-            "Id": "E2531",
-            "ShortDescription": "Validate if lambda runtime is deprecated",
-            "Source": "https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html"
+            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Id": "W2531",
+            "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
+            "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
         }
     },
     {
@@ -1811,8 +1811,8 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/cis_benchmark.yaml",
-        "Id": "5f8eb2d3-13a5-9564-75ab-44f8bb8b327a",
-        "Level": "Error",
+        "Id": "55db5449-3d01-c32f-2f13-2842ea9c8fe1",
+        "Level": "Warning",
         "Location": {
             "End": {
                 "ColumnNumber": 16,
@@ -1829,13 +1829,13 @@
                 "LineNumber": 1889
             }
         },
-        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2026-06-01' and update on '2026-07-01'. Please consider updating to 'python3.14'",
+        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2027-02-01' and update on '2027-03-03'. Please consider updating to 'python3.14'",
         "ParentId": null,
         "Rule": {
-            "Description": "Check the lambda runtime has reached the end of life",
-            "Id": "E2531",
-            "ShortDescription": "Validate if lambda runtime is deprecated",
-            "Source": "https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html"
+            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Id": "W2531",
+            "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
+            "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
         }
     },
     {
@@ -1926,8 +1926,8 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/cis_benchmark.yaml",
-        "Id": "11757704-6a62-c597-8f5d-022cd1dff615",
-        "Level": "Error",
+        "Id": "baf5cbbd-e551-22d7-6372-c4f4ed574669",
+        "Level": "Warning",
         "Location": {
             "End": {
                 "ColumnNumber": 16,
@@ -1944,13 +1944,13 @@
                 "LineNumber": 2334
             }
         },
-        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2026-06-01' and update on '2026-07-01'. Please consider updating to 'python3.14'",
+        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2027-02-01' and update on '2027-03-03'. Please consider updating to 'python3.14'",
         "ParentId": null,
         "Rule": {
-            "Description": "Check the lambda runtime has reached the end of life",
-            "Id": "E2531",
-            "ShortDescription": "Validate if lambda runtime is deprecated",
-            "Source": "https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html"
+            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Id": "W2531",
+            "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
+            "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
         }
     },
     {

--- a/test/fixtures/results/quickstart/non_strict/openshift.json
+++ b/test/fixtures/results/quickstart/non_strict/openshift.json
@@ -337,8 +337,8 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/openshift.yaml",
-        "Id": "ffdf37ec-2a7b-b9b9-a978-2acd3eda1589",
-        "Level": "Error",
+        "Id": "f58b0617-c381-c514-3383-32c1a1740546",
+        "Level": "Warning",
         "Location": {
             "End": {
                 "ColumnNumber": 14,
@@ -355,13 +355,13 @@
                 "LineNumber": 810
             }
         },
-        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2026-06-01' and update on '2026-07-01'. Please consider updating to 'python3.14'",
+        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2027-02-01' and update on '2027-03-03'. Please consider updating to 'python3.14'",
         "ParentId": null,
         "Rule": {
-            "Description": "Check the lambda runtime has reached the end of life",
-            "Id": "E2531",
-            "ShortDescription": "Validate if lambda runtime is deprecated",
-            "Source": "https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html"
+            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Id": "W2531",
+            "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
+            "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
         }
     },
     {

--- a/test/fixtures/results/quickstart/openshift.json
+++ b/test/fixtures/results/quickstart/openshift.json
@@ -399,8 +399,8 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/openshift.yaml",
-        "Id": "ffdf37ec-2a7b-b9b9-a978-2acd3eda1589",
-        "Level": "Error",
+        "Id": "f58b0617-c381-c514-3383-32c1a1740546",
+        "Level": "Warning",
         "Location": {
             "End": {
                 "ColumnNumber": 14,
@@ -417,13 +417,13 @@
                 "LineNumber": 810
             }
         },
-        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2026-06-01' and update on '2026-07-01'. Please consider updating to 'python3.14'",
+        "Message": "Runtime 'python3.8' was deprecated on '2024-10-14'. Creation was disabled on '2027-02-01' and update on '2027-03-03'. Please consider updating to 'python3.14'",
         "ParentId": null,
         "Rule": {
-            "Description": "Check the lambda runtime has reached the end of life",
-            "Id": "E2531",
-            "ShortDescription": "Validate if lambda runtime is deprecated",
-            "Source": "https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html"
+            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Id": "W2531",
+            "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
+            "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
         }
     },
     {

--- a/test/integration/test_quickstart_templates_non_strict.py
+++ b/test/integration/test_quickstart_templates_non_strict.py
@@ -31,14 +31,14 @@ class TestQuickStartTemplates(BaseCliTestCase):
             "results_filename": (
                 "test/fixtures/results/quickstart/non_strict/openshift.json"
             ),
-            "exit_code": 14,
+            "exit_code": 12,
         },
         {
             "filename": "test/fixtures/templates/quickstart/cis_benchmark.yaml",
             "results_filename": (
                 "test/fixtures/results/quickstart/non_strict/cis_benchmark.json"
             ),
-            "exit_code": 6,
+            "exit_code": 4,
         },
     ]
 

--- a/test/unit/rules/resources/lmbd/test_deprecated_runtime_create.py
+++ b/test/unit/rules/resources/lmbd/test_deprecated_runtime_create.py
@@ -43,7 +43,7 @@ def rule():
                 ValidationError(
                     "Runtime 'python3.7' was deprecated on "
                     "'2023-12-04'. Creation was disabled on "
-                    "'2024-01-09' and update on '2026-03-09'. "
+                    "'2024-01-09' and update on '2027-03-03'. "
                     "Please consider updating to 'python3.14'",
                 )
             ],
@@ -51,7 +51,7 @@ def rule():
         (
             # will be caught by the update rule
             "python3.7",
-            datetime(2026, 3, 10),
+            datetime(2027, 3, 4),
             [],
         ),
         (

--- a/test/unit/rules/resources/lmbd/test_deprecated_runtime_eol.py
+++ b/test/unit/rules/resources/lmbd/test_deprecated_runtime_eol.py
@@ -43,7 +43,7 @@ def rule():
                 ValidationError(
                     "Runtime 'python3.7' was deprecated on "
                     "'2023-12-04'. Creation was disabled on "
-                    "'2024-01-09' and update on '2026-03-09'. "
+                    "'2024-01-09' and update on '2027-03-03'. "
                     "Please consider updating to 'python3.14'",
                 )
             ],

--- a/test/unit/rules/resources/lmbd/test_deprecated_runtime_update.py
+++ b/test/unit/rules/resources/lmbd/test_deprecated_runtime_update.py
@@ -38,12 +38,12 @@ def rule():
         ),
         (
             "python3.7",
-            datetime(2026, 3, 10),
+            datetime(2027, 3, 3),
             [
                 ValidationError(
                     "Runtime 'python3.7' was deprecated on "
                     "'2023-12-04'. Creation was disabled on "
-                    "'2024-01-09' and update on '2026-03-09'. "
+                    "'2024-01-09' and update on '2027-03-03'. "
                     "Please consider updating to 'python3.14'",
                 )
             ],


### PR DESCRIPTION
## Summary
- Updated all Lambda runtime deprecation/create-block/update-block dates to match current [AWS documentation](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html)
- AWS extended many deadlines significantly (many create-block/update-block dates pushed to 2027-02-01/2027-03-03)
- java11, java17, java8.al2, python3.11 got a full year extension
- Added new runtimes: dotnet9, dotnet10, ruby4.0
- Updated successor recommendations: .NET → dotnet10, Ruby → ruby4.0

Fixes #4531

## Test plan
- All unit tests for deprecated runtime rules pass
- Integration test fixtures regenerated to reflect new rule behavior (E2531 → W2531 for python3.8 since create-block moved to future)