### PR TITLE
Avoid recomputing dataclass fields() on every evolve()

### DIFF
--- a/src/cfnlint/context/context.py
+++ b/src/cfnlint/context/context.py
@@ -15,11 +15,6 @@ from typing import TYPE_CHECKING, Any, Deque, Iterator, Set, Tuple
 
 import regex as re
 
-
-@lru_cache(maxsize=None)
-def _init_field_names(cls) -> tuple[str, ...]:
-    return tuple(f.name for f in fields(cls) if f.init)
-
 from cfnlint.context._mappings import Mappings
 from cfnlint.context.conditions._conditions import Conditions
 from cfnlint.context.parameters import ParameterSet
@@ -31,6 +26,7 @@ from cfnlint.helpers import (
     REGION_PRIMARY,
     TRANSFORM_LANGUAGE_EXTENSION,
     TRANSFORM_SAM,
+    init_field_names,
 )
 from cfnlint.schema import PROVIDER_SCHEMA_MANAGER, AttributeDict
 
@@ -216,7 +212,7 @@ class Context:
             new_ref_values.update(kwargs["ref_values"])
             kwargs["ref_values"] = new_ref_values
 
-        for name in _init_field_names(Context):
+        for name in init_field_names(Context):
             kwargs.setdefault(name, getattr(self, name))
 
         return cls(**kwargs)

--- a/src/cfnlint/context/context.py
+++ b/src/cfnlint/context/context.py
@@ -15,6 +15,11 @@ from typing import TYPE_CHECKING, Any, Deque, Iterator, Set, Tuple
 
 import regex as re
 
+
+@lru_cache(maxsize=None)
+def _init_field_names(cls) -> tuple[str, ...]:
+    return tuple(f.name for f in fields(cls) if f.init)
+
 from cfnlint.context._mappings import Mappings
 from cfnlint.context.conditions._conditions import Conditions
 from cfnlint.context.parameters import ParameterSet
@@ -211,9 +216,8 @@ class Context:
             new_ref_values.update(kwargs["ref_values"])
             kwargs["ref_values"] = new_ref_values
 
-        for f in fields(Context):
-            if f.init:
-                kwargs.setdefault(f.name, getattr(self, f.name))
+        for name in _init_field_names(Context):
+            kwargs.setdefault(name, getattr(self, name))
 
         return cls(**kwargs)
 

--- a/src/cfnlint/helpers.py
+++ b/src/cfnlint/helpers.py
@@ -19,6 +19,7 @@ import json
 import logging
 import os
 import sys
+from functools import lru_cache
 from io import BytesIO
 from typing import Any, Sequence
 from urllib.request import Request, urlopen, urlretrieve
@@ -773,3 +774,9 @@ def ensure_list(instance: Any) -> list[Any]:
     if isinstance(instance, (list, tuple)):
         return list(instance)
     return [instance]
+
+
+@lru_cache(maxsize=None)
+def init_field_names(cls) -> tuple[str, ...]:
+    """Return the names of a dataclass's init fields (cached per class)"""
+    return tuple(f.name for f in dataclasses.fields(cls) if f.init)

--- a/src/cfnlint/jsonschema/validators.py
+++ b/src/cfnlint/jsonschema/validators.py
@@ -21,18 +21,12 @@ from __future__ import annotations
 import logging
 from collections import deque
 from collections.abc import Mapping
-from dataclasses import dataclass, field, fields
-from functools import lru_cache
+from dataclasses import dataclass, field
 from typing import Any, Callable
-
-
-@lru_cache(maxsize=None)
-def _init_field_names(cls) -> tuple:
-    return tuple(f.name for f in fields(cls) if f.init)
 
 from cfnlint.conditions import UnknownSatisfisfaction
 from cfnlint.context import Context
-from cfnlint.helpers import is_function
+from cfnlint.helpers import init_field_names, is_function
 from cfnlint.jsonschema import _keywords, _keywords_cfn, _resolvers_cfn
 from cfnlint.jsonschema._filter import FunctionFilter
 from cfnlint.jsonschema._format import FormatChecker, cfn_format_checker
@@ -346,7 +340,7 @@ def create(
             StandardValidator(schema={'type': 'number'}, format_checker=None)
             """
             cls = self.__class__
-            for name in _init_field_names(Validator):
+            for name in init_field_names(Validator):
                 kwargs.setdefault(name, getattr(self, name))
 
             return cls(**kwargs)

--- a/src/cfnlint/jsonschema/validators.py
+++ b/src/cfnlint/jsonschema/validators.py
@@ -22,7 +22,13 @@ import logging
 from collections import deque
 from collections.abc import Mapping
 from dataclasses import dataclass, field, fields
+from functools import lru_cache
 from typing import Any, Callable
+
+
+@lru_cache(maxsize=None)
+def _init_field_names(cls) -> tuple:
+    return tuple(f.name for f in fields(cls) if f.init)
 
 from cfnlint.conditions import UnknownSatisfisfaction
 from cfnlint.context import Context
@@ -340,9 +346,8 @@ def create(
             StandardValidator(schema={'type': 'number'}, format_checker=None)
             """
             cls = self.__class__
-            for f in fields(Validator):
-                if f.init:
-                    kwargs.setdefault(f.name, getattr(self, f.name))
+            for name in _init_field_names(Validator):
+                kwargs.setdefault(name, getattr(self, name))
 
             return cls(**kwargs)
 


### PR DESCRIPTION
*Issue #, if available:* none — follow-up to #4586

*Description of changes:*

`Context.evolve()` and `Validator.evolve()` call `dataclasses.fields()` on every invocation — ~230k calls when linting a large template — rebuilding the fields tuple and re-filtering for `init` fields each time. The init-field name tuple is constant per class, so compute it once per class via a small `lru_cache`d helper in `cfnlint.helpers`, shared by both call sites.

Benchmarks (Apple M-series, warm, v1.53.2 baseline): on a ~330 KB real-world template, wall clock goes 4.20s → 4.11s (best of 6 runs, ~−2%). Modest on its own, but it stacks with #4590 — the two together measured ~−8–9% on two large real-world templates.

Full unit test suite passes (2644 passed, 1 skipped); ruff, ruff-format, isort, and mypy are clean on the changed files.

---

*Prepared with AI assistance (Claude Code).*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
