### PR TITLE
feat: Add version.json schema precedence and bundled fallback

### DIFF
--- a/.github/workflows/cd-pypi.yaml
+++ b/.github/workflows/cd-pypi.yaml
@@ -23,8 +23,11 @@ jobs:
           pip install --upgrade pip
           pip install --upgrade setuptools build wheel twine
           pip install -e .
-      - name: Download schemas
-        run: cfn-lint --update-specs --force
+      - name: Download schemas into package for bundling
+        run: |
+          cfn-lint --update-specs --force
+          cp -r "$(python -c 'from cfnlint.helpers import get_cache_dir; print(get_cache_dir())')/providers" src/cfnlint/data/schemas/providers
+          cp -r "$(python -c 'from cfnlint.helpers import get_cache_dir; print(get_cache_dir())')/resources" src/cfnlint/data/schemas/resources
       - name: Build and publish
         run: |
           python -m build

--- a/.github/workflows/cd-pypi.yaml
+++ b/.github/workflows/cd-pypi.yaml
@@ -25,9 +25,11 @@ jobs:
           pip install -e .
       - name: Download schemas into package for bundling
         run: |
+          cache_dir="$(python -c 'from cfnlint.helpers import get_cache_dir; print(get_cache_dir())')"
           cfn-lint --update-specs --force
-          cp -r "$(python -c 'from cfnlint.helpers import get_cache_dir; print(get_cache_dir())')/providers" src/cfnlint/data/schemas/providers
-          cp -r "$(python -c 'from cfnlint.helpers import get_cache_dir; print(get_cache_dir())')/resources" src/cfnlint/data/schemas/resources
+          cp -r "$cache_dir/providers" src/cfnlint/data/schemas/providers
+          cp -r "$cache_dir/resources" src/cfnlint/data/schemas/resources
+          cp "$cache_dir/version.json" src/cfnlint/data/schemas/version.json
       - name: Build and publish
         run: |
           python -m build

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@ src/cfnlint/data/schemas/providers/
 src/cfnlint/data/schemas/resources/
 src/cfnlint/data/DownloadsMetadata/
 
-
 # Local files for Build and Release
 Dockerfile.local
 create-release.sh

--- a/src/cfnlint/schema/manager.py
+++ b/src/cfnlint/schema/manager.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Any, Iterator, Sequence
 from cfnlint.helpers import (
     REGIONS,
     get_cache_dir,
+    get_url_content,
     get_url_retrieve,
     url_has_newer_version,
 )
@@ -34,6 +35,10 @@ _ENHANCED_SCHEMAS_URL = (
     "https://github.com/aws-cloudformation/"
     "resource-provider-enhanced-schemas/releases/download/latest/schemas-cfn-lint.zip"
 )
+_VERSION_URL = (
+    "https://github.com/aws-cloudformation/"
+    "resource-provider-enhanced-schemas/releases/download/latest/version.json"
+)
 
 _MODULE_SCHEMA = Schema(
     {"additionalProperties": True, "type": "object", "typeName": "Module"}
@@ -46,29 +51,60 @@ class ProviderSchemaManager:
         providers_dir: Path | None = None,
         resources_dir: Path | None = None,
     ) -> None:
-        _pkg_data = Path(os.path.dirname(__file__), "..", "data", "schemas")
-        _pkg_providers = _pkg_data / "providers"
-        _cache = Path(get_cache_dir())
-
-        if providers_dir:
-            self._providers_dir = providers_dir
-        elif _pkg_providers.exists() and any(_pkg_providers.glob("*.json")):
-            self._providers_dir = _pkg_providers
+        if providers_dir or resources_dir:
+            _cache = Path(get_cache_dir())
+            self._providers_dir = providers_dir or _cache / "providers"
+            self._resources_dir = resources_dir or _cache / "resources"
         else:
-            self._providers_dir = _cache / "providers"
-
-        if resources_dir:
-            self._resources_dir = resources_dir
-        elif (_pkg_data / "resources").exists() and any(
-            (_pkg_data / "resources").glob("*.json")
-        ):
-            self._resources_dir = _pkg_data / "resources"
-        else:
-            self._resources_dir = _cache / "resources"
+            self._providers_dir, self._resources_dir = self._resolve_schema_dirs()
         self._registry_schemas: dict[str, Schema] = {}
         self._provider_schema_modules: dict[str, dict[str, str]] = {}
         self._sam_schema_module: dict[str, str] | None = None
         self.reset()
+
+    @staticmethod
+    def _read_schema_date(directory: Path) -> str:
+        """Read schema_date from a version.json file."""
+        version_file = directory / "version.json"
+        try:
+            with open(version_file, "r", encoding="utf-8") as f:
+                data = json.load(f)
+                result: str = data.get("schema_date", "")
+                return result
+        except (FileNotFoundError, json.JSONDecodeError):
+            return ""
+
+    @staticmethod
+    def _resolve_schema_dirs() -> tuple[Path, Path]:
+        """Determine which schema directory to use.
+
+        Precedence:
+        1. If both bundled and cache exist, use whichever has a newer schema_date
+        2. If only bundled exists, use bundled
+        3. If only cache exists, use cache
+        4. If neither exists, use cache (auto-download will populate it)
+        """
+        _pkg_data = Path(os.path.dirname(__file__), "..", "data", "schemas")
+        _pkg_providers = _pkg_data / "providers"
+        _cache = Path(get_cache_dir())
+        _cache_providers = _cache / "providers"
+
+        bundled_exists = _pkg_providers.exists() and any(_pkg_providers.glob("*.json"))
+        cache_exists = _cache_providers.exists() and any(
+            _cache_providers.glob("*.json")
+        )
+
+        if bundled_exists and cache_exists:
+            bundled_date = ProviderSchemaManager._read_schema_date(_pkg_data)
+            cache_date = ProviderSchemaManager._read_schema_date(_cache)
+            if cache_date > bundled_date:
+                return _cache / "providers", _cache / "resources"
+            return _pkg_providers, _pkg_data / "resources"
+
+        if bundled_exists:
+            return _pkg_providers, _pkg_data / "resources"
+
+        return _cache / "providers", _cache / "resources"
 
     def reset(self) -> None:
         """
@@ -304,6 +340,13 @@ class ProviderSchemaManager:
                     dest = resources_dir / Path(name).name
                     with zip_ref.open(name) as src, open(dest, "wb") as dst:
                         dst.write(src.read())
+
+        try:
+            version_content = get_url_content(_VERSION_URL)
+            with open(_cache / "version.json", "w", encoding="utf-8") as vf:
+                vf.write(version_content)
+        except Exception:
+            LOGGER.debug("Could not download version.json")
 
         self._providers_dir = providers_dir
         self._resources_dir = resources_dir

--- a/src/cfnlint/schema/manager.py
+++ b/src/cfnlint/schema/manager.py
@@ -46,9 +46,25 @@ class ProviderSchemaManager:
         providers_dir: Path | None = None,
         resources_dir: Path | None = None,
     ) -> None:
+        _pkg_data = Path(os.path.dirname(__file__), "..", "data", "schemas")
+        _pkg_providers = _pkg_data / "providers"
         _cache = Path(get_cache_dir())
-        self._providers_dir = providers_dir or _cache / "providers"
-        self._resources_dir = resources_dir or _cache / "resources"
+
+        if providers_dir:
+            self._providers_dir = providers_dir
+        elif _pkg_providers.exists() and any(_pkg_providers.glob("*.json")):
+            self._providers_dir = _pkg_providers
+        else:
+            self._providers_dir = _cache / "providers"
+
+        if resources_dir:
+            self._resources_dir = resources_dir
+        elif (_pkg_data / "resources").exists() and any(
+            (_pkg_data / "resources").glob("*.json")
+        ):
+            self._resources_dir = _pkg_data / "resources"
+        else:
+            self._resources_dir = _cache / "resources"
         self._registry_schemas: dict[str, Schema] = {}
         self._provider_schema_modules: dict[str, dict[str, str]] = {}
         self._sam_schema_module: dict[str, str] | None = None
@@ -246,6 +262,9 @@ class ProviderSchemaManager:
     def update(self, force: bool) -> int:
         """Update schemas from the enhanced schemas repository.
 
+        Writes to the user cache directory. After update, switches
+        to reading from the cache so the fresh schemas are used.
+
         Args:
             force (bool): force the schemas to be downloaded
         Returns:
@@ -261,27 +280,33 @@ class ProviderSchemaManager:
             LOGGER.error("Failed to download enhanced schemas: %s", e)
             return 2
 
-        with zipfile.ZipFile(filehandle, "r") as zip_ref:
-            self._providers_dir.mkdir(parents=True, exist_ok=True)
-            self._resources_dir.mkdir(parents=True, exist_ok=True)
+        _cache = Path(get_cache_dir())
+        providers_dir = _cache / "providers"
+        resources_dir = _cache / "resources"
 
-            for f in self._providers_dir.glob("*.json"):
+        with zipfile.ZipFile(filehandle, "r") as zip_ref:
+            providers_dir.mkdir(parents=True, exist_ok=True)
+            resources_dir.mkdir(parents=True, exist_ok=True)
+
+            for f in providers_dir.glob("*.json"):
                 f.unlink()
-            for f in self._resources_dir.glob("*.json"):
+            for f in resources_dir.glob("*.json"):
                 f.unlink()
 
             for name in zip_ref.namelist():
                 if not name.endswith(".json"):
                     continue
                 if name.startswith("providers/"):
-                    dest = self._providers_dir / Path(name).name
+                    dest = providers_dir / Path(name).name
                     with zip_ref.open(name) as src, open(dest, "wb") as dst:
                         dst.write(src.read())
                 elif name.startswith("resources/"):
-                    dest = self._resources_dir / Path(name).name
+                    dest = resources_dir / Path(name).name
                     with zip_ref.open(name) as src, open(dest, "wb") as dst:
                         dst.write(src.read())
 
+        self._providers_dir = providers_dir
+        self._resources_dir = resources_dir
         LOGGER.info("Schemas updated successfully")
         self.reset()
         return 0

--- a/test/unit/module/schema/test_manager.py
+++ b/test/unit/module/schema/test_manager.py
@@ -320,3 +320,225 @@ class TestManagerPatch(BaseTestCase):
         )
 
         mock_exit.assert_called_with(1)
+
+
+class TestReadSchemaDate(BaseTestCase):
+    """Test _read_schema_date"""
+
+    def test_reads_valid_version_json(self):
+        """Returns schema_date from a valid version.json"""
+        import tempfile
+        from pathlib import Path
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            version_file = Path(tmpdir) / "version.json"
+            version_file.write_text(json.dumps({"schema_date": "2026-07-07T14:23:15Z"}))
+            result = ProviderSchemaManager._read_schema_date(Path(tmpdir))
+            self.assertEqual(result, "2026-07-07T14:23:15Z")
+
+    def test_returns_empty_when_missing(self):
+        """Returns empty string when version.json doesn't exist"""
+        import tempfile
+        from pathlib import Path
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = ProviderSchemaManager._read_schema_date(Path(tmpdir))
+            self.assertEqual(result, "")
+
+    def test_returns_empty_on_invalid_json(self):
+        """Returns empty string on malformed JSON"""
+        import tempfile
+        from pathlib import Path
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            version_file = Path(tmpdir) / "version.json"
+            version_file.write_text("not valid json{{{")
+            result = ProviderSchemaManager._read_schema_date(Path(tmpdir))
+            self.assertEqual(result, "")
+
+    def test_returns_empty_when_field_missing(self):
+        """Returns empty string when schema_date field is absent"""
+        import tempfile
+        from pathlib import Path
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            version_file = Path(tmpdir) / "version.json"
+            version_file.write_text(json.dumps({"other": "data"}))
+            result = ProviderSchemaManager._read_schema_date(Path(tmpdir))
+            self.assertEqual(result, "")
+
+
+class TestResolveSchemaDirs(BaseTestCase):
+    """Test _resolve_schema_dirs"""
+
+    @patch("cfnlint.schema.manager.get_cache_dir")
+    @patch("cfnlint.schema.manager.os.path.dirname")
+    def test_cache_only(self, mock_dirname, mock_cache_dir):
+        """When no bundled schemas exist, returns cache dirs"""
+        import tempfile
+        from pathlib import Path
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            mock_cache_dir.return_value = tmpdir
+            mock_dirname.return_value = str(Path(tmpdir) / "nonexistent")
+            providers, resources = ProviderSchemaManager._resolve_schema_dirs()
+            self.assertEqual(providers, Path(tmpdir) / "providers")
+            self.assertEqual(resources, Path(tmpdir) / "resources")
+
+    @patch("cfnlint.schema.manager.get_cache_dir")
+    @patch("cfnlint.schema.manager.os.path.dirname")
+    def test_cache_wins_when_newer(self, mock_dirname, mock_cache_dir):
+        """Cache wins when its schema_date is newer than bundled"""
+        import tempfile
+        from pathlib import Path
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pkg_schema_dir = Path(tmpdir) / "pkg" / "schema"
+            pkg_schema_dir.mkdir(parents=True)
+            pkg_data = pkg_schema_dir / ".." / "data" / "schemas"
+            pkg_providers = pkg_data / "providers"
+            pkg_providers.mkdir(parents=True)
+            (pkg_providers / "us-east-1.json").write_text("{}")
+            (pkg_data / "version.json").write_text(
+                json.dumps({"schema_date": "2026-07-01T00:00:00Z"})
+            )
+
+            cache_dir = Path(tmpdir) / "cache"
+            cache_dir.mkdir()
+            cache_providers = cache_dir / "providers"
+            cache_providers.mkdir()
+            (cache_providers / "us-east-1.json").write_text("{}")
+            (cache_dir / "version.json").write_text(
+                json.dumps({"schema_date": "2026-07-07T14:00:00Z"})
+            )
+
+            mock_dirname.return_value = str(pkg_schema_dir)
+            mock_cache_dir.return_value = str(cache_dir)
+
+            providers, resources = ProviderSchemaManager._resolve_schema_dirs()
+
+            self.assertEqual(providers, cache_providers)
+
+    @patch("cfnlint.schema.manager.get_cache_dir")
+    @patch("cfnlint.schema.manager.os.path.dirname")
+    def test_bundled_wins_when_newer(self, mock_dirname, mock_cache_dir):
+        """Bundled wins when its schema_date is newer than cache"""
+        import tempfile
+        from pathlib import Path
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pkg_schema_dir = Path(tmpdir) / "pkg" / "schema"
+            pkg_schema_dir.mkdir(parents=True)
+            pkg_data = pkg_schema_dir / ".." / "data" / "schemas"
+            pkg_providers = pkg_data / "providers"
+            pkg_providers.mkdir(parents=True)
+            (pkg_providers / "us-east-1.json").write_text("{}")
+            (pkg_data / "version.json").write_text(
+                json.dumps({"schema_date": "2026-07-07T14:00:00Z"})
+            )
+
+            cache_dir = Path(tmpdir) / "cache"
+            cache_dir.mkdir()
+            cache_providers = cache_dir / "providers"
+            cache_providers.mkdir()
+            (cache_providers / "us-east-1.json").write_text("{}")
+            (cache_dir / "version.json").write_text(
+                json.dumps({"schema_date": "2026-07-01T00:00:00Z"})
+            )
+
+            mock_dirname.return_value = str(pkg_schema_dir)
+            mock_cache_dir.return_value = str(cache_dir)
+
+            providers, resources = ProviderSchemaManager._resolve_schema_dirs()
+
+            self.assertEqual(providers, pkg_providers)
+
+
+class TestUpdateDownloadsVersionJson(BaseTestCase):
+    """Test that update() fetches version.json"""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.manager = _make_manager()
+
+    @patch("cfnlint.schema.manager.get_url_content")
+    @patch("cfnlint.schema.manager.url_has_newer_version")
+    @patch("cfnlint.schema.manager.get_url_retrieve")
+    @patch("cfnlint.schema.manager.get_cache_dir")
+    def test_version_json_saved(
+        self, mock_cache_dir, mock_get_url, mock_url_newer, mock_get_content
+    ):
+        """update() saves version.json to cache"""
+        import tempfile
+        from pathlib import Path
+
+        mock_url_newer.return_value = False
+        mock_get_content.return_value = '{"schema_date": "2026-07-07T14:23:15Z"}'
+
+        zip_buffer = io.BytesIO()
+        with zipfile.ZipFile(zip_buffer, "w") as zf:
+            zf.writestr(
+                "providers/us-east-1.json",
+                json.dumps({"AWS::S3::Bucket": "abc123"}),
+            )
+            zf.writestr(
+                "resources/abc123.json",
+                json.dumps({"typeName": "AWS::S3::Bucket", "properties": {}}),
+            )
+        zip_buffer.seek(0)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            mock_cache_dir.return_value = tmpdir
+
+            with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as tmp:
+                tmp.write(zip_buffer.getvalue())
+                tmp.flush()
+                mock_get_url.return_value = tmp.name
+
+                result = self.manager.update(force=True)
+
+            self.assertEqual(result, 0)
+            version_file = Path(tmpdir) / "version.json"
+            self.assertTrue(version_file.exists())
+            with open(version_file) as f:
+                data = json.load(f)
+            self.assertEqual(data["schema_date"], "2026-07-07T14:23:15Z")
+
+    @patch("cfnlint.schema.manager.get_url_content")
+    @patch("cfnlint.schema.manager.url_has_newer_version")
+    @patch("cfnlint.schema.manager.get_url_retrieve")
+    @patch("cfnlint.schema.manager.get_cache_dir")
+    def test_version_json_failure_non_fatal(
+        self, mock_cache_dir, mock_get_url, mock_url_newer, mock_get_content
+    ):
+        """update() succeeds even if version.json download fails"""
+        import tempfile
+        from pathlib import Path
+
+        mock_url_newer.return_value = False
+        mock_get_content.side_effect = Exception("Network error")
+
+        zip_buffer = io.BytesIO()
+        with zipfile.ZipFile(zip_buffer, "w") as zf:
+            zf.writestr(
+                "providers/us-east-1.json",
+                json.dumps({"AWS::S3::Bucket": "abc123"}),
+            )
+            zf.writestr(
+                "resources/abc123.json",
+                json.dumps({"typeName": "AWS::S3::Bucket", "properties": {}}),
+            )
+        zip_buffer.seek(0)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            mock_cache_dir.return_value = tmpdir
+
+            with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as tmp:
+                tmp.write(zip_buffer.getvalue())
+                tmp.flush()
+                mock_get_url.return_value = tmp.name
+
+                result = self.manager.update(force=True)
+
+            self.assertEqual(result, 0)
+            self.assertFalse((Path(tmpdir) / "version.json").exists())

--- a/test/unit/module/schema/test_manager.py
+++ b/test/unit/module/schema/test_manager.py
@@ -51,7 +51,8 @@ class TestUpdateResourceSchemas(BaseTestCase):
 
     @patch("cfnlint.schema.manager.url_has_newer_version")
     @patch("cfnlint.schema.manager.get_url_retrieve")
-    def test_update_force(self, mock_get_url, mock_url_newer):
+    @patch("cfnlint.schema.manager.get_cache_dir")
+    def test_update_force(self, mock_cache_dir, mock_get_url, mock_url_newer):
         """Force download even if cached"""
         import tempfile
         from pathlib import Path
@@ -71,13 +72,7 @@ class TestUpdateResourceSchemas(BaseTestCase):
         zip_buffer.seek(0)
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            providers_dir = Path(tmpdir) / "providers"
-            resources_dir = Path(tmpdir) / "resources"
-            providers_dir.mkdir()
-            resources_dir.mkdir()
-
-            self.manager._providers_dir = providers_dir
-            self.manager._resources_dir = resources_dir
+            mock_cache_dir.return_value = tmpdir
 
             with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as tmp:
                 tmp.write(zip_buffer.getvalue())
@@ -88,8 +83,8 @@ class TestUpdateResourceSchemas(BaseTestCase):
 
             self.assertEqual(result, 0)
             mock_get_url.assert_called_once()
-            self.assertTrue((providers_dir / "us-east-1.json").exists())
-            self.assertTrue((resources_dir / "abc123.json").exists())
+            self.assertTrue((Path(tmpdir) / "providers" / "us-east-1.json").exists())
+            self.assertTrue((Path(tmpdir) / "resources" / "abc123.json").exists())
 
     @patch("cfnlint.schema.manager.url_has_newer_version")
     @patch("cfnlint.schema.manager.get_url_retrieve")
@@ -162,7 +157,10 @@ class TestSamModuleLoading(BaseTestCase):
 
     @patch("cfnlint.schema.manager.url_has_newer_version")
     @patch("cfnlint.schema.manager.get_url_retrieve")
-    def test_update_extracts_sam_json(self, mock_get_url, mock_url_newer):
+    @patch("cfnlint.schema.manager.get_cache_dir")
+    def test_update_extracts_sam_json(
+        self, mock_cache_dir, mock_get_url, mock_url_newer
+    ):
         """Update extracts sam.json from zip into providers dir"""
         import tempfile
         from pathlib import Path
@@ -190,13 +188,7 @@ class TestSamModuleLoading(BaseTestCase):
         zip_buffer.seek(0)
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            providers_dir = Path(tmpdir) / "providers"
-            resources_dir = Path(tmpdir) / "resources"
-            providers_dir.mkdir()
-            resources_dir.mkdir()
-
-            self.manager._providers_dir = providers_dir
-            self.manager._resources_dir = resources_dir
+            mock_cache_dir.return_value = tmpdir
 
             with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as tmp:
                 tmp.write(zip_buffer.getvalue())
@@ -206,8 +198,8 @@ class TestSamModuleLoading(BaseTestCase):
                 result = self.manager.update(force=True)
 
             self.assertEqual(result, 0)
-            self.assertTrue((providers_dir / "sam.json").exists())
-            self.assertTrue((resources_dir / "sam123.json").exists())
+            self.assertTrue((Path(tmpdir) / "providers" / "sam.json").exists())
+            self.assertTrue((Path(tmpdir) / "resources" / "sam123.json").exists())
 
 
 class TestAutoDownloadOnMissingSchemas(BaseTestCase):

--- a/test/unit/module/schema/test_manager.py
+++ b/test/unit/module/schema/test_manager.py
@@ -35,6 +35,29 @@ LOGGER = logging.getLogger("cfnlint.schema.manager")
 LOGGER.disabled = True
 
 
+class TestInitWithExplicitDirs(BaseTestCase):
+    """Test __init__ with explicit providers_dir/resources_dir"""
+
+    def test_explicit_providers_dir(self):
+        """Explicit providers_dir is used directly"""
+        import tempfile
+        from pathlib import Path
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            providers = Path(tmpdir) / "p"
+            providers.mkdir()
+            (providers / "us-east-1.json").write_text(
+                json.dumps({"AWS::S3::Bucket": "abc123"})
+            )
+            resources = Path(tmpdir) / "r"
+            resources.mkdir()
+            mgr = ProviderSchemaManager(
+                providers_dir=providers, resources_dir=resources
+            )
+            self.assertEqual(mgr._providers_dir, providers)
+            self.assertEqual(mgr._resources_dir, resources)
+
+
 class TestUpdateResourceSchemas(BaseTestCase):
     """Used for Testing Resource Schemas"""
 

--- a/test/unit/module/schema/test_manager.py
+++ b/test/unit/module/schema/test_manager.py
@@ -476,6 +476,31 @@ class TestResolveSchemaDirs(BaseTestCase):
 
             self.assertEqual(providers, pkg_providers)
 
+    @patch("cfnlint.schema.manager.get_cache_dir")
+    @patch("cfnlint.schema.manager.os.path.dirname")
+    def test_bundled_only_no_cache(self, mock_dirname, mock_cache_dir):
+        """Bundled schemas used when cache is empty"""
+        import tempfile
+        from pathlib import Path
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pkg_schema_dir = Path(tmpdir) / "pkg" / "schema"
+            pkg_schema_dir.mkdir(parents=True)
+            pkg_data = pkg_schema_dir / ".." / "data" / "schemas"
+            pkg_providers = pkg_data / "providers"
+            pkg_providers.mkdir(parents=True)
+            (pkg_providers / "us-east-1.json").write_text("{}")
+
+            cache_dir = Path(tmpdir) / "cache"
+            cache_dir.mkdir()
+
+            mock_dirname.return_value = str(pkg_schema_dir)
+            mock_cache_dir.return_value = str(cache_dir)
+
+            providers, resources = ProviderSchemaManager._resolve_schema_dirs()
+
+            self.assertEqual(providers, pkg_providers)
+
 
 class TestUpdateDownloadsVersionJson(BaseTestCase):
     """Test that update() fetches version.json"""


### PR DESCRIPTION
## Summary
- Schema manager uses bundled schemas (PyPI install) by default, with user cache as fallback
- Compares `schema_date` from `version.json` between bundled and cache to determine precedence
- `cfn-lint -u` downloads to cache and fetches `version.json` — cache wins if newer
- A pip upgrade with newer bundled schemas takes precedence until user runs `-u` again
- CD workflow copies schemas + version.json into package dir for bundling

## Depends on
- aws-cloudformation/resource-provider-enhanced-schemas#22 (merged) — adds `version.json` to release artifacts

## Test plan
- [ ] Fresh pip install uses bundled schemas
- [ ] `cfn-lint -u` downloads to cache, cache takes precedence after
- [ ] Pre-commit (no bundled) auto-downloads to cache on first run
- [ ] pip upgrade with newer bundled schemas takes over from stale cache