### PR TITLE
Compute Context.module_names lazily to avoid rescan on every evolve()

### DIFF
--- a/src/cfnlint/context/context.py
+++ b/src/cfnlint/context/context.py
@@ -10,7 +10,7 @@ from abc import ABC, abstractmethod
 from collections import deque
 from copy import deepcopy
 from dataclasses import InitVar, dataclass, field, fields
-from functools import lru_cache
+from functools import cached_property, lru_cache
 from typing import TYPE_CHECKING, Any, Deque, Iterator, Set, Tuple
 
 import regex as re
@@ -191,18 +191,13 @@ class Context:
     # exceptions will affect the results.
     allow_exceptions: bool = field(init=True, default=True)
 
-    # Cached: logical IDs of MODULE-type resources
-    module_names: tuple[str, ...] = field(init=False, default=())
-
-    def __post_init__(self) -> None:
-        object.__setattr__(
-            self,
-            "module_names",
-            tuple(
-                name
-                for name, resource in self.resources.items()
-                if resource.type.endswith("::MODULE")
-            ),
+    @cached_property
+    def module_names(self) -> tuple[str, ...]:
+        """Logical IDs of MODULE-type resources (lazily computed and cached)"""
+        return tuple(
+            name
+            for name, resource in self.resources.items()
+            if resource.type.endswith("::MODULE")
         )
 
     def evolve(self, **kwargs) -> "Context":

--- a/test/unit/module/context/test_context.py
+++ b/test/unit/module/context/test_context.py
@@ -8,6 +8,7 @@ from collections import deque
 
 from cfnlint.context import Context, Path
 from cfnlint.context.conditions._conditions import Condition, Conditions
+from cfnlint.context.context import Resource
 
 
 class TestCfnContext(unittest.TestCase):
@@ -106,3 +107,43 @@ class TestCfnContext(unittest.TestCase):
                     {"Foo": True},
                 ),
             )
+
+
+class _CountingResources(dict):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.items_calls = 0
+
+    def items(self):
+        self.items_calls += 1
+        return super().items()
+
+
+class TestModuleNames(unittest.TestCase):
+    def test_module_names(self):
+        context = Context(
+            resources={
+                "MyModule": Resource({"Type": "My::Organization::Custom::MODULE"}),
+                "MyBucket": Resource({"Type": "AWS::S3::Bucket"}),
+            }
+        )
+        self.assertEqual(context.module_names, ("MyModule",))
+
+    def test_module_names_not_computed_on_evolve(self):
+        # evolve() constructs a new Context on nearly every schema-walk
+        # descend, so neither construction nor evolution may scan resources;
+        # the scan happens lazily on first read and is cached per instance
+        resources = _CountingResources(
+            {
+                "MyModule": Resource({"Type": "My::Organization::Custom::MODULE"}),
+                "MyBucket": Resource({"Type": "AWS::S3::Bucket"}),
+            }
+        )
+        context = Context(resources=resources)
+        evolved = context.evolve(regions=["us-west-2"]).evolve(path=Path())
+        self.assertEqual(resources.items_calls, 0)
+
+        self.assertEqual(evolved.module_names, ("MyModule",))
+        self.assertEqual(resources.items_calls, 1)
+        self.assertEqual(evolved.module_names, ("MyModule",))
+        self.assertEqual(resources.items_calls, 1)

--- a/test/unit/module/context/test_context.py
+++ b/test/unit/module/context/test_context.py
@@ -147,3 +147,15 @@ class TestModuleNames(unittest.TestCase):
         self.assertEqual(resources.items_calls, 1)
         self.assertEqual(evolved.module_names, ("MyModule",))
         self.assertEqual(resources.items_calls, 1)
+
+    def test_module_names_recomputed_when_resources_replaced(self):
+        context = Context(
+            resources={
+                "MyModule": Resource({"Type": "My::Organization::Custom::MODULE"}),
+            }
+        )
+        self.assertEqual(context.module_names, ("MyModule",))
+        replaced = context.evolve(
+            resources={"MyBucket": Resource({"Type": "AWS::S3::Bucket"})}
+        )
+        self.assertEqual(replaced.module_names, ())


### PR DESCRIPTION
*Issue #, if available:* #4585

*Description of changes:*

`Context.__post_init__` rebuilt `module_names` on every `Context` construction — including all `evolve()` clones created during the schema walk — making validation O(nodes × resources) on every template (#4510, first released in 1.51.1). See the linked issue for profiles: on a ~250 KB template with ~270 resources this is ~84k constructions triggering ~22.4M `str.endswith` calls, ~46% of total runtime.

This change replaces the eager field with `functools.cached_property`, so the tuple is computed at most once per instance and only when actually read. Both readers (`dynamicValidation` in `_keywords_cfn.py` and `GetAtt`) consult it only at specific nodes, so most instances never compute it at all. `cached_property` works on the frozen dataclass because it writes to the instance `__dict__` directly, bypassing the frozen `__setattr__`.

Behavior note: `module_names` is no longer a dataclass field, so it is not part of the generated `__eq__`/`__repr__`. It is fully derived from `resources` (which is a field), and nothing in the codebase introspects it as a field.

Benchmarks (Apple M-series, warm): synthetic 400-resource template 4.8s → 3.7s (pre-regression 1.51.0 baseline: 3.4s); a fleet of 66 large (~250 KB) generated templates 3m55s → 2m42s. Unit test suite and pre-commit hooks pass.

---

*Prepared with AI assistance (Claude Code); human-reviewed before submission.*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
