### PR TITLE
fix: E3042 false positive when Essential is omitted from ECS containers

### DIFF
--- a/src/cfnlint/data/schemas/extensions/aws_ecs_taskdefinition/containerdefinitions_essential.json
+++ b/src/cfnlint/data/schemas/extensions/aws_ecs_taskdefinition/containerdefinitions_essential.json
@@ -1,24 +1,19 @@
 {
  "contains": {
-  "properties": {
-   "Essential": {
-    "oneOf": [
-     {
-      "enum": [
-       true,
-       "true",
-       "True"
-      ]
-     },
-     {
-      "type": "object"
-     }
-    ]
-   }
-  },
-  "required": [
-   "Essential"
-  ]
+  "not": {
+   "properties": {
+    "Essential": {
+     "enum": [
+      false,
+      "false",
+      "False"
+     ]
+    }
+   },
+   "required": [
+    "Essential"
+   ]
+  }
  },
  "minItems": 1
 }

--- a/test/fixtures/results/integration/cfn-gather.json
+++ b/test/fixtures/results/integration/cfn-gather.json
@@ -30,64 +30,6 @@
     },
     {
         "Filename": "test/fixtures/templates/integration/cfn-gather.yaml",
-        "Id": "acc87818-2ac9-fe6f-e0d3-e3569b26a50e",
-        "Level": "Error",
-        "Location": {
-            "End": {
-                "ColumnNumber": 27,
-                "LineNumber": 10
-            },
-            "Path": [
-                "Resources",
-                "TaskDef",
-                "Properties",
-                "ContainerDefinitions"
-            ],
-            "Start": {
-                "ColumnNumber": 7,
-                "LineNumber": 10
-            }
-        },
-        "Message": "At least one essential container is required",
-        "ParentId": null,
-        "Rule": {
-            "Description": "Check that every TaskDefinition specifies at least one essential container",
-            "Id": "E3042",
-            "ShortDescription": "Validate at least one essential container is specified",
-            "Source": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-containerdefinitions.html#cfn-ecs-taskdefinition-containerdefinition-essential"
-        }
-    },
-    {
-        "Filename": "test/fixtures/templates/integration/cfn-gather.yaml",
-        "Id": "a77ded42-cbf9-f285-c9dd-2fd6e16939fa",
-        "Level": "Error",
-        "Location": {
-            "End": {
-                "ColumnNumber": 27,
-                "LineNumber": 28
-            },
-            "Path": [
-                "Resources",
-                "AwsvpcTaskDef",
-                "Properties",
-                "ContainerDefinitions"
-            ],
-            "Start": {
-                "ColumnNumber": 7,
-                "LineNumber": 28
-            }
-        },
-        "Message": "At least one essential container is required",
-        "ParentId": null,
-        "Rule": {
-            "Description": "Check that every TaskDefinition specifies at least one essential container",
-            "Id": "E3042",
-            "ShortDescription": "Validate at least one essential container is specified",
-            "Source": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-containerdefinitions.html#cfn-ecs-taskdefinition-containerdefinition-essential"
-        }
-    },
-    {
-        "Filename": "test/fixtures/templates/integration/cfn-gather.yaml",
         "Id": "6a91d17b-fc37-91bb-e56c-14d1a635901c",
         "Level": "Error",
         "Location": {

--- a/test/fixtures/results/integration/getatt-types.json
+++ b/test/fixtures/results/integration/getatt-types.json
@@ -31,35 +31,6 @@
     },
     {
         "Filename": "test/fixtures/templates/integration/getatt-types.yaml",
-        "Id": "13ff56be-c12a-6f3e-5920-5b39a4261c50",
-        "Level": "Error",
-        "Location": {
-            "End": {
-                "ColumnNumber": 27,
-                "LineNumber": 57
-            },
-            "Path": [
-                "Resources",
-                "TestTaskDefinitionWithGetAtt",
-                "Properties",
-                "ContainerDefinitions"
-            ],
-            "Start": {
-                "ColumnNumber": 7,
-                "LineNumber": 57
-            }
-        },
-        "Message": "At least one essential container is required",
-        "ParentId": null,
-        "Rule": {
-            "Description": "Check that every TaskDefinition specifies at least one essential container",
-            "Id": "E3042",
-            "ShortDescription": "Validate at least one essential container is specified",
-            "Source": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-containerdefinitions.html#cfn-ecs-taskdefinition-containerdefinition-essential"
-        }
-    },
-    {
-        "Filename": "test/fixtures/templates/integration/getatt-types.yaml",
         "Id": "16620b40-6f3e-69eb-874f-34b5f51cedee",
         "Level": "Error",
         "Location": {

--- a/test/fixtures/results/integration/ref-types.json
+++ b/test/fixtures/results/integration/ref-types.json
@@ -30,64 +30,6 @@
     },
     {
         "Filename": "test/fixtures/templates/integration/ref-types.yaml",
-        "Id": "92bca04d-77b2-5585-7f87-4eafcf1a04e8",
-        "Level": "Error",
-        "Location": {
-            "End": {
-                "ColumnNumber": 27,
-                "LineNumber": 72
-            },
-            "Path": [
-                "Resources",
-                "TaskDefinitionWithRefToResource",
-                "Properties",
-                "ContainerDefinitions"
-            ],
-            "Start": {
-                "ColumnNumber": 7,
-                "LineNumber": 72
-            }
-        },
-        "Message": "At least one essential container is required",
-        "ParentId": null,
-        "Rule": {
-            "Description": "Check that every TaskDefinition specifies at least one essential container",
-            "Id": "E3042",
-            "ShortDescription": "Validate at least one essential container is specified",
-            "Source": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-containerdefinitions.html#cfn-ecs-taskdefinition-containerdefinition-essential"
-        }
-    },
-    {
-        "Filename": "test/fixtures/templates/integration/ref-types.yaml",
-        "Id": "e8ace095-2267-fcb9-0f63-98c085e5c3a3",
-        "Level": "Error",
-        "Location": {
-            "End": {
-                "ColumnNumber": 27,
-                "LineNumber": 93
-            },
-            "Path": [
-                "Resources",
-                "TaskDefinitionWithRefToParameter",
-                "Properties",
-                "ContainerDefinitions"
-            ],
-            "Start": {
-                "ColumnNumber": 7,
-                "LineNumber": 93
-            }
-        },
-        "Message": "At least one essential container is required",
-        "ParentId": null,
-        "Rule": {
-            "Description": "Check that every TaskDefinition specifies at least one essential container",
-            "Id": "E3042",
-            "ShortDescription": "Validate at least one essential container is specified",
-            "Source": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-containerdefinitions.html#cfn-ecs-taskdefinition-containerdefinition-essential"
-        }
-    },
-    {
-        "Filename": "test/fixtures/templates/integration/ref-types.yaml",
         "Id": "29af1a18-2b97-bb15-35f6-b5be8c36a2a7",
         "Level": "Warning",
         "Location": {

--- a/test/unit/rules/resources/ecs/test_task_definition_essentials.py
+++ b/test/unit/rules/resources/ecs/test_task_definition_essentials.py
@@ -19,6 +19,11 @@ def rule():
     yield rule
 
 
+# Scenarios validated against CloudFormation/ECS on 2026-06-03:
+# - 1 container, no Essential: succeeds (defaults to true)
+# - 2 containers, no Essential: succeeds (both default to true)
+# - 1 Essential:false + 1 no Essential: succeeds (second defaults to true)
+# - All containers Essential:false: fails ("doesn't have any essential container")
 @pytest.mark.parametrize(
     "instance,expected",
     [
@@ -39,7 +44,31 @@ def rule():
             [],
         ),
         (
+            [{"Name": "container"}],  # validated
+            [],
+        ),
+        (
+            [{"Name": "container-one"}, {"Name": "container-two"}],  # validated
+            [],
+        ),
+        (
+            [{"Essential": False}, {"Name": "main"}],  # validated
+            [],
+        ),
+        (
             [{"Essential": False}],
+            [
+                ValidationError(
+                    "At least one essential container is required",
+                    rule=TaskDefinitionEssentialContainer(),
+                    path=deque([]),
+                    validator="contains",
+                    schema_path=deque(["contains"]),
+                )
+            ],
+        ),
+        (
+            [{"Essential": False}, {"Essential": False}],
             [
                 ValidationError(
                     "At least one essential container is required",


### PR DESCRIPTION
## Summary
- Fixes false positive E3042 when `Essential` is not specified in ECS TaskDefinition container definitions
- Per ECS API, omitting `Essential` defaults to `true` — the rule should only error when ALL containers explicitly set `Essential: false`
- Inverted schema logic from "must contain one with Essential=true" to "must contain one that is NOT Essential=false"

## Validated against CloudFormation/ECS (2026-06-03)
- 1 container, no Essential → succeeds (defaults to true)
- 2 containers, no Essential → succeeds (both default to true)  
- 1 Essential:false + 1 no Essential → succeeds (second defaults to true)
- All containers Essential:false → fails ("doesn't have any essential container")

Fixes #4535