### PR TITLE
fix: Require object for CreationPolicy and UpdatePolicy

### DIFF
--- a/src/cfnlint/jsonschema/_keywords.py
+++ b/src/cfnlint/jsonschema/_keywords.py
@@ -83,36 +83,16 @@ def additionalProperties(
 def allOf(
     validator: Validator, allOf: Any, instance: Any, schema: dict[str, Any]
 ) -> ValidationResult:
+    # allOf is conjunctive: every subschema must hold and there is no branch to
+    # select, so an unresolvable intrinsic function creates no ambiguity here
+    # (unlike anyOf/oneOf/if). Validate each subschema and yield all errors.
     validator = validator.evolve(
         function_filter=validator.function_filter.evolve(
             add_cfn_lint_keyword=False,
         ),
-        context=validator.context.evolve(
-            unresolvable_function_mode=True,
-        ),
     )
-    has_unknown = False
-    known_errors = []
-
     for index, subschema in enumerate(allOf):
-        errs = list(validator.descend(instance, subschema, schema_path=index))
-
-        if any(getattr(err, "unknown", False) for err in errs):
-            has_unknown = True
-        else:
-            known_errors.extend(errs)
-
-    # If we have unknown branches, we can't determine if allOf is satisfied
-    if has_unknown:
-        yield ValidationError(
-            f"Cannot determine allOf for {instance!r}",
-            unknown=True,
-        )
-        return
-
-    # Yield all known errors
-    for err in known_errors:
-        yield err
+        yield from validator.descend(instance, subschema, schema_path=index)
 
 
 def anyOf(

--- a/src/cfnlint/rules/functions/Ref.py
+++ b/src/cfnlint/rules/functions/Ref.py
@@ -7,7 +7,12 @@ from __future__ import annotations
 
 from typing import Any
 
-from cfnlint.helpers import VALID_PARAMETER_TYPES, VALID_PARAMETER_TYPES_LIST
+from cfnlint.helpers import (
+    PSEUDOPARAMS_MULTIPLE,
+    PSEUDOPARAMS_SINGLE,
+    VALID_PARAMETER_TYPES,
+    VALID_PARAMETER_TYPES_LIST,
+)
 from cfnlint.jsonschema import ValidationError, Validator
 from cfnlint.rules.functions._BaseFn import BaseFn, all_types
 
@@ -65,6 +70,29 @@ class Ref(BaseFn):
                     for x in VALID_PARAMETER_TYPES
                     if x not in VALID_PARAMETER_TYPES_LIST
                 ]:
+                    yield ValidationError(f"{instance!r} is not of type {reprs}")
+                    return
+
+        elif value in PSEUDOPARAMS_SINGLE or value in PSEUDOPARAMS_MULTIPLE:
+            # Pseudo parameters resolve to a known type: the SINGLE set are
+            # strings, PSEUDOPARAMS_MULTIPLE (AWS::NotificationARNs) is a list.
+            # Validate that resolved type against the schema, the same way we
+            # do for named parameters.
+            schema_types = self.resolve_type(validator, subschema)
+            if not schema_types:
+                return
+            reprs = ", ".join(repr(type) for type in schema_types)
+            is_list = value in PSEUDOPARAMS_MULTIPLE
+
+            if all(
+                st not in ["string", "boolean", "integer", "number"]
+                for st in schema_types
+            ):
+                if not is_list:
+                    yield ValidationError(f"{instance!r} is not of type {reprs}")
+                    return
+            elif all(st not in ["array"] for st in schema_types):
+                if is_list:
                     yield ValidationError(f"{instance!r} is not of type {reprs}")
                     return
 

--- a/src/cfnlint/rules/resources/CreationPolicy.py
+++ b/src/cfnlint/rules/resources/CreationPolicy.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from cfnlint.helpers import FUNCTIONS
 from cfnlint.jsonschema import Validator
 from cfnlint.rules.jsonschema.CfnLintJsonSchema import CfnLintJsonSchema
 
@@ -84,13 +85,8 @@ class CreationPolicy(CfnLintJsonSchema):
 
         validator = validator.evolve(
             context=validator.context.evolve(
-                functions=[
-                    "Fn::Sub",
-                    "Fn::Select",
-                    "Fn::FindInMap",
-                    "Fn::If",
-                    "Ref",
-                ],
+                functions=list(FUNCTIONS),
+                resources={},
                 strict_types=False,
             ),
             schema=self._get_schema(resource_type),

--- a/src/cfnlint/rules/resources/updatepolicy/Configuration.py
+++ b/src/cfnlint/rules/resources/updatepolicy/Configuration.py
@@ -6,7 +6,6 @@ SPDX-License-Identifier: MIT-0
 from typing import Any
 
 import cfnlint.data.schemas.other.resources
-import cfnlint.helpers
 from cfnlint.helpers import FUNCTIONS
 from cfnlint.jsonschema import Validator
 from cfnlint.rules.jsonschema.CfnLintJsonSchema import CfnLintJsonSchema, SchemaDetails
@@ -36,6 +35,7 @@ class Configuration(CfnLintJsonSchema):
         validator = validator.evolve(
             context=validator.context.evolve(
                 functions=list(FUNCTIONS),
+                resources={},
                 strict_types=False,
             ),
             schema=self._schema,

--- a/test/fixtures/results/integration/creationpolicy_yaml.json
+++ b/test/fixtures/results/integration/creationpolicy_yaml.json
@@ -1,0 +1,115 @@
+[
+    {
+        "Filename": "test/fixtures/templates/integration/creationpolicy.yaml",
+        "Id": "79d23d5c-b5c1-c364-58e0-b3c01c5aa274",
+        "Level": "Error",
+        "Location": {
+            "End": {
+                "ColumnNumber": 19,
+                "LineNumber": 31
+            },
+            "Path": [
+                "Resources",
+                "BareRefParam",
+                "CreationPolicy"
+            ],
+            "Start": {
+                "ColumnNumber": 5,
+                "LineNumber": 31
+            }
+        },
+        "Message": "{'Ref': 'P'} is not of type 'object'",
+        "ParentId": null,
+        "Rule": {
+            "Description": "Making sure the Ref has a String value (no other functions are supported)",
+            "Id": "E1020",
+            "ShortDescription": "Ref validation of value",
+            "Source": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-ref.html"
+        }
+    },
+    {
+        "Filename": "test/fixtures/templates/integration/creationpolicy.yaml",
+        "Id": "3f4508fa-3fdd-6bec-6e01-d63493f18c72",
+        "Level": "Error",
+        "Location": {
+            "End": {
+                "ColumnNumber": 19,
+                "LineNumber": 34
+            },
+            "Path": [
+                "Resources",
+                "BareRefResource",
+                "CreationPolicy",
+                "Ref"
+            ],
+            "Start": {
+                "ColumnNumber": 5,
+                "LineNumber": 34
+            }
+        },
+        "Message": "'ValidObject' is not one of ['P', 'SignalCount', 'AWS::AccountId', 'AWS::NoValue', 'AWS::NotificationARNs', 'AWS::Partition', 'AWS::Region', 'AWS::StackId', 'AWS::StackName', 'AWS::URLSuffix']",
+        "ParentId": null,
+        "Rule": {
+            "Description": "Making sure the Ref has a String value (no other functions are supported)",
+            "Id": "E1020",
+            "ShortDescription": "Ref validation of value",
+            "Source": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-ref.html"
+        }
+    },
+    {
+        "Filename": "test/fixtures/templates/integration/creationpolicy.yaml",
+        "Id": "4b94035f-269f-152b-e2a2-c63b9cc36b69",
+        "Level": "Error",
+        "Location": {
+            "End": {
+                "ColumnNumber": 19,
+                "LineNumber": 37
+            },
+            "Path": [
+                "Resources",
+                "BareRefPseudo",
+                "CreationPolicy"
+            ],
+            "Start": {
+                "ColumnNumber": 5,
+                "LineNumber": 37
+            }
+        },
+        "Message": "{'Ref': 'AWS::Region'} is not of type 'object'",
+        "ParentId": null,
+        "Rule": {
+            "Description": "Making sure the Ref has a String value (no other functions are supported)",
+            "Id": "E1020",
+            "ShortDescription": "Ref validation of value",
+            "Source": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-ref.html"
+        }
+    },
+    {
+        "Filename": "test/fixtures/templates/integration/creationpolicy.yaml",
+        "Id": "701e011a-40e0-f891-2327-7f29a76110d7",
+        "Level": "Error",
+        "Location": {
+            "End": {
+                "ColumnNumber": 19,
+                "LineNumber": 40
+            },
+            "Path": [
+                "Resources",
+                "BareSub",
+                "CreationPolicy"
+            ],
+            "Start": {
+                "ColumnNumber": 5,
+                "LineNumber": 40
+            }
+        },
+        "Message": "{'Fn::Sub': '${P}'} is not of type 'object'",
+        "ParentId": null,
+        "Rule": {
+            "Description": "Making sure the sub function is properly configured",
+            "Id": "E1019",
+            "ShortDescription": "Sub validation of parameters",
+            "Source": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-sub.html"
+        }
+    }
+]

--- a/test/fixtures/results/integration/updatepolicy_yaml.json
+++ b/test/fixtures/results/integration/updatepolicy_yaml.json
@@ -1,0 +1,30 @@
+[
+    {
+        "Filename": "test/fixtures/templates/integration/updatepolicy.yaml",
+        "Id": "9c312053-fd6c-cd5f-e0a6-acc1cd7985ff",
+        "Level": "Error",
+        "Location": {
+            "End": {
+                "ColumnNumber": 17,
+                "LineNumber": 49
+            },
+            "Path": [
+                "Resources",
+                "BareRef",
+                "UpdatePolicy"
+            ],
+            "Start": {
+                "ColumnNumber": 5,
+                "LineNumber": 49
+            }
+        },
+        "Message": "{'Ref': 'P'} is not of type 'object'",
+        "ParentId": null,
+        "Rule": {
+            "Description": "Making sure the Ref has a String value (no other functions are supported)",
+            "Id": "E1020",
+            "ShortDescription": "Ref validation of value",
+            "Source": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-ref.html"
+        }
+    }
+]

--- a/test/fixtures/templates/integration/creationpolicy.yaml
+++ b/test/fixtures/templates/integration/creationpolicy.yaml
@@ -1,0 +1,40 @@
+Parameters:
+  P:
+    Type: String
+  SignalCount:
+    Type: Number
+    Default: 1
+Conditions:
+  IsProd: !Equals [!Ref "AWS::Region", "us-east-1"]
+Resources:
+  # Valid: object literal with a nested Ref
+  ValidObject:
+    Type: AWS::CloudFormation::WaitCondition
+    CreationPolicy:
+      ResourceSignal:
+        Count: !Ref SignalCount
+        Timeout: PT15M
+  # Valid: Fn::If resolving to objects
+  ValidIf:
+    Type: AWS::CloudFormation::WaitCondition
+    CreationPolicy: !If
+      - IsProd
+      - ResourceSignal:
+          Count: 1
+          Timeout: PT15M
+      - ResourceSignal:
+          Count: 2
+          Timeout: PT15M
+  # Invalid: a bare intrinsic cannot stand in for the object
+  BareRefParam:
+    Type: AWS::CloudFormation::WaitCondition
+    CreationPolicy: !Ref P
+  BareRefResource:
+    Type: AWS::CloudFormation::WaitCondition
+    CreationPolicy: !Ref ValidObject
+  BareRefPseudo:
+    Type: AWS::CloudFormation::WaitCondition
+    CreationPolicy: !Ref "AWS::Region"
+  BareSub:
+    Type: AWS::CloudFormation::WaitCondition
+    CreationPolicy: !Sub "${P}"

--- a/test/fixtures/templates/integration/updatepolicy.yaml
+++ b/test/fixtures/templates/integration/updatepolicy.yaml
@@ -1,0 +1,56 @@
+Parameters:
+  P:
+    Type: String
+  Batch:
+    Type: Number
+    Default: 1
+Conditions:
+  IsProd: !Equals [!Ref "AWS::Region", "us-east-1"]
+Resources:
+  LaunchTemplate:
+    Type: AWS::EC2::LaunchTemplate
+    Properties:
+      LaunchTemplateData:
+        ImageId: ami-1234567890abcdef0
+        InstanceType: t3.micro
+  # Valid: object literal with a nested Ref
+  ValidObject:
+    Type: AWS::AutoScaling::AutoScalingGroup
+    UpdatePolicy:
+      AutoScalingRollingUpdate:
+        MaxBatchSize: !Ref Batch
+        MinInstancesInService: 0
+    Properties:
+      MinSize: "0"
+      MaxSize: "0"
+      AvailabilityZones: !GetAZs ""
+      LaunchTemplate:
+        LaunchTemplateId: !Ref LaunchTemplate
+        Version: !GetAtt LaunchTemplate.LatestVersionNumber
+  # Valid: Fn::If resolving to objects
+  ValidIf:
+    Type: AWS::AutoScaling::AutoScalingGroup
+    UpdatePolicy: !If
+      - IsProd
+      - AutoScalingRollingUpdate:
+          MaxBatchSize: 1
+      - AutoScalingRollingUpdate:
+          MaxBatchSize: 2
+    Properties:
+      MinSize: "0"
+      MaxSize: "0"
+      AvailabilityZones: !GetAZs ""
+      LaunchTemplate:
+        LaunchTemplateId: !Ref LaunchTemplate
+        Version: !GetAtt LaunchTemplate.LatestVersionNumber
+  # Invalid: a bare intrinsic cannot stand in for the object
+  BareRef:
+    Type: AWS::AutoScaling::AutoScalingGroup
+    UpdatePolicy: !Ref P
+    Properties:
+      MinSize: "0"
+      MaxSize: "0"
+      AvailabilityZones: !GetAZs ""
+      LaunchTemplate:
+        LaunchTemplateId: !Ref LaunchTemplate
+        Version: !GetAtt LaunchTemplate.LatestVersionNumber

--- a/test/integration/test_integration_templates.py
+++ b/test/integration/test_integration_templates.py
@@ -133,6 +133,20 @@ class TestQuickStartTemplates(BaseCliTestCase):
             ),
             "exit_code": 0,
         },
+        {
+            "filename": "test/fixtures/templates/integration/creationpolicy.yaml",
+            "results_filename": (
+                "test/fixtures/results/integration/creationpolicy_yaml.json"
+            ),
+            "exit_code": 2,
+        },
+        {
+            "filename": "test/fixtures/templates/integration/updatepolicy.yaml",
+            "results_filename": (
+                "test/fixtures/results/integration/updatepolicy_yaml.json"
+            ),
+            "exit_code": 2,
+        },
     ]
 
     def test_templates(self):

--- a/test/unit/rules/functions/test_ref.py
+++ b/test/unit/rules/functions/test_ref.py
@@ -138,6 +138,56 @@ def context(cfn):
                 ),
             ],
         ),
+        (
+            "Pseudo parameter (string) is not an object",
+            {"Ref": "AWS::Region"},
+            {"type": "object"},
+            {},
+            [
+                ValidationError(
+                    "{'Ref': 'AWS::Region'} is not of type 'object'",
+                ),
+            ],
+        ),
+        (
+            "Pseudo parameter (list) does not satisfy a scalar schema",
+            {"Ref": "AWS::NotificationARNs"},
+            {"type": "string"},
+            {},
+            [
+                ValidationError(
+                    "{'Ref': 'AWS::NotificationARNs'} is not of type 'string'",
+                ),
+            ],
+        ),
+        (
+            "Pseudo parameter (string) satisfies a string schema",
+            {"Ref": "AWS::Region"},
+            {"type": "string"},
+            {},
+            [],
+        ),
+        (
+            "Pseudo parameter (list) satisfies an array schema",
+            {"Ref": "AWS::NotificationARNs"},
+            {"type": "array"},
+            {},
+            [],
+        ),
+        (
+            "Pseudo parameter with no schema type is not validated",
+            {"Ref": "AWS::Region"},
+            {},
+            {},
+            [],
+        ),
+        (
+            "Pseudo parameter (string) satisfies a string/array schema",
+            {"Ref": "AWS::Region"},
+            {"type": ["string", "array"]},
+            {},
+            [],
+        ),
     ],
 )
 def test_validate(name, instance, schema, context_evolve, expected, rule, context, cfn):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

`CreationPolicy` and `UpdatePolicy` must resolve to an object. CloudFormation
rejects a bare intrinsic standing in for the whole object with
`Template format error: Expected an object` (verified against live
CloudFormation). Only an object literal or `Fn::If` (which resolves to an
object) is valid there; `Ref`/`Fn::Sub`/`Fn::FindInMap`, and `Ref` to a
resource or pseudo parameter, are not. Intrinsics nested at leaf properties
(e.g. `ResourceSignal.Count: !Ref Count`) remain valid.

Previously these were missed: `E3055`/`E3016` allowed the full function set and
leaned on type inference, and `UpdatePolicy` errors were swallowed entirely.

**Changes**
- `allOf` no longer flips `unresolvable_function_mode` or rolls errors up into a
  single "Cannot determine allOf". `allOf` is conjunctive — every subschema
  must hold and there is no branch to select — so an unresolvable intrinsic
  creates no ambiguity there; the suppression only hid legitimate errors. That
  mode still applies to the disjunctive keywords (`anyOf`/`oneOf`/`if`). This
  lets `UpdatePolicy` (E3016), whose schema is expressed via `allOf`/`if`/`then`,
  surface these errors the way `CreationPolicy` (E3055) already does.
- E3055/E3016 validate against plain object schemas and blank `Resources` from
  the reference context, so `Ref` to a resource is caught.
- `Ref` (E1020) now resolves pseudo-parameter types (string, or list for
  `AWS::NotificationARNs`) and validates them against the schema, mirroring the
  existing named-parameter check, so `Ref` to a pseudo at an object slot is
  caught.
- Added integration templates and snapshots for CreationPolicy and
  UpdatePolicy (`test/fixtures/templates/integration/`,
  `test/fixtures/results/integration/`).

**Verified against live CloudFormation** (CreateStack):

| Value at the policy slot | CloudFormation |
| --- | --- |
| object literal | accepted |
| `Fn::If` (object branches) | accepted |
| `Ref` (param / resource / pseudo), `Fn::Sub`, `Fn::FindInMap` | `Expected an object` |
| `Ref: AWS::NoValue` | `Expected an object` |
| nested leaf intrinsic (`Count: !Ref P`) | accepted |

**Known follow-up:** `Fn::Select` is not yet rejected at the object slot
because its declared output type is `all_types` (it can legitimately resolve to
an object via a list of objects, e.g. through `Fn::FindInMap`). Tracked
separately.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
