### PR TITLE
feat(cloudformation): E3043 for Serverless::Application

### DIFF
--- a/src/cfnlint/rules/resources/cloudformation/NestedStackParameters.py
+++ b/src/cfnlint/rules/resources/cloudformation/NestedStackParameters.py
@@ -3,7 +3,10 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 
+from __future__ import annotations
+
 import os
+from typing import Any
 
 import regex as re
 
@@ -30,19 +33,32 @@ class NestedStackParameters(CloudFormationLintRule):
         """Init"""
         super().__init__()
         self.resource_property_types.append("AWS::CloudFormation::Stack")
+        self.resource_property_types.append("AWS::Serverless::Application")
 
-    def __get_template_parameters(self, filename):
+    def _get_template_parameters(
+        self,
+        filename: str,
+    ) -> dict[str, Any] | None:
         try:
             (tmp, matches) = decode(filename)
         except:  # noqa: E722
             return None
         if matches:
             return None
+        if tmp is None:
+            return None
 
-        return tmp.get("Parameters", {})
+        params: dict[str, Any] = tmp.get("Parameters", {})
+        return params
 
-    def __compare_objects(self, template_parameters, nested_parameters, scenario, path):
-        matches = []
+    def _compare_objects(
+        self,
+        template_parameters: dict[str, Any],
+        nested_parameters: dict[str, Any],
+        scenario: dict[str, bool] | None,
+        path: list[str | int],
+    ) -> RuleMatches:
+        matches: RuleMatches = []
         for key in set(template_parameters.keys()) - set(nested_parameters.keys()):
             if scenario is None:
                 message = (
@@ -65,7 +81,7 @@ class NestedStackParameters(CloudFormationLintRule):
                 )
                 matches.append(RuleMatch(path, message.format(key, scenario_text)))
         for key in set(nested_parameters.keys()) - set(template_parameters.keys()):
-            if nested_parameters.get(key).get("Default") is None:
+            if nested_parameters.get(key, {}).get("Default") is None:
                 if scenario is None:
                     message = (
                         'Nested stack template parameter "{0}" is not specified at {1}'
@@ -84,53 +100,115 @@ class NestedStackParameters(CloudFormationLintRule):
 
         return matches
 
+    def _is_local_path(self, location: str) -> bool:
+        """Check if a location string is a local file path (not a URL)."""
+        return not (
+            location.startswith("http://")
+            or location.startswith("https://")
+            or location.startswith("s3://")
+        )
+
+    def _validate_nested_parameters(
+        self,
+        cfn: Template,
+        resource_name: str,
+        properties: dict[str, Any],
+        location_key: str,
+        base_dir: str,
+    ) -> RuleMatches:
+        """
+        Validate parameters for a nested stack or serverless application.
+
+        Args:
+            cfn: The template being validated
+            resource_name: Name of the resource
+            properties: Resource properties dict
+            location_key: Property name containing the template location
+                          ('TemplateURL' for Stack, 'Location' for Application)
+            base_dir: Base directory for resolving relative paths
+        """
+        matches: RuleMatches = []
+
+        parameter_groups = cfn.get_object_without_conditions(
+            obj=properties,
+            property_names=[location_key, "Parameters"],
+        )
+
+        for parameter_group in parameter_groups:
+            obj = parameter_group.get("Object")
+            template_location = obj.get(location_key)
+
+            # For Serverless::Application, Location can be a dict (SAR reference)
+            # In that case, skip validation
+            if isinstance(template_location, dict):
+                continue
+
+            if isinstance(template_location, str):
+                if self._is_local_path(template_location):
+                    template_path = os.path.normpath(
+                        os.path.join(base_dir, template_location)
+                    )
+                    if re.match(REGEX_DYN_REF, template_path):
+                        continue
+                    nested_parameters = self._get_template_parameters(template_path)
+                    template_parameters = obj.get("Parameters")
+                    if isinstance(nested_parameters, dict) and isinstance(
+                        template_parameters, dict
+                    ):
+                        matches.extend(
+                            self._compare_objects(
+                                template_parameters=template_parameters,
+                                nested_parameters=nested_parameters,
+                                path=[
+                                    "Resources",
+                                    resource_name,
+                                    "Properties",
+                                    "Parameters",
+                                ],
+                                scenario=parameter_group.get("Scenario"),
+                            )
+                        )
+
+        return matches
+
     def match(self, cfn: Template) -> RuleMatches:
         """Check CloudFormation Properties"""
-        matches = []
-        resources = cfn.get_resources("AWS::CloudFormation::Stack")
-        for resource_name, attributes in resources.items():
+        matches: RuleMatches = []
+
+        # Skip if template is passed via stdin (filename is None)
+        if not cfn.filename:
+            return matches
+
+        base_dir = os.path.dirname(os.path.abspath(cfn.filename))
+
+        # Validate AWS::CloudFormation::Stack resources
+        for resource_name, attributes in cfn.get_resources(
+            "AWS::CloudFormation::Stack"
+        ).items():
             properties = attributes.get("Properties", {})
-            # when template is passed via cat (or equivalent filename is none)
-            if cfn.filename:
-                base_dir = os.path.dirname(os.path.abspath(cfn.filename))
-
-                parameter_groups = cfn.get_object_without_conditions(
-                    obj=properties, property_names=["TemplateURL", "Parameters"]
+            matches.extend(
+                self._validate_nested_parameters(
+                    cfn=cfn,
+                    resource_name=resource_name,
+                    properties=properties,
+                    location_key="TemplateURL",
+                    base_dir=base_dir,
                 )
+            )
 
-                for parameter_group in parameter_groups:
-                    obj = parameter_group.get("Object")
-                    template_url = obj.get("TemplateURL")
-                    if isinstance(template_url, str):
-                        if not (
-                            template_url.startswith("http://")
-                            or template_url.startswith("https://")
-                            or template_url.startswith("s3://")
-                        ):
-                            template_path = os.path.normpath(
-                                os.path.join(base_dir, template_url)
-                            )
-                            if re.match(REGEX_DYN_REF, template_path):
-                                continue
-                            nested_parameters = self.__get_template_parameters(
-                                template_path
-                            )
-                            template_parameters = obj.get("Parameters")
-                            if isinstance(nested_parameters, dict) and isinstance(
-                                template_parameters, dict
-                            ):
-                                matches.extend(
-                                    self.__compare_objects(
-                                        template_parameters=template_parameters,
-                                        nested_parameters=nested_parameters,
-                                        path=[
-                                            "Resources",
-                                            resource_name,
-                                            "Properties",
-                                            "Parameters",
-                                        ],
-                                        scenario=parameter_group.get("Scenario"),
-                                    )
-                                )
+        # Validate AWS::Serverless::Application resources
+        for resource_name, attributes in cfn.get_resources(
+            "AWS::Serverless::Application"
+        ).items():
+            properties = attributes.get("Properties", {})
+            matches.extend(
+                self._validate_nested_parameters(
+                    cfn=cfn,
+                    resource_name=resource_name,
+                    properties=properties,
+                    location_key="Location",
+                    base_dir=base_dir,
+                )
+            )
 
         return matches

--- a/test/fixtures/templates/bad/resources/cloudformation/sam_app_nested.yaml
+++ b/test/fixtures/templates/bad/resources/cloudformation/sam_app_nested.yaml
@@ -1,0 +1,12 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Parameters:
+  AppName:
+    Type: String
+  Environment:
+    Type: String
+  Optional:
+    Type: String
+    Default: "default-value"
+Resources:
+  Placeholder:
+    Type: AWS::CloudFormation::WaitConditionHandle

--- a/test/fixtures/templates/bad/resources/cloudformation/sam_stacks.yaml
+++ b/test/fixtures/templates/bad/resources/cloudformation/sam_stacks.yaml
@@ -1,0 +1,50 @@
+Transform: AWS::Serverless-2016-10-31
+Conditions:
+  IsUsEast1: !Equals [!Ref 'AWS::Region', 'us-east-1']
+  IsUsWest2: !Equals [!Ref 'AWS::Region', 'us-west-2']
+Resources:
+  # Error: Specifies unknown parameter 'UnknownParam'
+  # Error: Missing required parameter 'Environment' (no default)
+  AppUnknownParam:
+    Type: AWS::Serverless::Application
+    Properties:
+      Location: ./sam_app_nested.yaml
+      Parameters:
+        AppName: my-app
+        UnknownParam: bad-value
+
+  # Error: Missing required parameters 'AppName' and 'Environment'
+  AppMissingRequired:
+    Type: AWS::Serverless::Application
+    Properties:
+      Location: ./sam_app_nested.yaml
+      Parameters:
+        Optional: just-optional
+
+  # Error: Multiple unknown parameters
+  AppMultipleUnknown:
+    Type: AWS::Serverless::Application
+    Properties:
+      Location: ./sam_app_nested.yaml
+      Parameters:
+        AppName: my-app
+        Environment: prod
+        BadParam1: value1
+        BadParam2: value2
+
+  # Error: Conditional with unknown parameters in some branches
+  AppConditionalBad:
+    Type: AWS::Serverless::Application
+    Properties:
+      Location: ./sam_app_nested.yaml
+      Parameters:
+        Fn::If:
+          - IsUsEast1
+          - AppName: east-app
+            WrongParam: wrong
+          - Fn::If:
+            - IsUsWest2
+            - Environment: west
+              AnotherWrong: bad
+            - AppName: fallback
+              StillWrong: value

--- a/test/fixtures/templates/good/resources/cloudformation/sam_app_nested.yaml
+++ b/test/fixtures/templates/good/resources/cloudformation/sam_app_nested.yaml
@@ -1,0 +1,12 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Parameters:
+  AppName:
+    Type: String
+  Environment:
+    Type: String
+  Optional:
+    Type: String
+    Default: "default-value"
+Resources:
+  Placeholder:
+    Type: AWS::CloudFormation::WaitConditionHandle

--- a/test/fixtures/templates/good/resources/cloudformation/sam_stacks.yaml
+++ b/test/fixtures/templates/good/resources/cloudformation/sam_stacks.yaml
@@ -1,0 +1,85 @@
+Transform: AWS::Serverless-2016-10-31
+Conditions:
+  IsUsEast1: !Equals [!Ref 'AWS::Region', 'us-east-1']
+Resources:
+  # Valid: local path with correct parameters (Optional has default, not required)
+  AppValid:
+    Type: AWS::Serverless::Application
+    Properties:
+      Location: ./sam_app_nested.yaml
+      Parameters:
+        AppName: my-app
+        Environment: prod
+
+  # Valid: local path with all parameters including optional
+  AppValidWithOptional:
+    Type: AWS::Serverless::Application
+    Properties:
+      Location: ./sam_app_nested.yaml
+      Parameters:
+        AppName: my-app
+        Environment: dev
+        Optional: custom-value
+
+  # Valid: SAR reference (dict Location) - should be skipped
+  AppSarReference:
+    Type: AWS::Serverless::Application
+    Properties:
+      Location:
+        ApplicationId: arn:aws:serverlessrepo:us-east-1:123456789012:applications/my-app
+        SemanticVersion: 1.0.0
+      Parameters:
+        SomeUnknownParam: value
+
+  # Valid: S3 URL - should be skipped
+  AppS3Url:
+    Type: AWS::Serverless::Application
+    Properties:
+      Location: s3://my-bucket/template.yaml
+      Parameters:
+        SomeUnknownParam: value
+
+  # Valid: HTTPS URL - should be skipped
+  AppHttpsUrl:
+    Type: AWS::Serverless::Application
+    Properties:
+      Location: https://s3.amazonaws.com/my-bucket/template.yaml
+      Parameters:
+        SomeUnknownParam: value
+
+  # Valid: Location using intrinsic function
+  AppIntrinsicLocation:
+    Type: AWS::Serverless::Application
+    Properties:
+      Location: !Sub "${AWS::Region}/template.yaml"
+      Parameters:
+        AppName: intrinsic-app
+
+  # Valid: Invalid local path (template not found) - should not crash
+  AppInvalidPath:
+    Type: AWS::Serverless::Application
+    Properties:
+      Location: ./nonexistent_template.yaml
+      Parameters:
+        SomeParam: value
+
+  # Valid: Conditional parameters
+  AppConditional:
+    Type: AWS::Serverless::Application
+    Properties:
+      Location: ./sam_app_nested.yaml
+      Parameters:
+        Fn::If:
+          - IsUsEast1
+          - AppName: east-app
+            Environment: prod
+          - AppName: west-app
+            Environment: dev
+
+  # Valid: Dynamic reference in Location
+  AppDynamicRef:
+    Type: AWS::Serverless::Application
+    Properties:
+      Location: "{{resolve:ssm:/my/template/path:1}}"
+      Parameters:
+        SomeParam: value

--- a/test/unit/rules/resources/cloudformation/test_nested_stack_parameters.py
+++ b/test/unit/rules/resources/cloudformation/test_nested_stack_parameters.py
@@ -6,7 +6,7 @@ SPDX-License-Identifier: MIT-0
 import logging
 from test.unit.rules import BaseRuleTestCase
 
-from cfnlint.rules.resources.cloudformation.NestedStackParameters import (  # pylint: disable=E0401
+from cfnlint.rules.resources.cloudformation.NestedStackParameters import (
     NestedStackParameters,
 )
 
@@ -28,6 +28,7 @@ class TestNestedStackParameters(BaseRuleTestCase):
         self.success_templates = [
             "test/fixtures/templates/good/resources/cloudformation/stacks.yaml",
             "test/fixtures/templates/good/resources/cloudformation/nested_stack_dynamic.yaml",
+            "test/fixtures/templates/good/resources/cloudformation/sam_stacks.yaml",
         ]
 
     def test_file_positive(self):
@@ -39,5 +40,19 @@ class TestNestedStackParameters(BaseRuleTestCase):
         err_count = 8
         self.helper_file_negative(
             "test/fixtures/templates/bad/resources/cloudformation/stacks.yaml",
+            err_count,
+        )
+
+    def test_file_negative_sam_application(self):
+        """Test failure for Serverless::Application with bad parameters"""
+        # Expected errors:
+        # AppUnknownParam: UnknownParam unknown, Environment missing = 2
+        # AppMissingRequired: AppName missing, Environment missing = 2
+        # AppMultipleUnknown: BadParam1, BadParam2 = 2 unknown
+        # AppConditionalBad: 3 scenarios × (1 unknown + 1 missing) = 6
+        # Total: 2 + 2 + 2 + 6 = 12
+        err_count = 12
+        self.helper_file_negative(
+            "test/fixtures/templates/bad/resources/cloudformation/sam_stacks.yaml",
             err_count,
         )


### PR DESCRIPTION
Extends E3043 (NestedStackParameters) to validate `AWS::Serverless::Application` with a local `Location`, checking passed parameters against the referenced template. Skips S3 URLs and SAR (`ApplicationId`/`SemanticVersion`) references.

Fixes #4612
Tracking: #4607