### PR TITLE
fix: treat an existing file path as literal instead of a glob pattern

### DIFF
--- a/src/cfnlint/config.py
+++ b/src/cfnlint/config.py
@@ -1052,7 +1052,10 @@ class ConfigMixIn(TemplateArgs, CliArgs, ConfigFileArgs):
         all_filenames = []
 
         for filename in filenames:
-            add_filenames = glob.glob(filename, recursive=True)
+            if Path(filename).is_file():
+                add_filenames = [filename]
+            else:
+                add_filenames = glob.glob(filename, recursive=True)
 
             if not add_filenames and not self.ignore_bad_template:
                 if raise_exception:

--- a/test/unit/module/config/test_config_mixin.py
+++ b/test/unit/module/config/test_config_mixin.py
@@ -5,6 +5,7 @@ SPDX-License-Identifier: MIT-0
 
 import logging
 import os
+import tempfile
 from pathlib import Path
 from test.testlib.testcase import BaseTestCase
 from unittest.mock import patch
@@ -198,6 +199,18 @@ class TestConfigMixIn(BaseTestCase):
                 ),
             ],
         )
+
+    @patch("cfnlint.config.ConfigFileArgs._read_config", create=True)
+    def test_config_literal_path_with_glob_characters(self, yaml_mock):
+        """Test literal paths containing glob metacharacters."""
+        yaml_mock.side_effect = [{}, {}]
+        with tempfile.TemporaryDirectory() as temp_dir:
+            filename = Path(temp_dir) / "template[1].yaml"
+            filename.touch()
+
+            config = cfnlint.config.ConfigMixIn(templates=[str(filename)])
+
+            self.assertEqual(config.templates, [str(filename)])
 
     @patch("cfnlint.config.ConfigFileArgs._read_config", create=True)
     @patch("sys.stdin.isatty", return_va=True)


### PR DESCRIPTION
*Issue #, if available:* Fixes #2136

*Description of changes:*

`ConfigMixIn` expands every template path through `glob.glob(filename, recursive=True)`. When the path is a real file whose name contains glob metacharacters, the brackets are read as a character class instead of literal text: the glob matches nothing and the template is silently dropped, or the pattern blows up on a bad character range. The reported case is the file name pytest's snapshot plugin produces:

```
emr/tests/__snapshots__/test_snapshot[emr--tests--emr.template.2.yaml].yaml
```

The fix checks the literal path first — if `Path(filename).is_file()` it is used as-is, otherwise the existing glob expansion runs unchanged. Patterns keep working exactly as before; a path that already resolves to a file is simply never reinterpreted as a pattern.

Test: `test_config_literal_path_with_glob_characters` creates `template[1].yaml` in a temporary directory and asserts it survives into `config.templates`. It fails on `main` (the list comes back empty) and passes with the fix.

AI-assisted (LLM used for drafting and for running the checks); the analysis and the runs are mine.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.