### PR TITLE
fix: Allow decimal values in Logs MetricFilter MetricValue pattern

### DIFF
--- a/src/cfnlint/data/schemas/patches/extensions/all/aws_logs_metricfilter/manual.json
+++ b/src/cfnlint/data/schemas/patches/extensions/all/aws_logs_metricfilter/manual.json
@@ -2,6 +2,6 @@
  {
   "op": "add",
   "path": "/definitions/MetricTransformation/properties/MetricValue/pattern",
-  "value": "^(([0-9]*)|(\\$.*))$"
+  "value": "^(([0-9]*\\.?[0-9]*)|(\\$.*))$"
  }
 ]

--- a/src/cfnlint/data/schemas/resources/4b4400caff5cc44e.json
+++ b/src/cfnlint/data/schemas/resources/4b4400caff5cc44e.json
@@ -57,7 +57,7 @@
     "MetricValue": {
      "maxLength": 100,
      "minLength": 1,
-     "pattern": "^(([0-9]*)|(\\$.*))$",
+     "pattern": "^(([0-9]*\\.?[0-9]*)|(\\$.*))$",
      "type": "string"
     },
     "Unit": {


### PR DESCRIPTION
## Summary

  - The MetricValue pattern `^(([0-9]*)|(\$.*))$` only accepted integers and `$` references
  - CloudFormation accepts decimal values (confirmed by deploying templates with `MetricValue: "1.0"` and `"1.5"`)
  - Updated pattern to `^(([0-9]*\.?[0-9]*)|(\$.*))$` to allow decimals

  ## Test plan

  - [x] Deployed MetricFilter with `MetricValue: "1.0"` — succeeded
  - [x] Deployed MetricFilter with `MetricValue: "1.5"` — succeeded
  - [x] Verified `cfn-lint --patch-specs` does not revert the fix