### PR TITLE
fix: Resolve false positives for dead config properties

### DIFF
--- a/src/cfnlint/data/schemas/extensions/aws_apigateway_stage/method_settings_resource_path.json
+++ b/src/cfnlint/data/schemas/extensions/aws_apigateway_stage/method_settings_resource_path.json
@@ -1,0 +1,53 @@
+{
+ "if": {
+  "anyOf": [
+   {
+    "required": [
+     "CacheDataEncrypted"
+    ]
+   },
+   {
+    "required": [
+     "CacheTtlInSeconds"
+    ]
+   },
+   {
+    "required": [
+     "CachingEnabled"
+    ]
+   },
+   {
+    "required": [
+     "DataTraceEnabled"
+    ]
+   },
+   {
+    "required": [
+     "LoggingLevel"
+    ]
+   },
+   {
+    "required": [
+     "MetricsEnabled"
+    ]
+   },
+   {
+    "required": [
+     "ThrottlingBurstLimit"
+    ]
+   },
+   {
+    "required": [
+     "ThrottlingRateLimit"
+    ]
+   }
+  ]
+ },
+ "then": {
+  "properties": {
+   "ResourcePath": {
+    "pattern": "^/.*$"
+   }
+  }
+ }
+}

--- a/src/cfnlint/data/schemas/extensions/aws_cloudfront_distribution/forward_enum.json
+++ b/src/cfnlint/data/schemas/extensions/aws_cloudfront_distribution/forward_enum.json
@@ -1,0 +1,27 @@
+{
+ "else": {
+  "properties": {
+   "ForwardedValues": {
+    "properties": {
+     "Cookies": {
+      "properties": {
+       "Forward": {
+        "enum": [
+         "all",
+         "none",
+         "whitelist"
+        ]
+       }
+      }
+     }
+    }
+   }
+  }
+ },
+ "if": {
+  "required": [
+   "CachePolicyId"
+  ]
+ },
+ "then": true
+}

--- a/src/cfnlint/rules/resources/apigateway/StageMethodSettingsIgnored.py
+++ b/src/cfnlint/rules/resources/apigateway/StageMethodSettingsIgnored.py
@@ -1,0 +1,59 @@
+"""
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from cfnlint.jsonschema import ValidationError, ValidationResult, Validator
+from cfnlint.rules.jsonschema.CfnLintKeyword import CfnLintKeyword
+
+_setting_properties = {
+    "CacheDataEncrypted",
+    "CacheTtlInSeconds",
+    "CachingEnabled",
+    "DataTraceEnabled",
+    "LoggingLevel",
+    "MetricsEnabled",
+    "ThrottlingBurstLimit",
+    "ThrottlingRateLimit",
+}
+
+
+class StageMethodSettingsIgnored(CfnLintKeyword):
+    id = "W3705"
+    shortdesc = "MethodSettings entry is ignored without any setting properties"
+    description = (
+        "When an API Gateway MethodSettings entry specifies only HttpMethod "
+        "and ResourcePath without any actual setting properties (LoggingLevel, "
+        "MetricsEnabled, etc.), the entry is silently dropped by API Gateway."
+    )
+    source_url = "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apigateway-stage-methodsetting.html"
+    tags = ["properties", "apigateway"]
+
+    def __init__(self) -> None:
+        super().__init__(
+            keywords=[
+                "Resources/AWS::ApiGateway::Stage/Properties/MethodSettings/*",
+            ]
+        )
+
+    def validate(
+        self, validator: Validator, _: Any, instance: Any, schema: dict[str, Any]
+    ) -> ValidationResult:
+        if not isinstance(instance, dict):
+            return
+
+        has_settings = any(prop in instance for prop in _setting_properties)
+        if has_settings:
+            return
+
+        if not instance:
+            return
+
+        yield ValidationError(
+            "MethodSettings entry has no effect without a setting "
+            "property (LoggingLevel, MetricsEnabled, CachingEnabled, etc.)",
+        )

--- a/src/cfnlint/rules/resources/apigateway/StageMethodSettingsResourcePath.py
+++ b/src/cfnlint/rules/resources/apigateway/StageMethodSettingsResourcePath.py
@@ -1,0 +1,38 @@
+"""
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import cfnlint.data.schemas.extensions.aws_apigateway_stage
+from cfnlint.jsonschema import ValidationError
+from cfnlint.rules.jsonschema.CfnLintJsonSchema import CfnLintJsonSchema, SchemaDetails
+
+
+class StageMethodSettingsResourcePath(CfnLintJsonSchema):
+    id = "E3723"
+    shortdesc = "ResourcePath must start with / when method settings are configured"
+    description = (
+        "When an API Gateway MethodSettings entry includes actual setting "
+        "properties (LoggingLevel, MetricsEnabled, etc.), the ResourcePath "
+        "must match the pattern '^/.*$'."
+    )
+    source_url = "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apigateway-stage-methodsetting.html"
+    tags = ["properties", "apigateway"]
+
+    def __init__(self) -> None:
+        super().__init__(
+            keywords=[
+                "Resources/AWS::ApiGateway::Stage/Properties/MethodSettings/*",
+            ],
+            schema_details=SchemaDetails(
+                module=cfnlint.data.schemas.extensions.aws_apigateway_stage,
+                filename="method_settings_resource_path.json",
+            ),
+        )
+
+    def message(self, instance: Any, err: ValidationError) -> str:
+        return err.message

--- a/src/cfnlint/rules/resources/cloudfront/DistributionCacheBehaviorForwardEnum.py
+++ b/src/cfnlint/rules/resources/cloudfront/DistributionCacheBehaviorForwardEnum.py
@@ -1,0 +1,39 @@
+"""
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import cfnlint.data.schemas.extensions.aws_cloudfront_distribution
+from cfnlint.jsonschema import ValidationError
+from cfnlint.rules.jsonschema.CfnLintJsonSchema import CfnLintJsonSchema, SchemaDetails
+
+
+class DistributionCacheBehaviorForwardEnum(CfnLintJsonSchema):
+    id = "E3722"
+    shortdesc = "Cookies Forward must be a valid enum when CachePolicyId is absent"
+    description = (
+        "When a CloudFront cache behavior does not specify a CachePolicyId, "
+        "the ForwardedValues Cookies Forward property must be one of "
+        "'all', 'none', or 'whitelist'."
+    )
+    source_url = "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-distribution-cookies.html"
+    tags = ["properties", "cloudfront"]
+
+    def __init__(self) -> None:
+        super().__init__(
+            keywords=[
+                "Resources/AWS::CloudFront::Distribution/Properties/DistributionConfig/DefaultCacheBehavior",
+                "Resources/AWS::CloudFront::Distribution/Properties/DistributionConfig/CacheBehaviors/*",
+            ],
+            schema_details=SchemaDetails(
+                module=cfnlint.data.schemas.extensions.aws_cloudfront_distribution,
+                filename="forward_enum.json",
+            ),
+        )
+
+    def message(self, instance: Any, err: ValidationError) -> str:
+        return err.message

--- a/src/cfnlint/rules/resources/cloudfront/DistributionCacheBehaviorForwardedValuesIgnored.py
+++ b/src/cfnlint/rules/resources/cloudfront/DistributionCacheBehaviorForwardedValuesIgnored.py
@@ -1,0 +1,48 @@
+"""
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from cfnlint.jsonschema import ValidationError, ValidationResult, Validator
+from cfnlint.rules.jsonschema.CfnLintKeyword import CfnLintKeyword
+
+
+class DistributionCacheBehaviorForwardedValuesIgnored(CfnLintKeyword):
+    id = "W3704"
+    shortdesc = "ForwardedValues is ignored when CachePolicyId is specified"
+    description = (
+        "When a CloudFront cache behavior specifies a CachePolicyId, "
+        "ForwardedValues is silently ignored. Remove ForwardedValues "
+        "or remove CachePolicyId."
+    )
+    source_url = "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-distribution-cachebehavior.html"
+    tags = ["properties", "cloudfront"]
+
+    def __init__(self) -> None:
+        super().__init__(
+            keywords=[
+                "Resources/AWS::CloudFront::Distribution/Properties/DistributionConfig/DefaultCacheBehavior",
+                "Resources/AWS::CloudFront::Distribution/Properties/DistributionConfig/CacheBehaviors/*",
+            ]
+        )
+
+    def validate(
+        self, validator: Validator, _: Any, instance: Any, schema: dict[str, Any]
+    ) -> ValidationResult:
+        if not isinstance(instance, dict):
+            return
+
+        if "CachePolicyId" not in instance:
+            return
+
+        if "ForwardedValues" not in instance:
+            return
+
+        yield ValidationError(
+            "'ForwardedValues' is ignored when 'CachePolicyId' is specified",
+            path=["ForwardedValues"],
+        )

--- a/test/unit/rules/functions/test_getatt.py
+++ b/test/unit/rules/functions/test_getatt.py
@@ -83,6 +83,8 @@ class _Fail(CfnLintKeyword):
                     " 'MetadataConfiguration.JournalTableConfiguration.TableArn',"
                     " 'MetadataConfiguration.InventoryTableConfiguration.TableName',"
                     " 'MetadataConfiguration.InventoryTableConfiguration.TableArn',"
+                    " 'MetadataConfiguration.AnnotationTableConfiguration.TableName',"
+                    " 'MetadataConfiguration.AnnotationTableConfiguration.TableArn',"
                     " 'WebsiteURL'] "
                     "in ['us-east-1']",
                     path=deque(["Fn::GetAtt", 1]),
@@ -229,6 +231,8 @@ class _Fail(CfnLintKeyword):
                     " 'MetadataConfiguration.JournalTableConfiguration.TableArn',"
                     " 'MetadataConfiguration.InventoryTableConfiguration.TableName',"
                     " 'MetadataConfiguration.InventoryTableConfiguration.TableArn',"
+                    " 'MetadataConfiguration.AnnotationTableConfiguration.TableName',"
+                    " 'MetadataConfiguration.AnnotationTableConfiguration.TableArn',"
                     " 'WebsiteURL'] in ['us-east-1'] when "
                     "{'Ref': 'MyResourceParameter'} is resolved",
                     path=deque(["Fn::GetAtt", 1]),

--- a/test/unit/rules/functions/test_sub.py
+++ b/test/unit/rules/functions/test_sub.py
@@ -293,6 +293,8 @@ def cfn():
                     " 'MetadataConfiguration.JournalTableConfiguration.TableArn',"
                     " 'MetadataConfiguration.InventoryTableConfiguration.TableName',"
                     " 'MetadataConfiguration.InventoryTableConfiguration.TableArn',"
+                    " 'MetadataConfiguration.AnnotationTableConfiguration.TableName',"
+                    " 'MetadataConfiguration.AnnotationTableConfiguration.TableArn',"
                     " 'WebsiteURL'] in ['us-east-1']",
                     path=deque(["Fn::Sub"]),
                     schema_path=deque([]),

--- a/test/unit/rules/resources/apigateway/test_stage_method_settings_ignored.py
+++ b/test/unit/rules/resources/apigateway/test_stage_method_settings_ignored.py
@@ -1,0 +1,57 @@
+"""
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+"""
+
+import pytest
+
+from cfnlint.jsonschema import ValidationError
+from cfnlint.rules.resources.apigateway.StageMethodSettingsIgnored import (
+    StageMethodSettingsIgnored,
+)
+
+
+@pytest.fixture(scope="module")
+def rule():
+    rule = StageMethodSettingsIgnored()
+    yield rule
+
+
+@pytest.mark.parametrize(
+    "instance,expected",
+    [
+        (
+            {"HttpMethod": "*", "ResourcePath": "api/{proxy+}"},
+            [
+                ValidationError(
+                    "MethodSettings entry has no effect without a setting "
+                    "property (LoggingLevel, MetricsEnabled, CachingEnabled, etc.)",
+                ),
+            ],
+        ),
+        (
+            {"HttpMethod": "*", "ResourcePath": "/*", "LoggingLevel": "INFO"},
+            [],
+        ),
+        (
+            {"HttpMethod": "*", "ResourcePath": "/*", "MetricsEnabled": True},
+            [],
+        ),
+        (
+            {"HttpMethod": "*", "ResourcePath": "/*", "CachingEnabled": True},
+            [],
+        ),
+        (
+            {},
+            [],
+        ),
+        (
+            "not a dict",
+            [],
+        ),
+    ],
+)
+def test_validate(instance, expected, rule, validator):
+    errs = list(rule.validate(validator, "", instance, {}))
+
+    assert errs == expected, f"Expected {expected} got {errs}"

--- a/test/unit/rules/resources/apigateway/test_stage_method_settings_resource_path.py
+++ b/test/unit/rules/resources/apigateway/test_stage_method_settings_resource_path.py
@@ -1,0 +1,93 @@
+"""
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+"""
+
+from collections import deque
+
+import pytest
+
+from cfnlint.jsonschema import ValidationError
+from cfnlint.rules.resources.apigateway.StageMethodSettingsResourcePath import (
+    StageMethodSettingsResourcePath,
+)
+
+
+@pytest.fixture(scope="module")
+def rule():
+    rule = StageMethodSettingsResourcePath()
+    yield rule
+
+
+@pytest.mark.parametrize(
+    "instance,expected",
+    [
+        (
+            {
+                "HttpMethod": "*",
+                "ResourcePath": "api/{proxy+}",
+                "LoggingLevel": "INFO",
+            },
+            [
+                ValidationError(
+                    "'api/{proxy+}' does not match '^/.*$'",
+                    rule=StageMethodSettingsResourcePath(),
+                    path=deque(["ResourcePath"]),
+                    schema_path=deque(["then", "properties", "ResourcePath", "pattern"]),
+                    validator="pattern",
+                ),
+            ],
+        ),
+        (
+            {
+                "HttpMethod": "*",
+                "ResourcePath": "/*",
+                "LoggingLevel": "INFO",
+            },
+            [],
+        ),
+        (
+            {
+                "HttpMethod": "*",
+                "ResourcePath": "/",
+                "MetricsEnabled": True,
+            },
+            [],
+        ),
+        (
+            {
+                "HttpMethod": "*",
+                "ResourcePath": "api/{proxy+}",
+            },
+            [],
+        ),
+        (
+            {
+                "HttpMethod": "*",
+                "ResourcePath": "no-slash",
+                "ThrottlingBurstLimit": 100,
+            },
+            [
+                ValidationError(
+                    "'no-slash' does not match '^/.*$'",
+                    rule=StageMethodSettingsResourcePath(),
+                    path=deque(["ResourcePath"]),
+                    schema_path=deque(["then", "properties", "ResourcePath", "pattern"]),
+                    validator="pattern",
+                ),
+            ],
+        ),
+        (
+            {},
+            [],
+        ),
+        (
+            "not a dict",
+            [],
+        ),
+    ],
+)
+def test_validate(instance, expected, rule, validator):
+    errs = list(rule.validate(validator, "", instance, {}))
+
+    assert errs == expected, f"Expected {expected} got {errs}"

--- a/test/unit/rules/resources/apigateway/test_stage_method_settings_resource_path.py
+++ b/test/unit/rules/resources/apigateway/test_stage_method_settings_resource_path.py
@@ -33,7 +33,9 @@ def rule():
                     "'api/{proxy+}' does not match '^/.*$'",
                     rule=StageMethodSettingsResourcePath(),
                     path=deque(["ResourcePath"]),
-                    schema_path=deque(["then", "properties", "ResourcePath", "pattern"]),
+                    schema_path=deque(
+                        ["then", "properties", "ResourcePath", "pattern"]
+                    ),
                     validator="pattern",
                 ),
             ],
@@ -72,7 +74,9 @@ def rule():
                     "'no-slash' does not match '^/.*$'",
                     rule=StageMethodSettingsResourcePath(),
                     path=deque(["ResourcePath"]),
-                    schema_path=deque(["then", "properties", "ResourcePath", "pattern"]),
+                    schema_path=deque(
+                        ["then", "properties", "ResourcePath", "pattern"]
+                    ),
                     validator="pattern",
                 ),
             ],

--- a/test/unit/rules/resources/cloudfront/test_distribution_cache_behavior_forward_enum.py
+++ b/test/unit/rules/resources/cloudfront/test_distribution_cache_behavior_forward_enum.py
@@ -1,0 +1,139 @@
+"""
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+"""
+
+from collections import deque
+
+import pytest
+
+from cfnlint.jsonschema import ValidationError
+from cfnlint.rules.resources.cloudfront.DistributionCacheBehaviorForwardEnum import (
+    DistributionCacheBehaviorForwardEnum,
+)
+
+
+@pytest.fixture(scope="module")
+def rule():
+    rule = DistributionCacheBehaviorForwardEnum()
+    yield rule
+
+
+@pytest.mark.parametrize(
+    "instance,expected",
+    [
+        (
+            {
+                "ForwardedValues": {
+                    "QueryString": False,
+                    "Cookies": {"Forward": "none"},
+                },
+                "TargetOriginId": "myOrigin",
+                "ViewerProtocolPolicy": "allow-all",
+            },
+            [],
+        ),
+        (
+            {
+                "ForwardedValues": {
+                    "QueryString": False,
+                    "Cookies": {"Forward": "all"},
+                },
+            },
+            [],
+        ),
+        (
+            {
+                "ForwardedValues": {
+                    "QueryString": False,
+                    "Cookies": {"Forward": "whitelist"},
+                },
+            },
+            [],
+        ),
+        (
+            {
+                "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
+                "ForwardedValues": {
+                    "QueryString": False,
+                    "Cookies": {"Forward": "None"},
+                },
+            },
+            [],
+        ),
+        (
+            {
+                "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
+            },
+            [],
+        ),
+        (
+            {
+                "ForwardedValues": {
+                    "QueryString": False,
+                    "Cookies": {"Forward": "None"},
+                },
+            },
+            [
+                ValidationError(
+                    "'None' is not one of ['all', 'none', 'whitelist']",
+                    rule=DistributionCacheBehaviorForwardEnum(),
+                    path=deque(["ForwardedValues", "Cookies", "Forward"]),
+                    schema_path=deque(
+                        [
+                            "else",
+                            "properties",
+                            "ForwardedValues",
+                            "properties",
+                            "Cookies",
+                            "properties",
+                            "Forward",
+                            "enum",
+                        ]
+                    ),
+                    validator="enum",
+                ),
+            ],
+        ),
+        (
+            {
+                "ForwardedValues": {
+                    "QueryString": False,
+                    "Cookies": {"Forward": "INVALID"},
+                },
+            },
+            [
+                ValidationError(
+                    "'INVALID' is not one of ['all', 'none', 'whitelist']",
+                    rule=DistributionCacheBehaviorForwardEnum(),
+                    path=deque(["ForwardedValues", "Cookies", "Forward"]),
+                    schema_path=deque(
+                        [
+                            "else",
+                            "properties",
+                            "ForwardedValues",
+                            "properties",
+                            "Cookies",
+                            "properties",
+                            "Forward",
+                            "enum",
+                        ]
+                    ),
+                    validator="enum",
+                ),
+            ],
+        ),
+        (
+            {},
+            [],
+        ),
+        (
+            "not a dict",
+            [],
+        ),
+    ],
+)
+def test_validate(instance, expected, rule, validator):
+    errs = list(rule.validate(validator, "", instance, {}))
+
+    assert errs == expected, f"Expected {expected} got {errs}"

--- a/test/unit/rules/resources/cloudfront/test_distribution_cache_behavior_forwarded_values_ignored.py
+++ b/test/unit/rules/resources/cloudfront/test_distribution_cache_behavior_forwarded_values_ignored.py
@@ -1,0 +1,62 @@
+"""
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+"""
+
+from collections import deque
+
+import pytest
+
+from cfnlint.jsonschema import ValidationError
+from cfnlint.rules.resources.cloudfront.DistributionCacheBehaviorForwardedValuesIgnored import (
+    DistributionCacheBehaviorForwardedValuesIgnored,
+)
+
+
+@pytest.fixture(scope="module")
+def rule():
+    rule = DistributionCacheBehaviorForwardedValuesIgnored()
+    yield rule
+
+
+@pytest.mark.parametrize(
+    "instance,expected",
+    [
+        (
+            {
+                "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
+                "ForwardedValues": {"QueryString": False},
+            },
+            [
+                ValidationError(
+                    "'ForwardedValues' is ignored when 'CachePolicyId' is specified",
+                    path=deque(["ForwardedValues"]),
+                ),
+            ],
+        ),
+        (
+            {
+                "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
+            },
+            [],
+        ),
+        (
+            {
+                "ForwardedValues": {"QueryString": False, "Cookies": {"Forward": "none"}},
+            },
+            [],
+        ),
+        (
+            {},
+            [],
+        ),
+        (
+            "not a dict",
+            [],
+        ),
+    ],
+)
+def test_validate(instance, expected, rule, validator):
+    errs = list(rule.validate(validator, "", instance, {}))
+
+    assert errs == expected, f"Expected {expected} got {errs}"

--- a/test/unit/rules/resources/cloudfront/test_distribution_cache_behavior_forwarded_values_ignored.py
+++ b/test/unit/rules/resources/cloudfront/test_distribution_cache_behavior_forwarded_values_ignored.py
@@ -8,7 +8,7 @@ from collections import deque
 import pytest
 
 from cfnlint.jsonschema import ValidationError
-from cfnlint.rules.resources.cloudfront.DistributionCacheBehaviorForwardedValuesIgnored import (
+from cfnlint.rules.resources.cloudfront.DistributionCacheBehaviorForwardedValuesIgnored import (  # noqa: E501
     DistributionCacheBehaviorForwardedValuesIgnored,
 )
 
@@ -42,7 +42,10 @@ def rule():
         ),
         (
             {
-                "ForwardedValues": {"QueryString": False, "Cookies": {"Forward": "none"}},
+                "ForwardedValues": {
+                    "QueryString": False,
+                    "Cookies": {"Forward": "none"},
+                },
             },
             [],
         ),


### PR DESCRIPTION
## Summary
- CloudFront `Cookies/Forward` enum was validated even when `CachePolicyId` is present (making `ForwardedValues` dead config ignored by the service)
- ApiGateway Stage `MethodSettings/ResourcePath` pattern was validated even when no actual setting properties are configured (making the entry dead config dropped by API Gateway)

### Changes
- **E3722**: Validate `Forward` enum only when `CachePolicyId` is absent via schema extension
- **E3723**: Validate `ResourcePath` pattern only when setting properties are present via schema extension
- **W3704**: Warn when `ForwardedValues` is specified alongside `CachePolicyId` (dead config)
- **W3705**: Warn when `MethodSettings` entry has no actual settings (dead config)

### Schema dependency
Depends on https://github.com/aws-cloudformation/resource-provider-enhanced-schemas/pull/12 to remove the unconditional constraints from the schema source.

## Test plan
- [ ] Unit tests for all four new rules pass
- [ ] `cfn-lint` no longer produces E3030 for `Forward: None` when `CachePolicyId` is present
- [ ] `cfn-lint` no longer produces E3031 for `ResourcePath` without leading `/` when no settings configured
- [ ] `cfn-lint` still errors on invalid `Forward` values when `CachePolicyId` is absent
- [ ] `cfn-lint` still errors on invalid `ResourcePath` when settings are present