### PR TITLE
fix(E3701): Prevent false positive for Fn::If in OutputArtifacts Name

### DIFF
--- a/src/cfnlint/rules/resources/codepipeline/PipelineArtifactNames.py
+++ b/src/cfnlint/rules/resources/codepipeline/PipelineArtifactNames.py
@@ -30,7 +30,7 @@ class PipelineArtifactNames(CfnLintKeyword):
                 "Resources/AWS::CodePipeline::Pipeline/Properties/Stages/*/Actions/*/OutputArtifacts/*/Name",
             ],
         )
-        self._output_artifact_names: dict[str, list[tuple[str, dict]]] = {}
+        self._output_artifact_names: dict[str, list[tuple[str, dict, tuple]]] = {}
 
     def initialize(self, cfn):
         self._output_artifact_names = {}
@@ -50,11 +50,24 @@ class PipelineArtifactNames(CfnLintKeyword):
             self._output_artifact_names[resource_name] = []
 
         if "OutputArtifacts" in validator.context.path.path:
-            for output_name, output_condition in self._output_artifact_names[
-                resource_name
-            ]:
+            current_status = validator.context.conditions.status
+            current_path = tuple(validator.context.path.path)
+
+            for (
+                output_name,
+                output_condition,
+                output_path,
+            ) in self._output_artifact_names[resource_name]:
                 if output_name != instance:
                     continue
+
+                # Skip if this is the exact same path with the same conditions.
+                # This happens when the validator processes the same Fn::If branch
+                # multiple times (once per scenario iteration). We only want to
+                # flag duplicates from different paths (i.e., different actions).
+                if output_path == current_path and output_condition == current_status:
+                    return
+
                 try:
                     validator.evolve(
                         context=validator.context.evolve(
@@ -72,10 +85,10 @@ class PipelineArtifactNames(CfnLintKeyword):
                     pass
 
             self._output_artifact_names[resource_name].append(
-                (instance, validator.context.conditions.status)
+                (instance, current_status, current_path)
             )
         elif "InputArtifacts" in validator.context.path.path:
-            for output_name, output_condition in self._output_artifact_names[
+            for output_name, output_condition, _ in self._output_artifact_names[
                 resource_name
             ]:
                 if output_name != instance:

--- a/test/unit/rules/resources/codepipeline/test_pipeline_artifact_names.py
+++ b/test/unit/rules/resources/codepipeline/test_pipeline_artifact_names.py
@@ -67,6 +67,68 @@ def _append_queues(queue1: Iterable, queue2: Iterable) -> deque:
             ],
             [],
         ),
+        # Issue #4584: Fn::If for OutputArtifacts Name should not be a false positive.
+        # When the validator processes Fn::If branches, it may call the rule twice for
+        # the same resolved value (same path + same conditions). This should not be
+        # treated as a duplicate.
+        (
+            [
+                # First call for SourceGit (Fn::If branch 1)
+                (
+                    "SourceGit",
+                    _append_queues(
+                        _standard_path,
+                        [0, "Actions", 0, "OutputArtifacts", 0, "Name", "Fn::If", 1],
+                    ),
+                    {"IsUsEast1": True},
+                ),
+                # Second call for same SourceGit (validator calls twice)
+                (
+                    "SourceGit",
+                    _append_queues(
+                        _standard_path,
+                        [0, "Actions", 0, "OutputArtifacts", 0, "Name", "Fn::If", 1],
+                    ),
+                    {"IsUsEast1": True},
+                ),
+                # First call for SourceZip (Fn::If branch 2)
+                (
+                    "SourceZip",
+                    _append_queues(
+                        _standard_path,
+                        [0, "Actions", 0, "OutputArtifacts", 0, "Name", "Fn::If", 2],
+                    ),
+                    {"IsUsEast1": False},
+                ),
+                # Second call for same SourceZip (validator calls twice)
+                (
+                    "SourceZip",
+                    _append_queues(
+                        _standard_path,
+                        [0, "Actions", 0, "OutputArtifacts", 0, "Name", "Fn::If", 2],
+                    ),
+                    {"IsUsEast1": False},
+                ),
+                # InputArtifacts with Fn::If
+                (
+                    "SourceGit",
+                    _append_queues(
+                        _standard_path,
+                        [1, "Actions", 0, "InputArtifacts", 0, "Name", "Fn::If", 1],
+                    ),
+                    {"IsUsEast1": True},
+                ),
+                (
+                    "SourceZip",
+                    _append_queues(
+                        _standard_path,
+                        [1, "Actions", 0, "InputArtifacts", 0, "Name", "Fn::If", 2],
+                    ),
+                    {"IsUsEast1": False},
+                ),
+            ],
+            [],  # No errors expected
+        ),
         (
             [
                 (


### PR DESCRIPTION
## Summary

Fixes #4584

When an `AWS::CodePipeline::Pipeline` source action sets its `OutputArtifacts` `Name` with an `Fn::If`, cfn-lint was incorrectly reporting **E3701** for both branches of the conditional, even though they are mutually exclusive.

## Root Cause

The validator calls the E3701 rule multiple times for the same resolved `Fn::If` value (once per scenario iteration). The rule was tracking only `(artifact_name, condition_status)` tuples, so when it saw the same name with the same conditions twice, it incorrectly flagged it as a duplicate.

## Solution

Track the full path in addition to name and conditions: `(artifact_name, condition_status, path)`. When the exact same tuple is seen again, recognize it as a redundant call from scenario iteration rather than a true duplicate.

True duplicates (same name from different actions) have different paths and are still correctly flagged.

## Testing

- Added unit test covering the `Fn::If` scenario
- Verified the reproduction template from the issue now passes
- Verified actual duplicates (same name in different actions) are still caught
- All existing tests pass

## Test Results

```
# Issue reproduction template (was E3701 false positive, now passes)
$ cfn-lint template.yaml
# No errors

# Actual duplicate (still caught)
$ cfn-lint actual-duplicate.yaml  
E3701 'DuplicateName' is already a defined 'OutputArtifact' Name
```