### PR TITLE
fix: Auto-download schemas when not present for pre-commit users

### DIFF
--- a/src/cfnlint/schema/manager.py
+++ b/src/cfnlint/schema/manager.py
@@ -98,6 +98,8 @@ class ProviderSchemaManager:
             Dict mapping resource type to schema hash
         """
         if region not in self._provider_schema_modules:
+            if not (self._providers_dir / "us-east-1.json").exists():
+                self.update(force=False)
             provider_file = self._providers_dir / f"{region}.json"
             if not provider_file.exists():
                 provider_file = self._providers_dir / "us-east-1.json"

--- a/test/unit/module/schema/test_manager.py
+++ b/test/unit/module/schema/test_manager.py
@@ -211,6 +211,50 @@ class TestSamModuleLoading(BaseTestCase):
             self.assertTrue((resources_dir / "sam123.json").exists())
 
 
+class TestAutoDownloadOnMissingSchemas(BaseTestCase):
+    """Test that schemas are auto-downloaded when provider files are missing"""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.manager = _make_manager()
+
+    @patch("cfnlint.schema.manager.ProviderSchemaManager.update")
+    def test_auto_downloads_when_no_providers(self, mock_update):
+        """When no provider files exist, update is called automatically"""
+        import tempfile
+        from pathlib import Path
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            providers_dir = Path(tmpdir) / "providers"
+            providers_dir.mkdir()
+
+            self.manager._providers_dir = providers_dir
+            self.manager._provider_schema_modules = {}
+
+            self.manager._load_provider_module("us-east-1")
+            mock_update.assert_called_once_with(force=False)
+
+    @patch("cfnlint.schema.manager.ProviderSchemaManager.update")
+    def test_no_auto_download_when_providers_exist(self, mock_update):
+        """When provider files exist, update is not called"""
+        import tempfile
+        from pathlib import Path
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            providers_dir = Path(tmpdir) / "providers"
+            providers_dir.mkdir()
+            (providers_dir / "us-east-1.json").write_text(
+                json.dumps({"AWS::S3::Bucket": "abc123"})
+            )
+
+            self.manager._providers_dir = providers_dir
+            self.manager._provider_schema_modules = {}
+            self.manager._sam_schema_module = {}
+
+            self.manager._load_provider_module("us-east-1")
+            mock_update.assert_not_called()
+
+
 class TestManagerGetResourceSchema(BaseTestCase):
     """Test get resource schema"""
 


### PR DESCRIPTION
## Summary
- When cfn-lint is installed via pre-commit (from git repo), schemas are not bundled
- Auto-downloads schemas on first run if provider files are missing
- Subsequent runs use cached schemas with no performance impact

fix #4557 

## Test plan
- [ ] Install cfn-lint as a pre-commit hook from git repo (no schemas present)
- [ ] Verify first run downloads schemas and lints successfully
- [ ] Verify subsequent runs use cached schemas without re-downloading