### PR TITLE
fix(E3005): skip DependsOn validation for SAM/MODULE sub-resources

### DIFF
--- a/src/cfnlint/rules/resources/DependsOn.py
+++ b/src/cfnlint/rules/resources/DependsOn.py
@@ -25,6 +25,15 @@ class DependsOn(CfnLintKeyword):
         if not validator.is_type(instance, "string"):
             return
 
+        # Skip validation for SAM/MODULE sub-resources (e.g. MyFuncAliaslive
+        # for MyFunc of type AWS::Serverless::Function). SAM generates many
+        # resources with dynamic names that we can't fully enumerate.
+        if any(
+            instance.startswith(m) and instance != m
+            for m in validator.context.module_names
+        ):
+            return
+
         resources = list(validator.context.resources.keys())
 
         if len(validator.context.path.path) > 1:

--- a/test/unit/rules/resources/test_dependson.py
+++ b/test/unit/rules/resources/test_dependson.py
@@ -8,6 +8,7 @@ from collections import deque
 import pytest
 
 from cfnlint.context import Path
+from cfnlint.context.context import Resource
 from cfnlint.jsonschema import ValidationError
 from cfnlint.rules.resources.DependsOn import DependsOn  # noqa: E501
 
@@ -151,3 +152,36 @@ def test_validate_with_no_cfn(rule, validator):
     errs = list(rule.validate(validator, False, "ParentBucketWithBadCondition", {}))
 
     assert errs == [], f"Test without cfn got {errs!r}"
+
+
+def test_sam_module_subresource_skipped(rule, validator):
+    """SAM-generated sub-resources are skipped like MODULE sub-resources.
+
+    When DependsOn references a resource that starts with a SAM function name
+    (e.g., MyFuncAliaslive for MyFunc of type AWS::Serverless::Function),
+    validation is skipped because SAM generates many resources with dynamic
+    names that can't be fully enumerated.
+    """
+    # Add a SAM function to the resources
+    resources = dict(validator.context.resources)
+    resources["MyFunc"] = Resource({"Type": "AWS::Serverless::Function"})
+
+    validator = validator.evolve(
+        context=validator.context.evolve(
+            path=Path(path=deque(["Resources", "MyResource", "DependsOn"])),
+            resources=resources,
+        )
+    )
+
+    # DependsOn a SAM-generated alias (MyFuncAliaslive) - should be skipped
+    errs = list(rule.validate(validator, False, "MyFuncAliaslive", {}))
+    assert errs == [], "SAM sub-resource should be skipped"
+
+    # DependsOn the SAM function itself - should still validate
+    errs = list(rule.validate(validator, False, "MyFunc", {}))
+    assert errs == [], "SAM function itself should be valid"
+
+    # DependsOn a completely unknown resource - should error
+    errs = list(rule.validate(validator, False, "TotallyUnknown", {}))
+    assert len(errs) == 1, "Unknown resource should error"
+    assert "TotallyUnknown" in errs[0].message


### PR DESCRIPTION
## Summary

SAM generates many resources with dynamic names (e.g., `MyFuncAliaslive`, `MyFuncVersion<hash>`) that cannot be fully enumerated in advance. This caused false E3005 errors when users referenced SAM-generated resources in `DependsOn`.

## Fix

Apply the same module-skip logic already used by GetAtt (E1010): if the DependsOn target starts with a SAM function or MODULE resource name, skip validation. This is more robust than trying to enumerate every possible SAM-generated resource pattern.

## Example

```yaml
Resources:
  lambdaLogicalId:
    Type: AWS::Serverless::Function
    Properties:
      AutoPublishAlias: live
      # ...

  MyAutoScaling:
    Type: AWS::ApplicationAutoScaling::ScalableTarget
    DependsOn: lambdaLogicalIdAliaslive  # No longer errors
```

## Testing

- Added unit test for SAM sub-resource skip behavior
- Verified invalid DependsOn references still error correctly
- All existing tests pass

Fixes #4631