### PR TITLE
fix(functions): allow FindInMap DefaultValue without transform

### DIFF
--- a/src/cfnlint/data/schemas/other/functions/findinmap.json
+++ b/src/cfnlint/data/schemas/other/functions/findinmap.json
@@ -2,14 +2,7 @@
  "cfnContext": {
   "functions": [],
   "schema": {
-   "else": {
-    "maxItems": 3
-   },
-   "if": {
-    "dynamicValidation": {
-     "transformCheck": "AWS::LanguageExtensions"
-    }
-   },
+   "maxItems": 4,
    "minItems": 3,
    "prefixItems": [
     {
@@ -39,9 +32,6 @@
      }
     }
    ],
-   "then": {
-    "maxItems": 4
-   },
    "type": "array"
   }
  },

--- a/test/unit/rules/functions/test_find_in_map.py
+++ b/test/unit/rules/functions/test_find_in_map.py
@@ -56,32 +56,24 @@ def context(cfn):
             [],
         ),
         (
+            "Valid Fn::FindInMap with DefaultValue",
+            {"Fn::FindInMap": ["A", "B", "C", {"DefaultValue": "D"}]},
+            {"type": "string"},
+            {},
+            None,
+            [],
+        ),
+        (
             "Invalid Fn::FindInMap too long",
-            {"Fn::FindInMap": ["foo", "bar", "key", "key2"]},
+            {"Fn::FindInMap": ["foo", "bar", "key", {"DefaultValue": "D"}, "key2"]},
             {"type": "string"},
             {},
             None,
             [
                 ValidationError(
-                    "expected maximum item count: 3, found: 4",
+                    "expected maximum item count: 4, found: 5",
                     path=deque(["Fn::FindInMap"]),
-                    schema_path=deque(["cfnContext", "schema", "else", "maxItems"]),
-                    validator="fn_findinmap",
-                ),
-                ValidationError(
-                    "'key2' is not of type 'object'",
-                    path=deque(["Fn::FindInMap", 3]),
-                    schema_path=deque(
-                        [
-                            "cfnContext",
-                            "schema",
-                            "prefixItems",
-                            3,
-                            "cfnContext",
-                            "schema",
-                            "type",
-                        ]
-                    ),
+                    schema_path=deque(["cfnContext", "schema", "maxItems"]),
                     validator="fn_findinmap",
                 ),
             ],


### PR DESCRIPTION
## Description

`Fn::FindInMap` with a fourth `DefaultValue` option is now valid without declaring `AWS::LanguageExtensions`, but cfn-lint still used the older transform-gated arity schema. This caused `E1011` for valid templates.

This updates the `Fn::FindInMap` function schema to allow four items by default while preserving the existing fourth-item object validation and transform-gated support for additional intrinsic functions in the map arguments.

Fixes #4627.

## Validation

- `.venv/bin/python -m pytest test/unit/rules/functions/test_find_in_map.py -q`
- `.venv/bin/python -m pytest test/unit/rules/functions -q`
- `.venv/bin/python -m pytest test/unit/rules/functions/test_find_in_map.py test/unit/module/jsonschema -q`
- `.venv/bin/ruff check test/unit/rules/functions/test_find_in_map.py`
- `.venv/bin/ruff format --check test/unit/rules/functions/test_find_in_map.py`
- `git diff --check`
