### PR TITLE
fix: Move schema cache to platform-appropriate user directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,12 +2,11 @@
 test/fixtures/templates/bad/limit_numbers.yaml
 test/fixtures/templates/bad/limit_size.yaml
 
-# Schema data files (downloaded at build time from enhanced-schemas repo)
-src/cfnlint/data/schemas/providers/*.json
-src/cfnlint/data/schemas/resources/*.json
-
-# Download metadata (ETag caching state)
+# Legacy schema data location (no longer used, but may exist from prior runs)
+src/cfnlint/data/schemas/providers/
+src/cfnlint/data/schemas/resources/
 src/cfnlint/data/DownloadsMetadata/
+
 
 # Local files for Build and Release
 Dockerfile.local

--- a/src/cfnlint/helpers.py
+++ b/src/cfnlint/helpers.py
@@ -409,9 +409,29 @@ class RegexDict(dict):
             return default
 
 
+def get_cache_dir() -> str:
+    """Returns the platform-appropriate cache directory for cfn-lint.
+
+    Uses AWS-standard paths:
+        Linux:   ~/.cache/aws/cfn-lint/schemas/
+        macOS:   ~/Library/Caches/aws/cfn-lint/schemas/
+        Windows: %LOCALAPPDATA%/aws/cfn-lint/schemas/
+    """
+    import sys
+
+    if sys.platform == "win32":
+        base = os.environ.get("LOCALAPPDATA", os.path.expanduser("~\\AppData\\Local"))
+    elif sys.platform == "darwin":
+        base = os.path.expanduser("~/Library/Caches")
+    else:
+        base = os.environ.get("XDG_CACHE_HOME", os.path.expanduser("~/.cache"))
+
+    return os.path.join(base, "aws", "cfn-lint", "schemas")
+
+
 def get_metadata_filename(url):
     """Returns the filename for a metadata file associated with a remote resource"""
-    caching_dir = os.path.join(os.path.dirname(__file__), "data", "DownloadsMetadata")
+    caching_dir = os.path.join(get_cache_dir(), "metadata")
     encoded_url = hashlib.sha256(url.encode()).hexdigest()
     metadata_filename = os.path.join(caching_dir, encoded_url + ".meta.json")
 
@@ -526,8 +546,7 @@ def load_metadata(filename):
 def save_metadata(metadata, filename):
     """Save the contents of the download metadata file"""
     dirname = os.path.dirname(filename)
-    if not os.path.exists(dirname):
-        os.mkdir(dirname)
+    os.makedirs(dirname, exist_ok=True)
 
     with open(filename, "w", encoding="utf-8") as metadata_file:
         json.dump(metadata, metadata_file)

--- a/src/cfnlint/helpers.py
+++ b/src/cfnlint/helpers.py
@@ -18,6 +18,7 @@ import inspect
 import json
 import logging
 import os
+import sys
 from io import BytesIO
 from typing import Any, Sequence
 from urllib.request import Request, urlopen, urlretrieve
@@ -417,8 +418,6 @@ def get_cache_dir() -> str:
         macOS:   ~/Library/Caches/aws/cfn-lint/schemas/
         Windows: %LOCALAPPDATA%/aws/cfn-lint/schemas/
     """
-    import sys
-
     if sys.platform == "win32":
         base = os.environ.get("LOCALAPPDATA", os.path.expanduser("~\\AppData\\Local"))
     elif sys.platform == "darwin":

--- a/src/cfnlint/schema/manager.py
+++ b/src/cfnlint/schema/manager.py
@@ -15,7 +15,12 @@ from functools import lru_cache
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Iterator, Sequence
 
-from cfnlint.helpers import REGIONS, get_url_retrieve, url_has_newer_version
+from cfnlint.helpers import (
+    REGIONS,
+    get_cache_dir,
+    get_url_retrieve,
+    url_has_newer_version,
+)
 from cfnlint.schema._exceptions import ResourceNotFoundError
 from cfnlint.schema._getatts import AttributeDict
 from cfnlint.schema._schema import Schema
@@ -41,12 +46,9 @@ class ProviderSchemaManager:
         providers_dir: Path | None = None,
         resources_dir: Path | None = None,
     ) -> None:
-        self._providers_dir = providers_dir or Path(
-            os.path.dirname(__file__), "..", "data", "schemas", "providers"
-        )
-        self._resources_dir = resources_dir or Path(
-            os.path.dirname(__file__), "..", "data", "schemas", "resources"
-        )
+        _cache = Path(get_cache_dir())
+        self._providers_dir = providers_dir or _cache / "providers"
+        self._resources_dir = resources_dir or _cache / "resources"
         self._registry_schemas: dict[str, Schema] = {}
         self._provider_schema_modules: dict[str, dict[str, str]] = {}
         self._sam_schema_module: dict[str, str] | None = None

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -11,9 +11,9 @@ from unittest.mock import patch
 
 import pytest
 
-_default_providers_dir = Path(__file__).parent.parent.parent / (
-    "src/cfnlint/data/schemas/providers"
-)
+from cfnlint.helpers import get_cache_dir
+
+_default_providers_dir = Path(get_cache_dir()) / "providers"
 
 _has_full_schemas = _default_providers_dir.exists() and any(
     _default_providers_dir.glob("*.json")

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -11,16 +11,14 @@ from pathlib import Path as FilePath
 import pytest
 
 from cfnlint.context import Path, create_context_for_template
-from cfnlint.helpers import FUNCTIONS
+from cfnlint.helpers import FUNCTIONS, get_cache_dir
 from cfnlint.jsonschema import CfnTemplateValidator
 from cfnlint.schema import PROVIDER_SCHEMA_MANAGER
 from cfnlint.template import Template
 
 _fixtures_dir = FilePath(__file__).parent.parent / "fixtures" / "schemas"
 
-_default_providers_dir = FilePath(__file__).parent.parent.parent / (
-    "src/cfnlint/data/schemas/providers"
-)
+_default_providers_dir = FilePath(get_cache_dir()) / "providers"
 
 _has_full_schemas = _default_providers_dir.exists() and any(
     _default_providers_dir.glob("*.json")

--- a/test/unit/module/helpers/test_downloads_metadata.py
+++ b/test/unit/module/helpers/test_downloads_metadata.py
@@ -42,20 +42,16 @@ class TestDownloadsMetadata(BaseTestCase):
 
             self.assertEqual(result, file_contents)
 
-    @patch("cfnlint.helpers.os.path.exists")
     @patch("cfnlint.helpers.os.path.dirname")
-    @patch("cfnlint.helpers.os.mkdir")
+    @patch("cfnlint.helpers.os.makedirs")
     @patch("cfnlint.helpers.json.dump")
-    def test_save_download_metadata(
-        self, mock_json_dump, mock_mkdir, mock_dirname, mock_path_exists
-    ):
+    def test_save_download_metadata(self, mock_json_dump, mock_makedirs, mock_dirname):
         """Test success run"""
 
         filename = "foo.bar"
         filedir = "foobardir"
         file_contents = {"etag": "foo"}
 
-        mock_path_exists.return_value = False
         mock_dirname.return_value = filedir
 
         builtin_module_name = "builtins"
@@ -63,5 +59,5 @@ class TestDownloadsMetadata(BaseTestCase):
         mo = mock_open()
         with patch("{}.open".format(builtin_module_name), mo):
             cfnlint.helpers.save_metadata(file_contents, filename)
-            mock_mkdir.assert_called_with(filedir)
+            mock_makedirs.assert_called_with(filedir, exist_ok=True)
             mock_json_dump.assert_called_once

--- a/test/unit/module/helpers/test_downloads_metadata.py
+++ b/test/unit/module/helpers/test_downloads_metadata.py
@@ -4,10 +4,12 @@ SPDX-License-Identifier: MIT-0
 """
 
 import json
+import os
 from test.testlib.testcase import BaseTestCase
 from unittest.mock import mock_open, patch
 
 import cfnlint.helpers
+from cfnlint.helpers import get_cache_dir
 
 
 class TestDownloadsMetadata(BaseTestCase):
@@ -61,3 +63,46 @@ class TestDownloadsMetadata(BaseTestCase):
             cfnlint.helpers.save_metadata(file_contents, filename)
             mock_makedirs.assert_called_with(filedir, exist_ok=True)
             mock_json_dump.assert_called_once
+
+
+class TestGetCacheDir(BaseTestCase):
+    """Test get_cache_dir platform logic"""
+
+    @patch.object(cfnlint.helpers.sys, "platform", "linux")
+    @patch.dict(os.environ, {}, clear=True)
+    def test_linux_default(self):
+        """Linux without XDG_CACHE_HOME uses ~/.cache"""
+        result = get_cache_dir()
+        expected = os.path.join(
+            os.path.expanduser("~/.cache"), "aws", "cfn-lint", "schemas"
+        )
+        self.assertEqual(result, expected)
+
+    @patch.object(cfnlint.helpers.sys, "platform", "linux")
+    @patch.dict(os.environ, {"XDG_CACHE_HOME": "/home/user/.my-cache"}, clear=True)
+    def test_linux_xdg(self):
+        """Linux with XDG_CACHE_HOME respects it"""
+        result = get_cache_dir()
+        expected = os.path.join("/home/user/.my-cache", "aws", "cfn-lint", "schemas")
+        self.assertEqual(result, expected)
+
+    @patch.object(cfnlint.helpers.sys, "platform", "darwin")
+    def test_macos(self):
+        """macOS uses ~/Library/Caches"""
+        result = get_cache_dir()
+        expected = os.path.join(
+            os.path.expanduser("~/Library/Caches"), "aws", "cfn-lint", "schemas"
+        )
+        self.assertEqual(result, expected)
+
+    @patch.object(cfnlint.helpers.sys, "platform", "win32")
+    @patch.dict(
+        os.environ, {"LOCALAPPDATA": "C:\\Users\\test\\AppData\\Local"}, clear=True
+    )
+    def test_windows(self):
+        """Windows uses LOCALAPPDATA"""
+        result = get_cache_dir()
+        expected = os.path.join(
+            "C:\\Users\\test\\AppData\\Local", "aws", "cfn-lint", "schemas"
+        )
+        self.assertEqual(result, expected)

--- a/test/unit/module/schema/test_manager.py
+++ b/test/unit/module/schema/test_manager.py
@@ -11,13 +11,12 @@ from pathlib import Path
 from test.testlib.testcase import BaseTestCase
 from unittest.mock import MagicMock, patch
 
+from cfnlint.helpers import get_cache_dir
 from cfnlint.schema._patch import SchemaPatch
 from cfnlint.schema.manager import ProviderSchemaManager, ResourceNotFoundError
 
 _fixtures_dir = Path(__file__).parent.parent.parent.parent / "fixtures" / "schemas"
-_default_providers_dir = Path(__file__).parent.parent.parent.parent.parent / (
-    "src/cfnlint/data/schemas/providers"
-)
+_default_providers_dir = Path(get_cache_dir()) / "providers"
 _has_full_schemas = _default_providers_dir.exists() and any(
     _default_providers_dir.glob("*.json")
 )


### PR DESCRIPTION
## Summary
- Schemas are now downloaded to a user-writable cache directory instead of the package install location
- Uses AWS-standard platform paths:
  - Linux: `~/.cache/aws/cfn-lint/schemas/`
  - macOS: `~/Library/Caches/aws/cfn-lint/schemas/`
  - Windows: `%LOCALAPPDATA%\aws\cfn-lint\schemas\`
- Respects `XDG_CACHE_HOME` on Linux when set

## Why
Writing into the package install directory fails on immutable/read-only installs (Nix, distro packages, containers) and can also fail in pre-commit environments. Moving to a user-writable cache location resolves both scenarios.

Auto-download on first run still works — if the cache dir is empty, `cfn-lint` downloads schemas automatically.

Fixes #4568
Fixes #4563

## Test plan
- [ ] Verify `cfn-lint -u` downloads to the new cache location
- [ ] Verify first-run auto-download works when cache is empty
- [ ] Verify read-only package installs (Nix) no longer error
- [ ] Verify pre-commit usage works without manual `cfn-lint -u`