### PR TITLE
Validate Fn::Select negative indexes

### DIFF
--- a/src/cfnlint/data/schemas/other/functions/select.json
+++ b/src/cfnlint/data/schemas/other/functions/select.json
@@ -11,6 +11,7 @@
         "Fn::FindInMap"
        ],
        "schema": {
+        "minimum": 0,
         "type": [
          "integer"
         ]
@@ -39,6 +40,7 @@
         "Fn::Length"
        ],
        "schema": {
+        "minimum": 0,
         "type": [
          "integer"
         ]

--- a/src/cfnlint/jsonschema/_resolvers_cfn.py
+++ b/src/cfnlint/jsonschema/_resolvers_cfn.py
@@ -368,6 +368,8 @@ def select(validator: Validator, instance: Any) -> ResolutionResult:
                 continue
             if not validator.is_type(obj, "array"):
                 continue
+            if i < 0:
+                continue
             if len(obj) <= i:
                 continue
             yield from obj_v.resolve_value(obj[i])

--- a/test/unit/module/jsonschema/test_resolvers_cfn.py
+++ b/test/unit/module/jsonschema/test_resolvers_cfn.py
@@ -115,6 +115,11 @@ def test_resolvers_ref(name, instance, response):
             [],
         ),
         (
+            "Invalid Select with a negative index",
+            {"Fn::Select": [-1, ["a", "b"]]},
+            [],
+        ),
+        (
             "Invalid Split with an invalid type",
             {"Fn::Split": {"foo": "bar"}},
             [],

--- a/test/unit/rules/functions/test_select.py
+++ b/test/unit/rules/functions/test_select.py
@@ -55,6 +55,30 @@ def template():
             ],
         ),
         (
+            "Invalid Fn::Select with a negative index",
+            {"Fn::Select": [-1, ["foo", "bar"]]},
+            {"type": "string"},
+            [
+                ValidationError(
+                    "-1 is less than the minimum of 0",
+                    path=deque(["Fn::Select", 0]),
+                    schema_path=deque(
+                        [
+                            "cfnContext",
+                            "schema",
+                            "else",
+                            "prefixItems",
+                            0,
+                            "cfnContext",
+                            "schema",
+                            "minimum",
+                        ]
+                    ),
+                    validator="fn_select",
+                ),
+            ],
+        ),
+        (
             "Invalid Fn::Length using an invalid function for index",
             {"Fn::Select": [{"Fn::Length": [1, 2]}, ["bar"]]},
             {"type": "string"},


### PR DESCRIPTION
## Description
Fixes #4605.

Fn::Select indexes now require a lower bound of 0 in the function schema, matching CloudFormation's documented zero-based index range. The resolver also skips negative resolved indexes defensively so invalid templates cannot use Python's negative list indexing or raise an internal IndexError while resolving values.

## Validation
- `.venv/bin/python -m pytest test/unit/rules/functions/test_select.py test/unit/rules/functions/test_select_language_extension.py test/unit/module/jsonschema/test_resolvers_cfn.py -q`
- `.venv/bin/python -m pytest test/unit/rules/functions test/unit/module/jsonschema -q`
- `.venv/bin/ruff check src/cfnlint/jsonschema/_resolvers_cfn.py test/unit/rules/functions/test_select.py test/unit/module/jsonschema/test_resolvers_cfn.py`
- `.venv/bin/ruff format --check src/cfnlint/jsonschema/_resolvers_cfn.py test/unit/rules/functions/test_select.py test/unit/module/jsonschema/test_resolvers_cfn.py`
- `git diff --check`

## Risk
Low. This only rejects negative Fn::Select indexes that CloudFormation does not allow, and keeps unresolved/invalid resolver paths from producing misleading resolved values.