### PR TITLE
fix: Make EC2::TrafficMirrorFilterRule TrafficDirection case-insensitive

### DIFF
--- a/scripts/smithy/update_schemas_from_smithy.py
+++ b/scripts/smithy/update_schemas_from_smithy.py
@@ -35,6 +35,7 @@ case_insensitive_resources = [
     "AWS::EC2::IPAMPool",
     "AWS::EC2::NetworkAcl",
     "AWS::EC2::SecurityGroup",
+    "AWS::EC2::TrafficMirrorFilterRule",
     "AWS::EC2::Volume",
     "AWS::ElastiCache::",
     "AWS::Route53Resolver::",

--- a/src/cfnlint/data/schemas/patches/extensions/all/aws_ec2_trafficmirrorfilterrule/smithy.json
+++ b/src/cfnlint/data/schemas/patches/extensions/all/aws_ec2_trafficmirrorfilterrule/smithy.json
@@ -1,7 +1,7 @@
 [
  {
   "op": "add",
-  "path": "/definitions/TrafficDirection/enum",
+  "path": "/definitions/TrafficDirection/enumCaseInsensitive",
   "value": [
    "egress",
    "ingress"
@@ -9,7 +9,7 @@
  },
  {
   "op": "add",
-  "path": "/definitions/TrafficMirrorRuleAction/enum",
+  "path": "/definitions/TrafficMirrorRuleAction/enumCaseInsensitive",
   "value": [
    "accept",
    "reject"

--- a/src/cfnlint/data/schemas/resources/df0dc3904abb859c.json
+++ b/src/cfnlint/data/schemas/resources/df0dc3904abb859c.json
@@ -21,7 +21,7 @@
    "type": "object"
   },
   "TrafficDirection": {
-   "enum": [
+   "enumCaseInsensitive": [
     "egress",
     "ingress"
    ],
@@ -44,7 +44,7 @@
    "type": "object"
   },
   "TrafficMirrorRuleAction": {
-   "enum": [
+   "enumCaseInsensitive": [
     "accept",
     "reject"
    ],


### PR DESCRIPTION
## Summary

  - CloudFormation accepts uppercase values (e.g. `INGRESS`) for `TrafficDirection` but the enum only had lowercase `[egress, ingress]`
  - Added `AWS::EC2::TrafficMirrorFilterRule` to `case_insensitive_resources` in the smithy script
  - Regenerated smithy patch to use `enumCaseInsensitive`

  ## Test plan

  - [x] Verified via shadow validation that `INGRESS` is accepted by CloudFormation
  - [x] Ran `cfn-lint --patch-specs` to confirm fix persists