### PR TITLE
feat(lambda): count SAM CloudWatchLogs events in E2529

### DIFF
--- a/src/cfnlint/rules/resources/lmbd/EventsLogGroupName.py
+++ b/src/cfnlint/rules/resources/lmbd/EventsLogGroupName.py
@@ -3,6 +3,8 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 
+from __future__ import annotations
+
 import json
 
 from cfnlint._typing import RuleMatches
@@ -28,7 +30,7 @@ class EventsLogGroupName(CloudFormationLintRule):
     tags = ["resources", "lambda"]
     limit = 2
 
-    def check_events_subscription_duplicated(self, cfn):
+    def check_events_subscription_duplicated(self, cfn: Template) -> RuleMatches:
         """Check if Lambda Events Subscription is duplicated"""
         matches = []
         message = (
@@ -37,22 +39,74 @@ class EventsLogGroupName(CloudFormationLintRule):
         )
 
         log_group_paths = self.__get_log_group_name_list(cfn)
-        for _, c in log_group_paths.items():
-            if len(c) > self.limit:
-                matches.append(RuleMatch(["Resources", c[2]], message))
+        for _, paths in log_group_paths.items():
+            if len(paths) > self.limit:
+                matches.append(RuleMatch(paths[2], message))
 
         return matches
 
-    def __get_log_group_name_list(self, cfn):
-        log_group_paths = {}
-        for value in cfn.get_resources("AWS::Logs::SubscriptionFilter").items():
-            prop = value[1].get("Properties")
+    def __get_log_group_name_list(
+        self,
+        cfn: Template,
+    ) -> dict[str, list[list[str | int]]]:
+        log_group_paths: dict[str, list[list[str | int]]] = {}
+
+        # Enumerate AWS::Logs::SubscriptionFilter resources
+        for resource_name, resource in cfn.get_resources(
+            "AWS::Logs::SubscriptionFilter"
+        ).items():
+            prop = resource.get("Properties")
+            if not isinstance(prop, dict):
+                continue
             log_group_name = json.dumps(prop.get("LogGroupName"))
 
             if log_group_name not in log_group_paths:
                 log_group_paths[log_group_name] = []
 
-            log_group_paths[log_group_name].append(value[0])
+            log_group_paths[log_group_name].append(
+                ["Resources", resource_name, "Properties", "LogGroupName"],
+            )
+
+        # Enumerate AWS::Serverless::Function CloudWatchLogs events
+        for resource_name, resource in cfn.get_resources(
+            "AWS::Serverless::Function"
+        ).items():
+            props = resource.get("Properties")
+            if not isinstance(props, dict):
+                continue
+            events = props.get("Events")
+            if not isinstance(events, dict):
+                continue
+
+            for event_id, event in events.items():
+                if not isinstance(event, dict):
+                    continue
+                if event.get("Type") != "CloudWatchLogs":
+                    continue
+                event_props = event.get("Properties")
+                if not isinstance(event_props, dict):
+                    continue
+                log_group_name_value = event_props.get("LogGroupName")
+                if log_group_name_value is None:
+                    continue
+
+                log_group_name = json.dumps(log_group_name_value)
+
+                if log_group_name not in log_group_paths:
+                    log_group_paths[log_group_name] = []
+
+                log_group_paths[log_group_name].append(
+                    [
+                        "Resources",
+                        resource_name,
+                        "Properties",
+                        "Events",
+                        event_id,
+                        "Properties",
+                        "LogGroupName",
+                    ],
+                )
+
         return log_group_paths
 
     def match(self, cfn: Template) -> RuleMatches:

--- a/test/unit/rules/resources/lmbd/test_events_log_group_name.py
+++ b/test/unit/rules/resources/lmbd/test_events_log_group_name.py
@@ -5,7 +5,10 @@ SPDX-License-Identifier: MIT-0
 
 from test.unit.rules import BaseRuleTestCase
 
+import pytest
+
 from cfnlint.rules.resources.lmbd.EventsLogGroupName import EventsLogGroupName
+from cfnlint.template import Template
 
 
 class TestEventsLogGroupName(BaseRuleTestCase):
@@ -25,9 +28,407 @@ class TestEventsLogGroupName(BaseRuleTestCase):
 
     def test_file_negative(self):
         """Test failure"""
-        # SAM event sources (CloudWatchLogs) are no longer transformed into
-        # AWS::Logs::SubscriptionFilter resources. The rule can only check
-        # explicitly declared subscription filters, not SAM-generated ones.
+        # The bad fixture has 3 CloudWatchLogs events pointing to FunctionALogGroup
+        # which exceeds the limit of 2
         self.helper_file_negative(
-            "test/fixtures/templates/bad/some_logs_stream_lambda.yaml", 0
+            "test/fixtures/templates/bad/some_logs_stream_lambda.yaml",
+            1,
         )
+
+
+@pytest.fixture(scope="module")
+def rule():
+    return EventsLogGroupName()
+
+
+class TestEventsLogGroupNameUnit:
+    """Unit tests for E2529 rule"""
+
+    def test_sam_events_exceeds_limit(self, rule):
+        """Test that >2 SAM CloudWatchLogs events on one log group fails"""
+        template = Template(
+            "",
+            {
+                "AWSTemplateFormatVersion": "2010-09-09",
+                "Transform": "AWS::Serverless-2016-10-31",
+                "Resources": {
+                    "MyLogGroup": {
+                        "Type": "AWS::Logs::LogGroup",
+                        "Properties": {"LogGroupName": "/aws/lambda/my-function"},
+                    },
+                    "LogSubscriptionFunction": {
+                        "Type": "AWS::Serverless::Function",
+                        "Properties": {
+                            "CodeUri": "hello_world/",
+                            "Handler": "app.lambda_handler",
+                            "Runtime": "python3.9",
+                            "Events": {
+                                "Event1": {
+                                    "Type": "CloudWatchLogs",
+                                    "Properties": {
+                                        "LogGroupName": {"Ref": "MyLogGroup"},
+                                        "FilterPattern": "",
+                                    },
+                                },
+                                "Event2": {
+                                    "Type": "CloudWatchLogs",
+                                    "Properties": {
+                                        "LogGroupName": {"Ref": "MyLogGroup"},
+                                        "FilterPattern": "",
+                                    },
+                                },
+                                "Event3": {
+                                    "Type": "CloudWatchLogs",
+                                    "Properties": {
+                                        "LogGroupName": {"Ref": "MyLogGroup"},
+                                        "FilterPattern": "",
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        )
+        matches = rule.match(template)
+        assert len(matches) == 1
+        # Verify path points to the SAM function's event
+        assert matches[0].path[0] == "Resources"
+        assert matches[0].path[1] == "LogSubscriptionFunction"
+        assert matches[0].path[3] == "Events"
+
+    def test_sam_events_within_limit(self, rule):
+        """Test that <=2 SAM CloudWatchLogs events on one log group passes"""
+        template = Template(
+            "",
+            {
+                "AWSTemplateFormatVersion": "2010-09-09",
+                "Transform": "AWS::Serverless-2016-10-31",
+                "Resources": {
+                    "MyLogGroup": {
+                        "Type": "AWS::Logs::LogGroup",
+                        "Properties": {"LogGroupName": "/aws/lambda/my-function"},
+                    },
+                    "LogSubscriptionFunction": {
+                        "Type": "AWS::Serverless::Function",
+                        "Properties": {
+                            "CodeUri": "hello_world/",
+                            "Handler": "app.lambda_handler",
+                            "Runtime": "python3.9",
+                            "Events": {
+                                "Event1": {
+                                    "Type": "CloudWatchLogs",
+                                    "Properties": {
+                                        "LogGroupName": {"Ref": "MyLogGroup"},
+                                        "FilterPattern": "",
+                                    },
+                                },
+                                "Event2": {
+                                    "Type": "CloudWatchLogs",
+                                    "Properties": {
+                                        "LogGroupName": {"Ref": "MyLogGroup"},
+                                        "FilterPattern": "",
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        )
+        matches = rule.match(template)
+        assert len(matches) == 0
+
+    def test_sam_events_unique_log_groups(self, rule):
+        """Test that SAM events on unique log groups passes"""
+        template = Template(
+            "",
+            {
+                "AWSTemplateFormatVersion": "2010-09-09",
+                "Transform": "AWS::Serverless-2016-10-31",
+                "Resources": {
+                    "LogGroup1": {
+                        "Type": "AWS::Logs::LogGroup",
+                        "Properties": {"LogGroupName": "/aws/lambda/function1"},
+                    },
+                    "LogGroup2": {
+                        "Type": "AWS::Logs::LogGroup",
+                        "Properties": {"LogGroupName": "/aws/lambda/function2"},
+                    },
+                    "LogGroup3": {
+                        "Type": "AWS::Logs::LogGroup",
+                        "Properties": {"LogGroupName": "/aws/lambda/function3"},
+                    },
+                    "LogSubscriptionFunction": {
+                        "Type": "AWS::Serverless::Function",
+                        "Properties": {
+                            "CodeUri": "hello_world/",
+                            "Handler": "app.lambda_handler",
+                            "Runtime": "python3.9",
+                            "Events": {
+                                "Event1": {
+                                    "Type": "CloudWatchLogs",
+                                    "Properties": {
+                                        "LogGroupName": {"Ref": "LogGroup1"},
+                                        "FilterPattern": "",
+                                    },
+                                },
+                                "Event2": {
+                                    "Type": "CloudWatchLogs",
+                                    "Properties": {
+                                        "LogGroupName": {"Ref": "LogGroup2"},
+                                        "FilterPattern": "",
+                                    },
+                                },
+                                "Event3": {
+                                    "Type": "CloudWatchLogs",
+                                    "Properties": {
+                                        "LogGroupName": {"Ref": "LogGroup3"},
+                                        "FilterPattern": "",
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        )
+        matches = rule.match(template)
+        assert len(matches) == 0
+
+    def test_mixed_explicit_filter_and_sam_events(self, rule):
+        """Test mixed explicit SubscriptionFilter and SAM events exceeding limit"""
+        dest_arn = "arn:aws:lambda:us-east-1:123456789012:function:f"
+        template = Template(
+            "",
+            {
+                "AWSTemplateFormatVersion": "2010-09-09",
+                "Transform": "AWS::Serverless-2016-10-31",
+                "Resources": {
+                    "MyLogGroup": {
+                        "Type": "AWS::Logs::LogGroup",
+                        "Properties": {"LogGroupName": "/aws/lambda/my-function"},
+                    },
+                    "ExplicitFilter1": {
+                        "Type": "AWS::Logs::SubscriptionFilter",
+                        "Properties": {
+                            "LogGroupName": {"Ref": "MyLogGroup"},
+                            "FilterPattern": "",
+                            "DestinationArn": dest_arn,
+                        },
+                    },
+                    "ExplicitFilter2": {
+                        "Type": "AWS::Logs::SubscriptionFilter",
+                        "Properties": {
+                            "LogGroupName": {"Ref": "MyLogGroup"},
+                            "FilterPattern": "",
+                            "DestinationArn": dest_arn,
+                        },
+                    },
+                    "LogSubscriptionFunction": {
+                        "Type": "AWS::Serverless::Function",
+                        "Properties": {
+                            "CodeUri": "hello_world/",
+                            "Handler": "app.lambda_handler",
+                            "Runtime": "python3.9",
+                            "Events": {
+                                "Event1": {
+                                    "Type": "CloudWatchLogs",
+                                    "Properties": {
+                                        "LogGroupName": {"Ref": "MyLogGroup"},
+                                        "FilterPattern": "",
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        )
+        # 2 explicit filters + 1 SAM event = 3, exceeds limit of 2
+        matches = rule.match(template)
+        assert len(matches) == 1
+
+    def test_explicit_filters_only_exceeds_limit(self, rule):
+        """Test explicit SubscriptionFilters exceeding limit"""
+        dest_arn = "arn:aws:lambda:us-east-1:123456789012:function:f"
+        template = Template(
+            "",
+            {
+                "AWSTemplateFormatVersion": "2010-09-09",
+                "Resources": {
+                    "MyLogGroup": {
+                        "Type": "AWS::Logs::LogGroup",
+                        "Properties": {"LogGroupName": "/aws/lambda/my-function"},
+                    },
+                    "ExplicitFilter1": {
+                        "Type": "AWS::Logs::SubscriptionFilter",
+                        "Properties": {
+                            "LogGroupName": {"Ref": "MyLogGroup"},
+                            "FilterPattern": "",
+                            "DestinationArn": dest_arn,
+                        },
+                    },
+                    "ExplicitFilter2": {
+                        "Type": "AWS::Logs::SubscriptionFilter",
+                        "Properties": {
+                            "LogGroupName": {"Ref": "MyLogGroup"},
+                            "FilterPattern": "",
+                            "DestinationArn": dest_arn,
+                        },
+                    },
+                    "ExplicitFilter3": {
+                        "Type": "AWS::Logs::SubscriptionFilter",
+                        "Properties": {
+                            "LogGroupName": {"Ref": "MyLogGroup"},
+                            "FilterPattern": "",
+                            "DestinationArn": dest_arn,
+                        },
+                    },
+                },
+            },
+        )
+        matches = rule.match(template)
+        assert len(matches) == 1
+
+    def test_non_dict_events_no_crash(self, rule):
+        """Test that non-dict Events does not crash"""
+        template = Template(
+            "",
+            {
+                "AWSTemplateFormatVersion": "2010-09-09",
+                "Transform": "AWS::Serverless-2016-10-31",
+                "Resources": {
+                    "LogSubscriptionFunction": {
+                        "Type": "AWS::Serverless::Function",
+                        "Properties": {
+                            "CodeUri": "hello_world/",
+                            "Handler": "app.lambda_handler",
+                            "Runtime": "python3.9",
+                            "Events": {
+                                "Fn::If": ["Cond", {"Event1": {}}, {"Event2": {}}],
+                            },
+                        },
+                    },
+                },
+            },
+        )
+        # Should not crash, and should not produce matches
+        matches = rule.match(template)
+        assert len(matches) == 0
+
+    def test_non_dict_event_no_crash(self, rule):
+        """Test that non-dict individual event does not crash"""
+        template = Template(
+            "",
+            {
+                "AWSTemplateFormatVersion": "2010-09-09",
+                "Transform": "AWS::Serverless-2016-10-31",
+                "Resources": {
+                    "LogSubscriptionFunction": {
+                        "Type": "AWS::Serverless::Function",
+                        "Properties": {
+                            "CodeUri": "hello_world/",
+                            "Handler": "app.lambda_handler",
+                            "Runtime": "python3.9",
+                            "Events": {
+                                "Event1": {"Ref": "SomeParameter"},
+                            },
+                        },
+                    },
+                },
+            },
+        )
+        # Should not crash
+        matches = rule.match(template)
+        assert len(matches) == 0
+
+    def test_non_dict_event_properties_no_crash(self, rule):
+        """Test that non-dict event Properties does not crash"""
+        template = Template(
+            "",
+            {
+                "AWSTemplateFormatVersion": "2010-09-09",
+                "Transform": "AWS::Serverless-2016-10-31",
+                "Resources": {
+                    "LogSubscriptionFunction": {
+                        "Type": "AWS::Serverless::Function",
+                        "Properties": {
+                            "CodeUri": "hello_world/",
+                            "Handler": "app.lambda_handler",
+                            "Runtime": "python3.9",
+                            "Events": {
+                                "Event1": {
+                                    "Type": "CloudWatchLogs",
+                                    "Properties": {"Fn::If": ["Cond", {}, {}]},
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        )
+        # Should not crash
+        matches = rule.match(template)
+        assert len(matches) == 0
+
+    def test_missing_loggroupname_no_crash(self, rule):
+        """Test that missing LogGroupName does not crash"""
+        template = Template(
+            "",
+            {
+                "AWSTemplateFormatVersion": "2010-09-09",
+                "Transform": "AWS::Serverless-2016-10-31",
+                "Resources": {
+                    "LogSubscriptionFunction": {
+                        "Type": "AWS::Serverless::Function",
+                        "Properties": {
+                            "CodeUri": "hello_world/",
+                            "Handler": "app.lambda_handler",
+                            "Runtime": "python3.9",
+                            "Events": {
+                                "Event1": {
+                                    "Type": "CloudWatchLogs",
+                                    "Properties": {"FilterPattern": ""},
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        )
+        # Should not crash
+        matches = rule.match(template)
+        assert len(matches) == 0
+
+    def test_non_cloudwatchlogs_event_ignored(self, rule):
+        """Test that non-CloudWatchLogs event types are ignored"""
+        template = Template(
+            "",
+            {
+                "AWSTemplateFormatVersion": "2010-09-09",
+                "Transform": "AWS::Serverless-2016-10-31",
+                "Resources": {
+                    "LogSubscriptionFunction": {
+                        "Type": "AWS::Serverless::Function",
+                        "Properties": {
+                            "CodeUri": "hello_world/",
+                            "Handler": "app.lambda_handler",
+                            "Runtime": "python3.9",
+                            "Events": {
+                                "ApiEvent": {
+                                    "Type": "Api",
+                                    "Properties": {"Path": "/hello", "Method": "get"},
+                                },
+                                "ScheduleEvent": {
+                                    "Type": "Schedule",
+                                    "Properties": {"Schedule": "rate(1 minute)"},
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        )
+        matches = rule.match(template)
+        assert len(matches) == 0

--- a/test/unit/rules/resources/lmbd/test_events_log_group_name.py
+++ b/test/unit/rules/resources/lmbd/test_events_log_group_name.py
@@ -291,116 +291,6 @@ class TestEventsLogGroupNameUnit:
         matches = rule.match(template)
         assert len(matches) == 1
 
-    def test_non_dict_events_no_crash(self, rule):
-        """Test that non-dict Events does not crash"""
-        template = Template(
-            "",
-            {
-                "AWSTemplateFormatVersion": "2010-09-09",
-                "Transform": "AWS::Serverless-2016-10-31",
-                "Resources": {
-                    "LogSubscriptionFunction": {
-                        "Type": "AWS::Serverless::Function",
-                        "Properties": {
-                            "CodeUri": "hello_world/",
-                            "Handler": "app.lambda_handler",
-                            "Runtime": "python3.9",
-                            "Events": {
-                                "Fn::If": ["Cond", {"Event1": {}}, {"Event2": {}}],
-                            },
-                        },
-                    },
-                },
-            },
-        )
-        # Should not crash, and should not produce matches
-        matches = rule.match(template)
-        assert len(matches) == 0
-
-    def test_non_dict_event_no_crash(self, rule):
-        """Test that non-dict individual event does not crash"""
-        template = Template(
-            "",
-            {
-                "AWSTemplateFormatVersion": "2010-09-09",
-                "Transform": "AWS::Serverless-2016-10-31",
-                "Resources": {
-                    "LogSubscriptionFunction": {
-                        "Type": "AWS::Serverless::Function",
-                        "Properties": {
-                            "CodeUri": "hello_world/",
-                            "Handler": "app.lambda_handler",
-                            "Runtime": "python3.9",
-                            "Events": {
-                                "Event1": {"Ref": "SomeParameter"},
-                            },
-                        },
-                    },
-                },
-            },
-        )
-        # Should not crash
-        matches = rule.match(template)
-        assert len(matches) == 0
-
-    def test_non_dict_event_properties_no_crash(self, rule):
-        """Test that non-dict event Properties does not crash"""
-        template = Template(
-            "",
-            {
-                "AWSTemplateFormatVersion": "2010-09-09",
-                "Transform": "AWS::Serverless-2016-10-31",
-                "Resources": {
-                    "LogSubscriptionFunction": {
-                        "Type": "AWS::Serverless::Function",
-                        "Properties": {
-                            "CodeUri": "hello_world/",
-                            "Handler": "app.lambda_handler",
-                            "Runtime": "python3.9",
-                            "Events": {
-                                "Event1": {
-                                    "Type": "CloudWatchLogs",
-                                    "Properties": {"Fn::If": ["Cond", {}, {}]},
-                                },
-                            },
-                        },
-                    },
-                },
-            },
-        )
-        # Should not crash
-        matches = rule.match(template)
-        assert len(matches) == 0
-
-    def test_missing_loggroupname_no_crash(self, rule):
-        """Test that missing LogGroupName does not crash"""
-        template = Template(
-            "",
-            {
-                "AWSTemplateFormatVersion": "2010-09-09",
-                "Transform": "AWS::Serverless-2016-10-31",
-                "Resources": {
-                    "LogSubscriptionFunction": {
-                        "Type": "AWS::Serverless::Function",
-                        "Properties": {
-                            "CodeUri": "hello_world/",
-                            "Handler": "app.lambda_handler",
-                            "Runtime": "python3.9",
-                            "Events": {
-                                "Event1": {
-                                    "Type": "CloudWatchLogs",
-                                    "Properties": {"FilterPattern": ""},
-                                },
-                            },
-                        },
-                    },
-                },
-            },
-        )
-        # Should not crash
-        matches = rule.match(template)
-        assert len(matches) == 0
-
     def test_non_cloudwatchlogs_event_ignored(self, rule):
         """Test that non-CloudWatchLogs event types are ignored"""
         template = Template(
@@ -430,5 +320,194 @@ class TestEventsLogGroupNameUnit:
                 },
             },
         )
+        matches = rule.match(template)
+        assert len(matches) == 0
+
+
+class TestEventsLogGroupNameGuardBranches:
+    """Tests that exercise defensive guard branches for coverage"""
+
+    def test_subscription_filter_non_dict_properties(self, rule):
+        """Test SubscriptionFilter with non-dict Properties (line 60)"""
+        template = Template(
+            "",
+            {
+                "AWSTemplateFormatVersion": "2010-09-09",
+                "Resources": {
+                    "BadFilter": {
+                        "Type": "AWS::Logs::SubscriptionFilter",
+                        # Properties is a string instead of dict
+                        "Properties": "not-a-dict",
+                    },
+                },
+            },
+        )
+        # Should skip the resource and not crash
+        matches = rule.match(template)
+        assert len(matches) == 0
+
+    def test_sam_function_non_dict_properties(self, rule):
+        """Test SAM Function with non-dict Properties (line 76)"""
+        template = Template(
+            "",
+            {
+                "AWSTemplateFormatVersion": "2010-09-09",
+                "Transform": "AWS::Serverless-2016-10-31",
+                "Resources": {
+                    "BadFunction": {
+                        "Type": "AWS::Serverless::Function",
+                        # Properties is a string instead of dict
+                        "Properties": "not-a-dict",
+                    },
+                },
+            },
+        )
+        # Should skip the resource and not crash
+        matches = rule.match(template)
+        assert len(matches) == 0
+
+    def test_sam_function_non_dict_events(self, rule):
+        """Test SAM Function with non-dict Events value (line 79)"""
+        template = Template(
+            "",
+            {
+                "AWSTemplateFormatVersion": "2010-09-09",
+                "Transform": "AWS::Serverless-2016-10-31",
+                "Resources": {
+                    "FunctionWithBadEvents": {
+                        "Type": "AWS::Serverless::Function",
+                        "Properties": {
+                            "CodeUri": "hello_world/",
+                            "Handler": "app.lambda_handler",
+                            "Runtime": "python3.9",
+                            # Events is a string instead of dict
+                            "Events": "not-a-dict",
+                        },
+                    },
+                },
+            },
+        )
+        # Should skip the Events and not crash
+        matches = rule.match(template)
+        assert len(matches) == 0
+
+    def test_sam_function_non_dict_event_entry(self, rule):
+        """Test SAM Function with non-dict individual event (line 83)"""
+        template = Template(
+            "",
+            {
+                "AWSTemplateFormatVersion": "2010-09-09",
+                "Transform": "AWS::Serverless-2016-10-31",
+                "Resources": {
+                    "FunctionWithBadEvent": {
+                        "Type": "AWS::Serverless::Function",
+                        "Properties": {
+                            "CodeUri": "hello_world/",
+                            "Handler": "app.lambda_handler",
+                            "Runtime": "python3.9",
+                            "Events": {
+                                # Event value is a string instead of dict
+                                "BadEvent": "not-a-dict",
+                            },
+                        },
+                    },
+                },
+            },
+        )
+        # Should skip the event and not crash
+        matches = rule.match(template)
+        assert len(matches) == 0
+
+    def test_sam_cloudwatchlogs_non_dict_event_properties(self, rule):
+        """Test CloudWatchLogs event with non-dict Properties (line 88)"""
+        template = Template(
+            "",
+            {
+                "AWSTemplateFormatVersion": "2010-09-09",
+                "Transform": "AWS::Serverless-2016-10-31",
+                "Resources": {
+                    "FunctionWithBadEventProps": {
+                        "Type": "AWS::Serverless::Function",
+                        "Properties": {
+                            "CodeUri": "hello_world/",
+                            "Handler": "app.lambda_handler",
+                            "Runtime": "python3.9",
+                            "Events": {
+                                "BadCloudWatchEvent": {
+                                    "Type": "CloudWatchLogs",
+                                    # Properties is a string instead of dict
+                                    "Properties": "not-a-dict",
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        )
+        # Should skip the event and not crash
+        matches = rule.match(template)
+        assert len(matches) == 0
+
+    def test_sam_cloudwatchlogs_missing_loggroupname(self, rule):
+        """Test CloudWatchLogs event with missing LogGroupName (line 91)"""
+        template = Template(
+            "",
+            {
+                "AWSTemplateFormatVersion": "2010-09-09",
+                "Transform": "AWS::Serverless-2016-10-31",
+                "Resources": {
+                    "FunctionWithMissingLogGroup": {
+                        "Type": "AWS::Serverless::Function",
+                        "Properties": {
+                            "CodeUri": "hello_world/",
+                            "Handler": "app.lambda_handler",
+                            "Runtime": "python3.9",
+                            "Events": {
+                                "IncompleteEvent": {
+                                    "Type": "CloudWatchLogs",
+                                    "Properties": {
+                                        # LogGroupName is missing
+                                        "FilterPattern": "",
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        )
+        # Should skip the event and not crash
+        matches = rule.match(template)
+        assert len(matches) == 0
+
+    def test_sam_cloudwatchlogs_null_loggroupname(self, rule):
+        """Test CloudWatchLogs event with explicit null LogGroupName (line 91)"""
+        template = Template(
+            "",
+            {
+                "AWSTemplateFormatVersion": "2010-09-09",
+                "Transform": "AWS::Serverless-2016-10-31",
+                "Resources": {
+                    "FunctionWithNullLogGroup": {
+                        "Type": "AWS::Serverless::Function",
+                        "Properties": {
+                            "CodeUri": "hello_world/",
+                            "Handler": "app.lambda_handler",
+                            "Runtime": "python3.9",
+                            "Events": {
+                                "NullLogGroupEvent": {
+                                    "Type": "CloudWatchLogs",
+                                    "Properties": {
+                                        "LogGroupName": None,
+                                        "FilterPattern": "",
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        )
+        # Should skip the event and not crash
         matches = rule.match(template)
         assert len(matches) == 0


### PR DESCRIPTION
Extends E2529 (EventsLogGroupName) to count `AWS::Serverless::Function` `CloudWatchLogs` events toward the 2-subscription-filters-per-log-group limit, merging with explicit `AWS::Logs::SubscriptionFilter` resources. Post-#4491 SAM resources are no longer expanded, so these were uncounted.

Fixes #4609
Tracking: #4607