### PR TITLE
fix: Prevent path traversal in nested stack TemplateURL resolution

### DIFF
--- a/src/cfnlint/context/context.py
+++ b/src/cfnlint/context/context.py
@@ -470,8 +470,18 @@ def _nested_stack_get_atts(filename: str, template_url: str) -> None | Attribute
     ):
         return None
 
+    # Block absolute paths specified directly in the template
+    if os.path.isabs(template_url):
+        return None
+
     base_dir = os.path.dirname(os.path.abspath(filename))
     template_path = os.path.normpath(os.path.join(base_dir, template_url))
+
+    # Ensure resolved path stays within current working directory
+    # to prevent path traversal attacks (e.g., ../../../../etc/passwd)
+    cwd = os.path.abspath(os.getcwd())
+    if not (template_path.startswith(cwd + os.sep) or template_path == cwd):
+        return None
 
     if re.match(REGEX_DYN_REF, template_path):
         return None

--- a/test/unit/module/context/test_resource.py
+++ b/test/unit/module/context/test_resource.py
@@ -122,3 +122,48 @@ def test_nested_stacks(name, instance, filename, decode_results, expected_getatt
         assert expected_getatts == resource.get_atts(region), (
             f"{name!r} test got {resource.get_atts(region)}"
         )
+
+
+@pytest.mark.parametrize(
+    "name,template_url",
+    [
+        (
+            "Absolute path",
+            "/etc/passwd",
+        ),
+        (
+            "Absolute path with Windows style",
+            "C:\\Windows\\System32\\config\\SAM",
+        ),
+        (
+            "Path traversal escaping cwd",
+            "../../../../etc/passwd",
+        ),
+        (
+            "Path traversal to root",
+            "../../../../../../../etc/passwd",
+        ),
+    ],
+)
+def test_nested_stack_path_traversal_blocked(name, template_url):
+    """
+    Test that path traversal attempts are blocked and decode is never called.
+    This prevents reading arbitrary files outside the current working directory.
+    """
+    region = "us-east-1"
+    instance = {
+        "Type": "AWS::CloudFormation::Stack",
+        "Properties": {"TemplateURL": template_url},
+    }
+    # Use a filename within the cwd
+    filename = "templates/main.yaml"
+
+    with patch("cfnlint.decode.decode") as mock_decode:
+        # decode should never be called for traversal attempts
+        mock_decode.side_effect = AssertionError("decode should not be called")
+
+        resource = Resource(instance, filename)
+
+        # Should fall back to default GetAtts pattern (no file read)
+        expected = AttributeDict({"Outputs\\..*": "/properties/CfnLintStringType"})
+        assert expected == resource.get_atts(region), f"{name!r} should block traversal"


### PR DESCRIPTION
## Summary

Add path confinement checks to prevent reading arbitrary files outside the current working directory when resolving relative `TemplateURL` paths for nested CloudFormation stacks.

## Changes

- Block absolute paths specified in `TemplateURL` (e.g., `/etc/passwd`)
- Ensure resolved paths stay within `os.getcwd()` after normalization
- Add unit tests for path traversal scenarios

## Behavior

When a `TemplateURL` path would resolve outside the current working directory, cfn-lint gracefully falls back to the default `Outputs.*` pattern rather than attempting to read the file. This maintains compatibility while adding defense-in-depth.

**Allowed:**
- `./nested/child.yaml`
- `../sibling/child.yaml` (if result is still under cwd)

**Blocked:**
- `../../../../etc/passwd` (escapes cwd)
- `/etc/passwd` (absolute path)

## User Impact

Users running cfn-lint with nested stacks in sibling directories should run from the common parent directory to ensure all templates are within the cwd boundary.