### PR TITLE
test(functions): assert FindInMap rejects non-DefaultValue 4th item without transform

### DIFF
--- a/test/unit/rules/functions/test_find_in_map.py
+++ b/test/unit/rules/functions/test_find_in_map.py
@@ -64,6 +64,32 @@ def context(cfn):
             [],
         ),
         (
+            "Invalid Fn::FindInMap 4th item not a DefaultValue object"
+            " without transform",
+            {"Fn::FindInMap": ["A", "B", "C", "notanobject"]},
+            {"type": "string"},
+            {},
+            None,
+            [
+                ValidationError(
+                    "'notanobject' is not of type 'object'",
+                    path=deque(["Fn::FindInMap", 3]),
+                    schema_path=deque(
+                        [
+                            "cfnContext",
+                            "schema",
+                            "prefixItems",
+                            3,
+                            "cfnContext",
+                            "schema",
+                            "type",
+                        ]
+                    ),
+                    validator="fn_findinmap",
+                ),
+            ],
+        ),
+        (
             "Invalid Fn::FindInMap too long",
             {"Fn::FindInMap": ["foo", "bar", "key", {"DefaultValue": "D"}, "key2"]},
             {"type": "string"},


### PR DESCRIPTION
## Description

Follow-up to #4628, which made `Fn::FindInMap` `maxItems` unconditionally 4 so a `DefaultValue` 4th element is accepted without the `AWS::LanguageExtensions` transform.

This adds a regression/guardrail test asserting that a 4th element which is **not** a `{DefaultValue: ...}` object is still rejected via `prefixItems[3]` (`'notanobject' is not of type 'object'`) even without the transform — locking in that relaxing the arity did not weaken the 4th-element shape check.

Test-only change; no runtime behavior change.

## Validation

- `pytest test/unit/rules/functions/test_find_in_map.py -q`
- `ruff check` / `ruff format --check` on the changed file
