### PR TITLE
Fix shared pricing defaults

### DIFF
--- a/scripts/update_specs_from_pricing.py
+++ b/scripts/update_specs_from_pricing.py
@@ -398,7 +398,7 @@ def get_results(service, product_families, default=None):
                         )
                         continue
                     if not results.get(location):
-                        results[location] = default
+                        results[location] = set(default)
                     instance_type = product.get("attributes").get("instanceType")
                     if instance_type:
                         results[location].add(instance_type)

--- a/test/unit/module/maintenance/test_update_specs_from_pricing.py
+++ b/test/unit/module/maintenance/test_update_specs_from_pricing.py
@@ -1,0 +1,66 @@
+"""
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+"""
+
+import importlib.util
+import json
+from pathlib import Path
+from test.testlib.testcase import BaseTestCase
+from unittest.mock import patch
+
+
+def _load_update_specs_from_pricing():
+    path = Path(__file__).parents[4] / "scripts" / "update_specs_from_pricing.py"
+    spec = importlib.util.spec_from_file_location("update_specs_from_pricing", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestUpdateSpecsFromPricing(BaseTestCase):
+    """Used for testing pricing spec generation."""
+
+    def test_get_results_copies_default_values_per_region(self):
+        """Default values stay isolated between generated region enums."""
+        module = _load_update_specs_from_pricing()
+        pages = [
+            {
+                "PriceList": [
+                    json.dumps(
+                        {
+                            "product": {
+                                "productFamily": "Database Instance",
+                                "attributes": {
+                                    "location": "US East (N. Virginia)",
+                                    "locationType": "AWS Region",
+                                    "instanceType": "db.r5.large",
+                                },
+                            }
+                        }
+                    ),
+                    json.dumps(
+                        {
+                            "product": {
+                                "productFamily": "Database Instance",
+                                "attributes": {
+                                    "location": "EU (Ireland)",
+                                    "locationType": "AWS Region",
+                                    "instanceType": "db.r6g.large",
+                                },
+                            }
+                        }
+                    ),
+                ]
+            }
+        ]
+
+        with patch.object(module, "get_paginator", return_value=pages):
+            results = module.get_results(
+                "AmazonNeptune",
+                ["Database Instance"],
+                default=set(["db.serverless"]),
+            )
+
+        self.assertEqual(results["us-east-1"], set(["db.serverless", "db.r5.large"]))
+        self.assertEqual(results["eu-west-1"], set(["db.serverless", "db.r6g.large"]))


### PR DESCRIPTION
## Summary
- Copy the default pricing enum values when initializing each region
- Add a regression test showing region-specific values do not leak between generated enums

## Why
`get_results()` can be called with a mutable default set, currently for the Neptune `db.serverless` baseline. Reusing that same set for every new region means instance types discovered for one region can be added to the enum for another region.

## Testing
- `.venv/bin/python -m pytest test/unit/module/maintenance/test_update_specs_from_pricing.py -q`
- `.venv/bin/python -m pytest test/unit/module/maintenance -q`
- `.venv/bin/python -m compileall -q scripts/update_specs_from_pricing.py test/unit/module/maintenance/test_update_specs_from_pricing.py`
- `git diff --check`