### PR TITLE
docs: add MegaLinter to the README integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ There are IDE plugins available to get direct linter feedback from you favorite 
 
 ### [GitHub Action](https://github.com/marketplace/actions/cfn-lint-action)
 
+### [MegaLinter](https://megalinter.io/)
+
+[MegaLinter](https://megalinter.io/) is an open-source linters aggregator for CI that runs cfn-lint on CloudFormation templates out of the box ([documentation](https://megalinter.io/latest/descriptors/cloudformation_cfn_lint/)).
+
 ### [Online demo](https://github.com/PatMyron/cfn-lint-online)
 
 ## Basic Usage


### PR DESCRIPTION
Hi, and thanks for maintaining cfn-lint!

cfn-lint has been embedded in [MegaLinter](https://megalinter.io/) (an open-source linters aggregator for CI) for a few years now, so users get it out of the box on their CloudFormation templates. This PR just adds a short mention next to the GitHub Action and online demo sections in the README, so cfn-lint users can find that option too.

Details on how it's wired up: https://megalinter.io/latest/descriptors/cloudformation_cfn_lint/

Happy to tweak the wording or move it elsewhere if you prefer.