### PR TITLE
fix(ec2): Allow FromPort/ToPort for ICMPv6 in W3687

### DIFF
--- a/src/cfnlint/data/schemas/extensions/aws_ec2_securitygroup/protocols_and_port_ranges_exclude.json
+++ b/src/cfnlint/data/schemas/extensions/aws_ec2_securitygroup/protocols_and_port_ranges_exclude.json
@@ -13,9 +13,14 @@
       17,
       "17",
       "udp",
+      58,
+      "58",
+      "icmpv6",
       "TCP",
       "UDP",
-      "ICMP"
+      "ICMP",
+      "ICMPv6",
+      "ICMPV6"
      ]
     },
     "type": [

--- a/test/unit/rules/resources/ec2/test_sg_protocols_ports_exclusive.py
+++ b/test/unit/rules/resources/ec2/test_sg_protocols_ports_exclusive.py
@@ -46,6 +46,38 @@ def rule():
         ),
         (
             {
+                "IpProtocol": "icmpv6",
+                "FromPort": -1,
+                "ToPort": -1,
+            },
+            [],
+        ),
+        (
+            {
+                "IpProtocol": "ICMPv6",
+                "FromPort": 8,
+                "ToPort": 0,
+            },
+            [],
+        ),
+        (
+            {
+                "IpProtocol": 58,
+                "FromPort": -1,
+                "ToPort": -1,
+            },
+            [],
+        ),
+        (
+            {
+                "IpProtocol": "58",
+                "FromPort": -1,
+                "ToPort": -1,
+            },
+            [],
+        ),
+        (
+            {
                 "IpProtocol": -1,
                 "FromPort": -1,
                 "ToPort": -1,


### PR DESCRIPTION
Add icmpv6 protocol variants (58, "58", "icmpv6", "ICMPv6", "ICMPV6") to the exclusion allowlist so that W3687 does not incorrectly flag FromPort/ToPort as ignored for ICMPv6 security group rules. These properties specify ICMP type and code which are valid for ICMPv6.

aws/aws-cdk#38422

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
