### PR TITLE
fix(lambda): W2530 SnapStart support for Serverless::Function

### DIFF
--- a/src/cfnlint/rules/resources/lmbd/SnapStart.py
+++ b/src/cfnlint/rules/resources/lmbd/SnapStart.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from cfnlint.helpers import is_function
 from cfnlint.jsonschema import ValidationError, ValidationResult, Validator
 from cfnlint.rules.jsonschema.CfnLintKeyword import CfnLintKeyword
 
@@ -25,7 +26,10 @@ class SnapStart(CfnLintKeyword):
 
     def __init__(self):
         super().__init__(
-            ["Resources/AWS::Lambda::Function/Properties/SnapStart/ApplyOn"]
+            [
+                "Resources/AWS::Lambda::Function/Properties/SnapStart/ApplyOn",
+                "Resources/AWS::Serverless::Function/Properties/SnapStart/ApplyOn",
+            ]
         )
 
     def validate(
@@ -38,6 +42,49 @@ class SnapStart(CfnLintKeyword):
             return
 
         resource_name: str = str(validator.context.path.path[1])
+        resource_type: str = str(validator.context.path.cfn_path[1])
+
+        # For AWS::Serverless::Function, check for AutoPublishAlias
+        # which is the SAM mechanism that publishes a version
+        if resource_type == "AWS::Serverless::Function":
+            resources = validator.cfn.template.get("Resources", {})
+            if not isinstance(resources, dict):
+                return
+
+            # If Resources is an intrinsic function, we can't evaluate it
+            fn_key, _ = is_function(resources)
+            if fn_key is not None:
+                return
+
+            resource = resources.get(resource_name, {})
+            if not isinstance(resource, dict):
+                return
+
+            # If resource is an intrinsic function, we can't evaluate it
+            fn_key, _ = is_function(resource)
+            if fn_key is not None:
+                return
+
+            properties = resource.get("Properties", {})
+            if not isinstance(properties, dict):
+                return
+
+            # If properties is an intrinsic function, we can't evaluate it
+            fn_key, _ = is_function(properties)
+            if fn_key is not None:
+                return
+
+            # AutoPublishAlias causes SAM to generate AWS::Lambda::Version
+            # and AWS::Lambda::Alias resources
+            if properties.get("AutoPublishAlias") is not None:
+                return
+
+            yield ValidationError(
+                "'SnapStart' is enabled but 'AutoPublishAlias' is not configured",
+            )
+            return
+
+        # For AWS::Lambda::Function, check for attached AWS::Lambda::Version
         lambda_version_type = "AWS::Lambda::Version"
         if list(
             validator.cfn.get_resource_children(resource_name, [lambda_version_type])

--- a/test/unit/rules/resources/lmbd/test_snapstart.py
+++ b/test/unit/rules/resources/lmbd/test_snapstart.py
@@ -331,10 +331,116 @@ class TestSnapStartSamEdgeCases:
         errs = list(rule.validate(validator, "", "PublishedVersions", {}))
         assert errs == []
 
-    def test_sam_with_non_dict_resources(self, rule, validator):
-        """Non-dict Resources should not cause errors"""
+    def test_sam_with_intrinsic_resources(self, rule, validator):
+        """Resources as intrinsic function should bail out without error"""
         template = {
             "Resources": {"Ref": "SomeRef"},
+        }
+        validator = validator.evolve(
+            cfn=Template("", template),
+            context=Context(
+                path=Path(
+                    path=deque(
+                        [
+                            "Resources",
+                            "MyFunction",
+                            "Properties",
+                            "SnapStart",
+                            "ApplyOn",
+                        ]
+                    ),
+                    cfn_path=deque(
+                        [
+                            "Resources",
+                            "AWS::Serverless::Function",
+                            "Properties",
+                            "SnapStart",
+                            "ApplyOn",
+                        ]
+                    ),
+                )
+            ),
+        )
+        errs = list(rule.validate(validator, "", "PublishedVersions", {}))
+        assert errs == []
+
+    def test_sam_with_string_resources(self, rule, validator):
+        """Resources as string should bail out without error (line 52)"""
+        template = {
+            "Resources": "not-a-dict",
+        }
+        validator = validator.evolve(
+            cfn=Template("", template),
+            context=Context(
+                path=Path(
+                    path=deque(
+                        [
+                            "Resources",
+                            "MyFunction",
+                            "Properties",
+                            "SnapStart",
+                            "ApplyOn",
+                        ]
+                    ),
+                    cfn_path=deque(
+                        [
+                            "Resources",
+                            "AWS::Serverless::Function",
+                            "Properties",
+                            "SnapStart",
+                            "ApplyOn",
+                        ]
+                    ),
+                )
+            ),
+        )
+        errs = list(rule.validate(validator, "", "PublishedVersions", {}))
+        assert errs == []
+
+    def test_sam_with_string_resource(self, rule, validator):
+        """Resource as string should bail out without error (line 61)"""
+        template = {
+            "Resources": {
+                "MyFunction": "not-a-dict",
+            }
+        }
+        validator = validator.evolve(
+            cfn=Template("", template),
+            context=Context(
+                path=Path(
+                    path=deque(
+                        [
+                            "Resources",
+                            "MyFunction",
+                            "Properties",
+                            "SnapStart",
+                            "ApplyOn",
+                        ]
+                    ),
+                    cfn_path=deque(
+                        [
+                            "Resources",
+                            "AWS::Serverless::Function",
+                            "Properties",
+                            "SnapStart",
+                            "ApplyOn",
+                        ]
+                    ),
+                )
+            ),
+        )
+        errs = list(rule.validate(validator, "", "PublishedVersions", {}))
+        assert errs == []
+
+    def test_sam_with_string_properties(self, rule, validator):
+        """Properties as string should bail out without error (line 70)"""
+        template = {
+            "Resources": {
+                "MyFunction": {
+                    "Type": "AWS::Serverless::Function",
+                    "Properties": "not-a-dict",
+                },
+            }
         }
         validator = validator.evolve(
             cfn=Template("", template),

--- a/test/unit/rules/resources/lmbd/test_snapstart.py
+++ b/test/unit/rules/resources/lmbd/test_snapstart.py
@@ -10,6 +10,7 @@ import pytest
 from cfnlint.context import Context, Path
 from cfnlint.jsonschema import ValidationError
 from cfnlint.rules.resources.lmbd.SnapStart import SnapStart
+from cfnlint.template import Template
 
 
 @pytest.fixture(scope="module")
@@ -46,35 +47,109 @@ def template():
                     "SnapStart": {"ApplyOn": "PublishedVersions"},
                 },
             },
+            "GoodSamSnapStart": {
+                "Type": "AWS::Serverless::Function",
+                "Properties": {
+                    "Handler": "handler",
+                    "Runtime": "python3.9",
+                    "CodeUri": "s3://bucket/key",
+                    "SnapStart": {"ApplyOn": "PublishedVersions"},
+                    "AutoPublishAlias": "live",
+                },
+            },
+            "BadSamSnapStart": {
+                "Type": "AWS::Serverless::Function",
+                "Properties": {
+                    "Handler": "handler",
+                    "Runtime": "python3.9",
+                    "CodeUri": "s3://bucket/key",
+                    "SnapStart": {"ApplyOn": "PublishedVersions"},
+                },
+            },
+            "GoodSamSnapStartIntrinsic": {
+                "Type": "AWS::Serverless::Function",
+                "Properties": {
+                    "Handler": "handler",
+                    "Runtime": "python3.9",
+                    "CodeUri": "s3://bucket/key",
+                    "SnapStart": {"ApplyOn": "PublishedVersions"},
+                    "AutoPublishAlias": {"Ref": "AliasName"},
+                },
+            },
+            "SamSnapStartNone": {
+                "Type": "AWS::Serverless::Function",
+                "Properties": {
+                    "Handler": "handler",
+                    "Runtime": "python3.9",
+                    "CodeUri": "s3://bucket/key",
+                    "SnapStart": {"ApplyOn": "None"},
+                },
+            },
         }
     }
 
 
 @pytest.mark.parametrize(
-    "name,instance,path,expected",
+    "name,instance,path,cfn_path,expected",
     [
         (
             "None type should result in no errors",
             "None",  # Not
             deque(["Resources", "BadSnapStart", "Properties", "SnapStart", "ApplyOn"]),
+            deque(
+                [
+                    "Resources",
+                    "AWS::Lambda::Function",
+                    "Properties",
+                    "SnapStart",
+                    "ApplyOn",
+                ]
+            ),
             [],
         ),
         (
             "Wrong type should result in no errors",
             [],  # wrong type
             deque(["Resources", "BadSnapStart", "Properties", "SnapStart", "ApplyOn"]),
+            deque(
+                [
+                    "Resources",
+                    "AWS::Lambda::Function",
+                    "Properties",
+                    "SnapStart",
+                    "ApplyOn",
+                ]
+            ),
             [],
         ),
         (
             "Correctly associated version to lambda function",
             "PublishedVersions",
             deque(["Resources", "GoodSnapStart", "Properties", "SnapStart", "ApplyOn"]),
+            deque(
+                [
+                    "Resources",
+                    "AWS::Lambda::Function",
+                    "Properties",
+                    "SnapStart",
+                    "ApplyOn",
+                ]
+            ),
             [],
         ),
         (
             "Lambda function doesn't have version attached",
             "PublishedVersions",
             deque(["Resources", "BadSnapStart", "Properties", "SnapStart", "ApplyOn"]),
+            deque(
+                [
+                    "Resources",
+                    "AWS::Lambda::Function",
+                    "Properties",
+                    "SnapStart",
+                    "ApplyOn",
+                ]
+            ),
             [
                 ValidationError(
                     "'SnapStart' is enabled but an 'AWS::Lambda::Version' "
@@ -82,25 +157,209 @@ def template():
                 )
             ],
         ),
+        (
+            "SAM function with AutoPublishAlias - valid",
+            "PublishedVersions",
+            deque(
+                ["Resources", "GoodSamSnapStart", "Properties", "SnapStart", "ApplyOn"]
+            ),
+            deque(
+                [
+                    "Resources",
+                    "AWS::Serverless::Function",
+                    "Properties",
+                    "SnapStart",
+                    "ApplyOn",
+                ]
+            ),
+            [],
+        ),
+        (
+            "SAM function without AutoPublishAlias - invalid",
+            "PublishedVersions",
+            deque(
+                ["Resources", "BadSamSnapStart", "Properties", "SnapStart", "ApplyOn"]
+            ),
+            deque(
+                [
+                    "Resources",
+                    "AWS::Serverless::Function",
+                    "Properties",
+                    "SnapStart",
+                    "ApplyOn",
+                ]
+            ),
+            [
+                ValidationError(
+                    "'SnapStart' is enabled but 'AutoPublishAlias' is not configured",
+                )
+            ],
+        ),
+        (
+            "SAM function with intrinsic AutoPublishAlias - valid",
+            "PublishedVersions",
+            deque(
+                [
+                    "Resources",
+                    "GoodSamSnapStartIntrinsic",
+                    "Properties",
+                    "SnapStart",
+                    "ApplyOn",
+                ]
+            ),
+            deque(
+                [
+                    "Resources",
+                    "AWS::Serverless::Function",
+                    "Properties",
+                    "SnapStart",
+                    "ApplyOn",
+                ]
+            ),
+            [],
+        ),
+        (
+            "SAM function ApplyOn None - no error",
+            "None",
+            deque(
+                ["Resources", "SamSnapStartNone", "Properties", "SnapStart", "ApplyOn"]
+            ),
+            deque(
+                [
+                    "Resources",
+                    "AWS::Serverless::Function",
+                    "Properties",
+                    "SnapStart",
+                    "ApplyOn",
+                ]
+            ),
+            [],
+        ),
     ],
 )
-def test_validate(name, instance, path, expected, rule, validator):
+def test_validate(name, instance, path, cfn_path, expected, rule, validator):
     validator = validator.evolve(
         context=Context(
             path=Path(
                 path=path,
-                cfn_path=deque(
-                    [
-                        "Resources",
-                        "AWS::Lambda::Function",
-                        "Properties",
-                        "SnapStart",
-                        "ApplyOn",
-                    ]
-                ),
+                cfn_path=cfn_path,
             )
         )
     )
     errs = list(rule.validate(validator, "", instance, {}))
 
     assert errs == expected, f"{name!r}: expected {expected!r} got {errs!r}"
+
+
+class TestSnapStartSamEdgeCases:
+    """Test edge cases for SAM function handling"""
+
+    @pytest.fixture
+    def rule(self):
+        return SnapStart()
+
+    def test_sam_with_non_dict_properties(self, rule, validator):
+        """Non-dict Properties should not cause errors"""
+        template = {
+            "Resources": {
+                "MyFunction": {
+                    "Type": "AWS::Serverless::Function",
+                    "Properties": {"Ref": "SomeRef"},
+                },
+            }
+        }
+        validator = validator.evolve(
+            cfn=Template("", template),
+            context=Context(
+                path=Path(
+                    path=deque(
+                        [
+                            "Resources",
+                            "MyFunction",
+                            "Properties",
+                            "SnapStart",
+                            "ApplyOn",
+                        ]
+                    ),
+                    cfn_path=deque(
+                        [
+                            "Resources",
+                            "AWS::Serverless::Function",
+                            "Properties",
+                            "SnapStart",
+                            "ApplyOn",
+                        ]
+                    ),
+                )
+            ),
+        )
+        errs = list(rule.validate(validator, "", "PublishedVersions", {}))
+        assert errs == []
+
+    def test_sam_with_non_dict_resource(self, rule, validator):
+        """Non-dict resource should not cause errors"""
+        template = {
+            "Resources": {
+                "MyFunction": {"Ref": "SomeRef"},
+            }
+        }
+        validator = validator.evolve(
+            cfn=Template("", template),
+            context=Context(
+                path=Path(
+                    path=deque(
+                        [
+                            "Resources",
+                            "MyFunction",
+                            "Properties",
+                            "SnapStart",
+                            "ApplyOn",
+                        ]
+                    ),
+                    cfn_path=deque(
+                        [
+                            "Resources",
+                            "AWS::Serverless::Function",
+                            "Properties",
+                            "SnapStart",
+                            "ApplyOn",
+                        ]
+                    ),
+                )
+            ),
+        )
+        errs = list(rule.validate(validator, "", "PublishedVersions", {}))
+        assert errs == []
+
+    def test_sam_with_non_dict_resources(self, rule, validator):
+        """Non-dict Resources should not cause errors"""
+        template = {
+            "Resources": {"Ref": "SomeRef"},
+        }
+        validator = validator.evolve(
+            cfn=Template("", template),
+            context=Context(
+                path=Path(
+                    path=deque(
+                        [
+                            "Resources",
+                            "MyFunction",
+                            "Properties",
+                            "SnapStart",
+                            "ApplyOn",
+                        ]
+                    ),
+                    cfn_path=deque(
+                        [
+                            "Resources",
+                            "AWS::Serverless::Function",
+                            "Properties",
+                            "SnapStart",
+                            "ApplyOn",
+                        ]
+                    ),
+                )
+            ),
+        )
+        errs = list(rule.validate(validator, "", "PublishedVersions", {}))
+        assert errs == []


### PR DESCRIPTION
Makes W2530 (SnapStart) SAM-aware: adds the `AWS::Serverless::Function` keyword path and treats `AutoPublishAlias` as satisfying the version-attached requirement (SAM no longer synthesizes `AWS::Lambda::Version` after #4491).

Fixes #4611
Tracking: #4607