### PR TITLE
fix(codepipeline): stop E3701 flagging Fn::If OutputArtifact names as duplicates

### DIFF
--- a/src/cfnlint/rules/resources/codepipeline/PipelineArtifactNames.py
+++ b/src/cfnlint/rules/resources/codepipeline/PipelineArtifactNames.py
@@ -30,7 +30,7 @@ class PipelineArtifactNames(CfnLintKeyword):
                 "Resources/AWS::CodePipeline::Pipeline/Properties/Stages/*/Actions/*/OutputArtifacts/*/Name",
             ],
         )
-        self._output_artifact_names: dict[str, list[tuple[str, dict]]] = {}
+        self._output_artifact_names: dict[str, list[tuple[str, dict, tuple]]] = {}
 
     def initialize(self, cfn):
         self._output_artifact_names = {}
@@ -49,11 +49,14 @@ class PipelineArtifactNames(CfnLintKeyword):
         if resource_name not in self._output_artifact_names:
             self._output_artifact_names[resource_name] = []
 
+        path = tuple(validator.context.path.path)
         if "OutputArtifacts" in validator.context.path.path:
-            for output_name, output_condition in self._output_artifact_names[
-                resource_name
-            ]:
-                if output_name != instance:
+            for (
+                output_name,
+                output_condition,
+                output_path,
+            ) in self._output_artifact_names[resource_name]:
+                if output_name != instance or output_path == path:
                     continue
                 try:
                     validator.evolve(
@@ -72,10 +75,10 @@ class PipelineArtifactNames(CfnLintKeyword):
                     pass
 
             self._output_artifact_names[resource_name].append(
-                (instance, validator.context.conditions.status)
+                (instance, validator.context.conditions.status, path)
             )
         elif "InputArtifacts" in validator.context.path.path:
-            for output_name, output_condition in self._output_artifact_names[
+            for output_name, output_condition, _ in self._output_artifact_names[
                 resource_name
             ]:
                 if output_name != instance:

--- a/test/unit/rules/resources/codepipeline/test_pipeline_artifact_names.py
+++ b/test/unit/rules/resources/codepipeline/test_pipeline_artifact_names.py
@@ -273,6 +273,43 @@ def _append_queues(queue1: Iterable, queue2: Iterable) -> deque:
                 ),
             ],
         ),
+        (
+            [
+                (
+                    "Foo",
+                    _append_queues(
+                        _standard_path,
+                        [0, "Actions", 0, "OutputArtifacts", 0, "Name", "Fn::If", 1],
+                    ),
+                    {"IsUsEast1": True},
+                ),
+                (
+                    "Foo",
+                    _append_queues(
+                        _standard_path,
+                        [0, "Actions", 0, "OutputArtifacts", 0, "Name", "Fn::If", 1],
+                    ),
+                    {"IsUsEast1": True},
+                ),
+                (
+                    "Bar",
+                    _append_queues(
+                        _standard_path,
+                        [0, "Actions", 0, "OutputArtifacts", 0, "Name", "Fn::If", 2],
+                    ),
+                    {"IsUsEast1": False},
+                ),
+                (
+                    "Bar",
+                    _append_queues(
+                        _standard_path,
+                        [0, "Actions", 0, "OutputArtifacts", 0, "Name", "Fn::If", 2],
+                    ),
+                    {"IsUsEast1": False},
+                ),
+            ],
+            [],
+        ),
     ],
 )
 def test_validate(instances, expected, rule, validator):


### PR DESCRIPTION
*Issue #, if available:* Fixes #4584

*Description of changes:*

An `OutputArtifacts` `Name` given as an `Fn::If` is visited twice per branch at the identical path, so E3701 compared the second visit against the entry it had just recorded for itself and reported the name as already defined. The rule now records the instance path with each name and skips same-path entries; genuine duplicates at different paths still error.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
