### PR TITLE
feat(lambda): W2533 Handler/Runtime on Zip Serverless::Function

### DIFF
--- a/src/cfnlint/rules/resources/lmbd/ZipPackageRequiredProperties.py
+++ b/src/cfnlint/rules/resources/lmbd/ZipPackageRequiredProperties.py
@@ -3,6 +3,8 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 
+from typing import Any, Dict, List
+
 from cfnlint._typing import Path, RuleMatches
 from cfnlint.rules import CloudFormationLintRule, RuleMatch
 from cfnlint.template import Template
@@ -20,60 +22,168 @@ class ZipPackageRequiredProperties(CloudFormationLintRule):
     source_url = "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html"
     tags = ["resources", "lambda"]
 
+    def _check_lambda_function(
+        self,
+        cfn: Template,
+        resource_name: str,
+        properties: Dict[str, Any],
+        required_properties: List[str],
+    ) -> RuleMatches:
+        """Check AWS::Lambda::Function for missing required properties."""
+        matches: RuleMatches = []
+
+        for scenario in cfn.get_object_without_conditions(
+            properties, ["PackageType", "Code", "Handler", "Runtime"]
+        ):
+            props = scenario.get("Object")
+            path: Path = ["Resources", resource_name, "Properties"]
+
+            # check is zip deployment
+            is_zip_deployment = True
+            code = props.get("Code")
+
+            if props.get("PackageType") == "Zip":
+                path.append("PackageType")
+            elif isinstance(code, dict) and (code.get("ZipFile") or code.get("S3Key")):
+                path.append("Code")
+            else:
+                is_zip_deployment = False
+
+            if not is_zip_deployment:
+                continue
+
+            # check required properties for zip deployment
+            missing_properties = []
+            for p in required_properties:
+                if props.get(p) is None:
+                    missing_properties.append(p)
+
+            if len(missing_properties) > 0:
+                message = "Properties {0} missing for zip file deployment at {1}"
+                matches.append(
+                    RuleMatch(
+                        path,
+                        message.format(
+                            missing_properties,
+                            "/".join(
+                                map(str, ["Resources", resource_name, "Properties"])
+                            ),
+                        ),
+                    )
+                )
+
+        return matches
+
+    def _check_serverless_function(
+        self,
+        cfn: Template,
+        resource_name: str,
+        properties: Dict[str, Any],
+        required_properties: List[str],
+    ) -> RuleMatches:
+        """Check AWS::Serverless::Function for missing required properties."""
+        matches: RuleMatches = []
+
+        for scenario in cfn.get_object_without_conditions(
+            properties,
+            [
+                "PackageType",
+                "CodeUri",
+                "InlineCode",
+                "ImageUri",
+                "Handler",
+                "Runtime",
+            ],
+        ):
+            props = scenario.get("Object")
+            path: Path = ["Resources", resource_name, "Properties"]
+
+            # check is zip deployment for SAM
+            # SAM functions are Zip by default unless PackageType is "Image"
+            # PackageType is authoritative - check it first before inferring
+            # from other properties
+            is_zip_deployment = True
+
+            if props.get("PackageType") == "Image":
+                is_zip_deployment = False
+            elif props.get("PackageType") == "Zip":
+                # Explicit Zip package type (authoritative, even if ImageUri present)
+                path.append("PackageType")
+            elif props.get("ImageUri") is not None:
+                # ImageUri implies Image package type (when PackageType not set)
+                is_zip_deployment = False
+            elif props.get("CodeUri") is not None:
+                # CodeUri indicates Zip deployment
+                path.append("CodeUri")
+            elif props.get("InlineCode") is not None:
+                # InlineCode indicates Zip deployment
+                path.append("InlineCode")
+            else:
+                # Default is Zip package type for SAM functions
+                # (no CodeUri/InlineCode/ImageUri means code will be
+                # provided at deployment time as zip)
+                pass
+
+            if not is_zip_deployment:
+                continue
+
+            # check required properties for zip deployment
+            missing_properties = []
+            for p in required_properties:
+                if props.get(p) is None:
+                    missing_properties.append(p)
+
+            if len(missing_properties) > 0:
+                message = "Properties {0} missing for zip file deployment at {1}"
+                matches.append(
+                    RuleMatch(
+                        path,
+                        message.format(
+                            missing_properties,
+                            "/".join(
+                                map(str, ["Resources", resource_name, "Properties"])
+                            ),
+                        ),
+                    )
+                )
+
+        return matches
+
     def match(self, cfn: Template) -> RuleMatches:
-        matches = []
+        matches: RuleMatches = []
         required_properties = [
             "Handler",
             "Runtime",
         ]  # required if package is a .zip file
 
+        # Check AWS::Lambda::Function resources
         resources = cfn.get_resources(["AWS::Lambda::Function"])
-
         for resource_name, resource in resources.items():
             properties = resource.get("Properties")
             if not isinstance(properties, dict):
                 continue
+            matches.extend(
+                self._check_lambda_function(
+                    cfn,
+                    resource_name,
+                    properties,
+                    required_properties,
+                )
+            )
 
-            for scenario in cfn.get_object_without_conditions(
-                properties, ["PackageType", "Code", "Handler", "Runtime"]
-            ):
-                props = scenario.get("Object")
-                path: Path = ["Resources", resource_name, "Properties"]
-
-                # check is zip deployment
-                is_zip_deployment = True
-                code = props.get("Code")
-
-                if props.get("PackageType") == "Zip":
-                    path.append("PackageType")
-                elif isinstance(code, dict) and (
-                    code.get("ZipFile") or code.get("S3Key")
-                ):
-                    path.append("Code")
-                else:
-                    is_zip_deployment = False
-
-                if not is_zip_deployment:
-                    continue
-
-                # check required properties for zip deployment
-                missing_properties = []
-                for p in required_properties:
-                    if props.get(p) is None:
-                        missing_properties.append(p)
-
-                if len(missing_properties) > 0:
-                    message = "Properties {0} missing for zip file deployment at {1}"
-                    matches.append(
-                        RuleMatch(
-                            path,
-                            message.format(
-                                missing_properties,
-                                "/".join(
-                                    map(str, ["Resources", resource_name, "Properties"])
-                                ),
-                            ),
-                        )
-                    )
+        # Check AWS::Serverless::Function resources
+        sam_resources = cfn.get_resources(["AWS::Serverless::Function"])
+        for resource_name, resource in sam_resources.items():
+            properties = resource.get("Properties")
+            if not isinstance(properties, dict):
+                continue
+            matches.extend(
+                self._check_serverless_function(
+                    cfn,
+                    resource_name,
+                    properties,
+                    required_properties,
+                )
+            )
 
         return matches

--- a/test/fixtures/templates/bad/resources/lambda/sam_required_properties.yaml
+++ b/test/fixtures/templates/bad/resources/lambda/sam_required_properties.yaml
@@ -1,0 +1,31 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: SAM Functions missing Handler/Runtime for Zip deployments.
+Resources:
+  MissingBoth: # Missing Handler and Runtime
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: s3://my-bucket/function.zip
+#      Handler: index.handler
+#      Runtime: python3.9
+  MissingRuntime: # Missing Runtime only
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: index.handler
+      CodeUri: s3://my-bucket/function.zip
+#      Runtime: python3.9
+  MissingHandler: # Missing Handler only
+    Type: AWS::Serverless::Function
+    Properties:
+      Runtime: python3.9
+      InlineCode: |
+        def handler(event, context):
+          pass
+#      Handler: index.handler
+  ZipWithStrayImageUri: # PackageType: Zip is authoritative even with ImageUri present
+    Type: AWS::Serverless::Function
+    Properties:
+      PackageType: Zip
+      ImageUri: 123456789012.dkr.ecr.us-east-1.amazonaws.com/my-repo:latest
+#      Handler: index.handler
+#      Runtime: python3.9

--- a/test/fixtures/templates/good/resources/lambda/sam_required_properties.yaml
+++ b/test/fixtures/templates/good/resources/lambda/sam_required_properties.yaml
@@ -1,0 +1,36 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: SAM Functions with proper Handler/Runtime for Zip deployments.
+Resources:
+  ZipFunctionWithCodeUri: # Zip deployment with CodeUri
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: index.handler
+      Runtime: python3.9
+      CodeUri: s3://my-bucket/function.zip
+  ZipFunctionWithInlineCode: # Zip deployment with InlineCode
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: index.handler
+      Runtime: nodejs22.x
+      InlineCode: |
+        exports.handler = function(event, context) {}
+  ZipFunctionExplicitPackageType: # Explicit Zip PackageType
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: index.handler
+      Runtime: python3.12
+      CodeUri: s3://my-bucket/function.zip
+      PackageType: Zip
+  ImageFunction: # Image deployment - no Handler/Runtime needed
+    Type: AWS::Serverless::Function
+    Properties:
+      PackageType: Image
+    Metadata:
+      DockerTag: latest
+      DockerContext: ./hello-world
+      Dockerfile: Dockerfile
+  ImageFunctionWithImageUri: # Image deployment via ImageUri - no Handler/Runtime needed
+    Type: AWS::Serverless::Function
+    Properties:
+      ImageUri: 123456789012.dkr.ecr.us-east-1.amazonaws.com/my-repo:latest

--- a/test/unit/rules/resources/lmbd/test_zip_package_required_properties.py
+++ b/test/unit/rules/resources/lmbd/test_zip_package_required_properties.py
@@ -17,7 +17,8 @@ class TestZipPackageRequiredProperties(BaseRuleTestCase):
         super(TestZipPackageRequiredProperties, self).setUp()
         self.collection.register(ZipPackageRequiredProperties())
         self.success_templates = [
-            "test/fixtures/templates/good/resources/lambda/required_properties.yaml"
+            "test/fixtures/templates/good/resources/lambda/required_properties.yaml",
+            "test/fixtures/templates/good/resources/lambda/sam_required_properties.yaml",
         ]
 
     def test_file_positive(self):
@@ -27,4 +28,10 @@ class TestZipPackageRequiredProperties(BaseRuleTestCase):
         self.helper_file_negative(
             "test/fixtures/templates/bad/resources/lambda/required_properties.yaml",
             err_count=3,
+        )
+
+    def test_file_negative_sam(self):
+        self.helper_file_negative(
+            "test/fixtures/templates/bad/resources/lambda/sam_required_properties.yaml",
+            err_count=4,
         )

--- a/test/unit/rules/resources/lmbd/test_zip_package_required_properties.py
+++ b/test/unit/rules/resources/lmbd/test_zip_package_required_properties.py
@@ -5,9 +5,12 @@ SPDX-License-Identifier: MIT-0
 
 from test.unit.rules import BaseRuleTestCase
 
+import pytest
+
 from cfnlint.rules.resources.lmbd.ZipPackageRequiredProperties import (
     ZipPackageRequiredProperties,
 )
+from cfnlint.template import Template
 
 
 class TestZipPackageRequiredProperties(BaseRuleTestCase):
@@ -35,3 +38,306 @@ class TestZipPackageRequiredProperties(BaseRuleTestCase):
             "test/fixtures/templates/bad/resources/lambda/sam_required_properties.yaml",
             err_count=4,
         )
+
+
+@pytest.fixture(scope="module")
+def rule():
+    rule = ZipPackageRequiredProperties()
+    yield rule
+
+
+@pytest.mark.parametrize(
+    "name,template,expected_count",
+    [
+        # SAM function with bare minimum (default Zip, no CodeUri/InlineCode/ImageUri)
+        # This covers the else: pass branch (lines 121-125)
+        (
+            "SAM bare default Zip function missing Handler/Runtime",
+            {
+                "AWSTemplateFormatVersion": "2010-09-09",
+                "Transform": "AWS::Serverless-2016-10-31",
+                "Resources": {
+                    "BareFunction": {
+                        "Type": "AWS::Serverless::Function",
+                        "Properties": {},
+                    },
+                },
+            },
+            1,  # Missing both Handler and Runtime
+        ),
+        # SAM function with bare minimum but with Handler/Runtime (valid)
+        (
+            "SAM bare default Zip function with Handler/Runtime",
+            {
+                "AWSTemplateFormatVersion": "2010-09-09",
+                "Transform": "AWS::Serverless-2016-10-31",
+                "Resources": {
+                    "BareFunction": {
+                        "Type": "AWS::Serverless::Function",
+                        "Properties": {
+                            "Handler": "index.handler",
+                            "Runtime": "python3.9",
+                        },
+                    },
+                },
+            },
+            0,
+        ),
+        # Lambda function with non-dict Properties (guard branch line 163-164)
+        (
+            "Lambda with non-dict Properties",
+            {
+                "AWSTemplateFormatVersion": "2010-09-09",
+                "Resources": {
+                    "BadFunction": {
+                        "Type": "AWS::Lambda::Function",
+                        "Properties": "not-a-dict",
+                    },
+                },
+            },
+            0,  # Should skip, not error
+        ),
+        # SAM function with non-dict Properties (guard branch line 178-179)
+        (
+            "SAM with non-dict Properties",
+            {
+                "AWSTemplateFormatVersion": "2010-09-09",
+                "Transform": "AWS::Serverless-2016-10-31",
+                "Resources": {
+                    "BadFunction": {
+                        "Type": "AWS::Serverless::Function",
+                        "Properties": ["not", "a", "dict"],
+                    },
+                },
+            },
+            0,  # Should skip, not error
+        ),
+        # Lambda function with intrinsic Ref in Properties
+        # Note: {"Ref": "X"} is still a dict, so it passes the guard
+        # but get_object_without_conditions will process it
+        (
+            "Lambda with Ref in Properties",
+            {
+                "AWSTemplateFormatVersion": "2010-09-09",
+                "Resources": {
+                    "RefFunction": {
+                        "Type": "AWS::Lambda::Function",
+                        "Properties": {"Ref": "SomeParameter"},
+                    },
+                },
+            },
+            0,  # Ref resolves to unknown, skipped as not Zip
+        ),
+        # SAM function with intrinsic Ref in Properties
+        # Note: {"Ref": "X"} is still a dict, so it passes the guard
+        (
+            "SAM with Ref in Properties",
+            {
+                "AWSTemplateFormatVersion": "2010-09-09",
+                "Transform": "AWS::Serverless-2016-10-31",
+                "Resources": {
+                    "RefFunction": {
+                        "Type": "AWS::Serverless::Function",
+                        "Properties": {"Ref": "SomeParameter"},
+                    },
+                },
+            },
+            # This hits the else: pass branch
+            # (no CodeUri/InlineCode/ImageUri/PackageType)
+            # and reports missing Handler/Runtime
+            1,
+        ),
+        # SAM Image function via PackageType (line 107-108)
+        (
+            "SAM Image via PackageType",
+            {
+                "AWSTemplateFormatVersion": "2010-09-09",
+                "Transform": "AWS::Serverless-2016-10-31",
+                "Resources": {
+                    "ImageFunction": {
+                        "Type": "AWS::Serverless::Function",
+                        "Properties": {
+                            "PackageType": "Image",
+                        },
+                    },
+                },
+            },
+            0,  # Image functions don't need Handler/Runtime
+        ),
+        # SAM Image function via ImageUri only (line 112-114)
+        (
+            "SAM Image via ImageUri",
+            {
+                "AWSTemplateFormatVersion": "2010-09-09",
+                "Transform": "AWS::Serverless-2016-10-31",
+                "Resources": {
+                    "ImageFunction": {
+                        "Type": "AWS::Serverless::Function",
+                        "Properties": {
+                            "ImageUri": (
+                                "123456789012.dkr.ecr.us-east-1.amazonaws.com/repo:tag"
+                            ),
+                        },
+                    },
+                },
+            },
+            0,  # Image functions don't need Handler/Runtime
+        ),
+        # SAM Zip function via CodeUri (line 115-117)
+        (
+            "SAM Zip via CodeUri missing Handler/Runtime",
+            {
+                "AWSTemplateFormatVersion": "2010-09-09",
+                "Transform": "AWS::Serverless-2016-10-31",
+                "Resources": {
+                    "ZipFunction": {
+                        "Type": "AWS::Serverless::Function",
+                        "Properties": {
+                            "CodeUri": "s3://bucket/code.zip",
+                        },
+                    },
+                },
+            },
+            1,  # Missing Handler and Runtime
+        ),
+        # SAM Zip function via InlineCode (line 118-120)
+        (
+            "SAM Zip via InlineCode missing Handler/Runtime",
+            {
+                "AWSTemplateFormatVersion": "2010-09-09",
+                "Transform": "AWS::Serverless-2016-10-31",
+                "Resources": {
+                    "ZipFunction": {
+                        "Type": "AWS::Serverless::Function",
+                        "Properties": {
+                            "InlineCode": "def handler(e, c): pass",
+                        },
+                    },
+                },
+            },
+            1,  # Missing Handler and Runtime
+        ),
+        # SAM explicit PackageType: Zip (line 109-111)
+        (
+            "SAM explicit PackageType Zip missing Handler/Runtime",
+            {
+                "AWSTemplateFormatVersion": "2010-09-09",
+                "Transform": "AWS::Serverless-2016-10-31",
+                "Resources": {
+                    "ZipFunction": {
+                        "Type": "AWS::Serverless::Function",
+                        "Properties": {
+                            "PackageType": "Zip",
+                            "CodeUri": "s3://bucket/code.zip",
+                        },
+                    },
+                },
+            },
+            1,  # Missing Handler and Runtime
+        ),
+        # Lambda with explicit PackageType: Zip (line 45-46)
+        (
+            "Lambda explicit PackageType Zip missing Handler/Runtime",
+            {
+                "AWSTemplateFormatVersion": "2010-09-09",
+                "Resources": {
+                    "ZipFunction": {
+                        "Type": "AWS::Lambda::Function",
+                        "Properties": {
+                            "PackageType": "Zip",
+                            "Role": "arn:aws:iam::123456789012:role/role",
+                            "Code": {
+                                "S3Bucket": "bucket",
+                                "S3Key": "code.zip",
+                            },
+                        },
+                    },
+                },
+            },
+            1,  # Missing Handler and Runtime
+        ),
+        # Lambda with ZipFile in Code (line 47-48)
+        (
+            "Lambda with ZipFile missing Handler/Runtime",
+            {
+                "AWSTemplateFormatVersion": "2010-09-09",
+                "Resources": {
+                    "ZipFunction": {
+                        "Type": "AWS::Lambda::Function",
+                        "Properties": {
+                            "Role": "arn:aws:iam::123456789012:role/role",
+                            "Code": {
+                                "ZipFile": "def handler(e, c): pass",
+                            },
+                        },
+                    },
+                },
+            },
+            1,  # Missing Handler and Runtime
+        ),
+        # Lambda with S3Key in Code (line 47-48)
+        (
+            "Lambda with S3Key missing Handler/Runtime",
+            {
+                "AWSTemplateFormatVersion": "2010-09-09",
+                "Resources": {
+                    "ZipFunction": {
+                        "Type": "AWS::Lambda::Function",
+                        "Properties": {
+                            "Role": "arn:aws:iam::123456789012:role/role",
+                            "Code": {
+                                "S3Bucket": "bucket",
+                                "S3Key": "code.zip",
+                            },
+                        },
+                    },
+                },
+            },
+            1,  # Missing Handler and Runtime
+        ),
+        # Lambda Image function (not Zip, line 49-50)
+        (
+            "Lambda Image function",
+            {
+                "AWSTemplateFormatVersion": "2010-09-09",
+                "Resources": {
+                    "ImageFunction": {
+                        "Type": "AWS::Lambda::Function",
+                        "Properties": {
+                            "PackageType": "Image",
+                            "Role": "arn:aws:iam::123456789012:role/role",
+                            "Code": {
+                                "ImageUri": (
+                                    "123456789012.dkr.ecr.us-east-1.amazonaws.com"
+                                    "/repo:tag"
+                                ),
+                            },
+                        },
+                    },
+                },
+            },
+            0,  # Image functions don't need Handler/Runtime
+        ),
+        # Template with no Lambda/SAM functions
+        (
+            "Template with no functions",
+            {
+                "AWSTemplateFormatVersion": "2010-09-09",
+                "Resources": {
+                    "Bucket": {
+                        "Type": "AWS::S3::Bucket",
+                        "Properties": {},
+                    },
+                },
+            },
+            0,
+        ),
+    ],
+)
+def test_match(name, template, expected_count, rule):
+    cfn = Template("", template, regions=["us-east-1"])
+    matches = rule.match(cfn)
+    assert len(matches) == expected_count, (
+        f"Test {name!r}: expected {expected_count} matches, "
+        f"got {len(matches)}: {matches}"
+    )


### PR DESCRIPTION
Extends W2533 to require `Handler`/`Runtime` on Zip-package `AWS::Serverless::Function` (the SAM schema enforces neither). `PackageType` is treated as authoritative; Image functions are excluded.

Fixes #4613
Tracking: #4607