### PR TITLE
Cache RefResolver subschemas lookup per instance

### DIFF
--- a/src/cfnlint/schema/resolver/_resolver.py
+++ b/src/cfnlint/schema/resolver/_resolver.py
@@ -64,6 +64,7 @@ class RefResolver:
     _urljoin_cache: Any = field(init=True, default=None)
     _cache: Any = field(init=True, default=None)
     _cache_cfn_pointer: Any = field(init=True, default=None)
+    _subschemas_cache: Any = field(init=False, default=None)
     store: Any = field(init=True, default=None)
 
     def __post_init__(self):
@@ -296,12 +297,15 @@ class RefResolver:
         return document
 
     def _get_subschemas_cache(self):
+        if self._subschemas_cache is not None:
+            return self._subschemas_cache
         cache = {key: [] for key in _SUBSCHEMAS_KEYWORDS}
         for keyword, subschema in _search_schema(
             self.referrer,
             _match_subschema_keywords,
         ):
             cache[keyword].append(subschema)
+        self._subschemas_cache = cache
         return cache
 
     def _find_in_subschemas(self, url):


### PR DESCRIPTION
*Issue #, if available:* none — follow-up to #4586, found while profiling for #4585

*Description of changes:*

`RefResolver._get_subschemas_cache()` re-ran a full breadth-first walk of the entire referrer schema document (`_search_schema`) on every `resolve()` call, despite the name suggesting a cache. The referrer schema is immutable for the lifetime of a resolver instance, so memoize the result on the instance (a new `init=False` field).

Benchmarks (v1.53.2 baseline): on a ~330 KB real-world template, cumulative profile time in `_get_subschemas_cache` drops 1.65s → 0.05s (the top self-time hotspot remaining after #4586); end-to-end wall clock on that template goes 4.20s → 3.90s (Apple M-series, best of 6, ~−7%). On a CI runner, a same-runner interleaved 3-way comparison over 72 real-world templates measured ~−4.5% end-to-end with zero overlap between arms — full table in the comment below.

Full unit test suite passes (2644 passed, 1 skipped); ruff, ruff-format, isort, and mypy are clean on the changed file.

---

*Prepared with AI assistance (Claude Code).*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

