### PR TITLE
fix: LanguageExtensions transform preserves Fn::Sub with underscore variables

### DIFF
--- a/src/cfnlint/template/transforms/_language_extensions.py
+++ b/src/cfnlint/template/transforms/_language_extensions.py
@@ -17,7 +17,7 @@ import regex as re
 
 from cfnlint.conditions._utils import get_hash
 from cfnlint.decode.node import str_node
-from cfnlint.helpers import FUNCTION_FOR_EACH
+from cfnlint.helpers import FUNCTION_FOR_EACH, REGEX_SUB_PARAMETERS
 from cfnlint.template.transforms._types import TransformResult
 
 LOGGER = logging.getLogger("cfnlint")
@@ -209,8 +209,14 @@ class _Transform:
         s: str,
         params: Mapping[str, Any],
     ) -> Tuple[bool, str]:
-        pattern = r"(\$|&){[a-zA-Z0-9\.:]+}"
-        if not re.search(pattern, s):
+        _ampersand_pattern = re.compile(r"&{\s*[^!\s].*?\s*}")
+
+        def _has_variables(value: str) -> bool:
+            return bool(
+                REGEX_SUB_PARAMETERS.search(value) or _ampersand_pattern.search(value)
+            )
+
+        if not _has_variables(s):
             return (True, s)
 
         new_s = deepcopy(s)
@@ -227,7 +233,7 @@ class _Transform:
         if isinstance(s, str_node):
             new_s = str_node(new_s, s.start_mark, s.end_mark)
 
-        return (not (bool(re.search(pattern, new_s))), new_s)
+        return (not _has_variables(new_s), new_s)
 
 
 class _ForEachValue:

--- a/test/unit/module/template/transforms/test_language_extensions.py
+++ b/test/unit/module/template/transforms/test_language_extensions.py
@@ -1422,3 +1422,42 @@ class TestTransformFnIfWithStringCondition(TestCase):
             self.assertEqual(fn_if[0], "Condition${Identifier}")
             self.assertEqual(fn_if[1], 1)
             self.assertEqual(fn_if[2], 2)
+
+
+class TestTransformSubWithUnderscoreVariable(TestCase):
+    def setUp(self) -> None:
+        self.template_obj = convert_dict(
+            {
+                "Transforms": ["AWS::LanguageExtensions"],
+                "Resources": {
+                    "Bucket": {
+                        "Type": "AWS::S3::Bucket",
+                        "Properties": {
+                            "BucketName": {
+                                "Fn::Sub": [
+                                    "${Bucket_Arn}/*",
+                                    {
+                                        "Bucket_Arn": {
+                                            "Fn::GetAtt": [
+                                                "Bucket",
+                                                "Arn",
+                                            ]
+                                        }
+                                    },
+                                ]
+                            },
+                        },
+                    },
+                },
+            }
+        )
+        return super().setUp()
+
+    def test_transform(self):
+        cfn = Template(filename="", template=self.template_obj, regions=["us-east-1"])
+        matches, template = language_extension(cfn)
+        self.assertListEqual(matches, [])
+        bucket_name = template["Resources"]["Bucket"]["Properties"]["BucketName"]
+        self.assertIn("Fn::Sub", bucket_name)
+        self.assertEqual(bucket_name["Fn::Sub"][0], "${Bucket_Arn}/*")
+        self.assertIn("Bucket_Arn", bucket_name["Fn::Sub"][1])


### PR DESCRIPTION
## Summary
- The regex pattern in `_replace_string_params` used a restrictive character class that didn't match all valid `Fn::Sub` variable names (e.g. those with underscores like `${S3Bucket_Arn}`)
- Replaced it with `REGEX_SUB_PARAMETERS`, the canonical pattern used elsewhere in the codebase, to ensure consistent variable detection
- When the pattern failed to detect a variable, the transform incorrectly stripped the `Fn::Sub` wrapper, exposing the raw template string to downstream rules like E3514

Fixes #4545

## Test plan
- [x] Verified the reproduction template from #4545 no longer produces E3514 false positive
- [x] Confirmed the transform preserves the `Fn::Sub` structure post-fix
- [x] Added unit test for `Fn::Sub` with underscore variable names
- [x] All existing unit tests pass