### PR TITLE
fix: Don't error on FindInMap keys resolved from parameter defaults

### DIFF
--- a/src/cfnlint/rules/functions/_BaseFn.py
+++ b/src/cfnlint/rules/functions/_BaseFn.py
@@ -175,6 +175,12 @@ class BaseFn(CfnLintJsonSchema):
         all_errs = []
         for value, v, resolve_err in validator.resolve_value(instance):
             if resolve_err:
+                # A resolution error against a value that only exists because
+                # of a parameter's Default (which a deployer can override at
+                # deployment time) is not a definite failure, so we don't
+                # report it. Hardcoded values are still validated.
+                if v.context.is_resolved_from_parameters:
+                    continue
                 yield from self.fix_errors(iter([resolve_err]))
                 continue
             errs = list(

--- a/test/unit/rules/functions/test_find_in_map.py
+++ b/test/unit/rules/functions/test_find_in_map.py
@@ -278,3 +278,64 @@ def test_validate(
         assert ref_mock.call_count == len(ref_mock_values) or 1
 
     assert errs == expected, f"Test {name!r} got {errs!r}"
+
+
+@pytest.fixture(scope="module")
+def cfn_with_default():
+    return Template(
+        "",
+        {
+            "Parameters": {"Stage": {"Type": "String", "Default": ""}},
+            "Resources": {"Dummy": Resource({"Type": "AWS::SNS::Topic"})},
+            "Mappings": {"StageMap": {"gamma": {"TCS": "1"}, "prod": {"TCS": "2"}}},
+        },
+        regions=["us-east-1"],
+    )
+
+
+@pytest.mark.parametrize(
+    "name,instance,expected_messages",
+    [
+        (
+            # A Ref to a parameter's Default resolves to a value that a
+            # deployer can override, so a missing mapping key isn't a
+            # definite failure and must not be reported (was E1011).
+            "Top level key from a parameter Default is not reported",
+            {"Fn::FindInMap": ["StageMap", {"Ref": "Stage"}, "TCS"]},
+            [],
+        ),
+        (
+            "Second level key from a parameter Default is not reported",
+            {"Fn::FindInMap": ["StageMap", "gamma", {"Ref": "Stage"}]},
+            [],
+        ),
+        (
+            # Hardcoded keys aren't overridable, so they are still validated.
+            "Hardcoded top level key is still reported",
+            {"Fn::FindInMap": ["StageMap", "typo", "TCS"]},
+            ["'typo' is not one of ['gamma', 'prod'] for mapping 'StageMap'"],
+        ),
+        (
+            "Hardcoded second level key is still reported",
+            {"Fn::FindInMap": ["StageMap", "gamma", "typo"]},
+            ["'typo' is not one of ['TCS'] for mapping 'StageMap' and key 'gamma'"],
+        ),
+    ],
+)
+def test_resolve_from_parameter_default(
+    name, instance, expected_messages, rule, cfn_with_default
+):
+    """Values resolved from an overridable parameter Default shouldn't
+    surface resolution errors, while hardcoded values still do."""
+    context = create_context_for_template(cfn_with_default)
+    validator = CfnTemplateValidator({}).extend(validators={})(
+        context=context, cfn=cfn_with_default
+    )
+
+    # A constraining schema is required for resolution to run
+    schema = {"type": "string", "pattern": "^[0-9]+$"}
+    errs = list(rule.resolve(validator, schema, instance, {}))
+
+    assert [err.message for err in errs] == expected_messages, (
+        f"{name!r} failed and got errors {[e.message for e in errs]!r}"
+    )


### PR DESCRIPTION
### Summary
`E1011` fired an **Error** when a `Fn::FindInMap` key came from a `Ref` to a parameter whose `Default` was empty or stale (not a mapping key). Since a default can be overridden at deployment time, this isn't a definite failure. This brings `Fn::FindInMap` in line with the equivalent `Fn::Sub` / `Fn::Equals` / `Fn::Not` cases, which already no longer report.

Example that incorrectly errored:

```yaml
Parameters:
  Stage:
    Type: String
    Default: ""
Mappings:
  StageMap:
    gamma: {TCS: "111111111111"}
    prod: {TCS: "222222222222"}
Resources:
  Dummy:
    Type: AWS::SNS::Topic
    Properties:
      TopicName:
        Fn::FindInMap: ["StageMap", {Ref: Stage}, "TCS"]
```

### Root cause
In `BaseFn.resolve()` (`src/cfnlint/rules/functions/_BaseFn.py`), the `resolve_err` branch passed resolver errors through without checking `is_resolved_from_parameters`, unlike the descend-error branch just below it that already honors the flag.

### Fix
Skip the resolver error when the value was resolved from a parameter default. Hardcoded keys are still validated and continue to report `E1011`.

### Tests
Added `test_resolve_from_parameter_default` covering top/second-level keys x from-default/hardcoded. The from-default cases fail without the fix; the hardcoded cases pass both ways. Full unit suite passes; `ruff check` / `ruff format` clean.