### PR TITLE
Validate JSONPath reference paths (.$) in Step Functions state machine definitions

### DIFF
--- a/src/cfnlint/rules/resources/stepfunctions/StateMachineDefinition.py
+++ b/src/cfnlint/rules/resources/stepfunctions/StateMachineDefinition.py
@@ -214,30 +214,24 @@ class StateMachineDefinition(CfnLintJsonSchema):
             return True
         return False
 
-    def _validate_reference_paths(
+    def _validate_payload(
         self,
         instance: Any,
         k: str,
-        path: deque | None = None,
-        in_payload: bool = False,
+        path: deque,
     ) -> ValidationResult:
         """
-        Per the Amazon States Language specification, inside a payload template
-        a field whose name ends with '.$' must have a value that is a valid
-        JSONPath (beginning with '$') or an intrinsic function call.
-
-        Reference: https://states-language.net/spec.html#payload-template
+        Recurse through a payload template value. Every field inside a payload
+        template inherits the payload semantics, so a nested field whose name
+        ends with '.$' must resolve to a valid JSONPath or intrinsic function.
         """
-        path = deque() if path is None else path
-
         if isinstance(instance, dict):
             for key, value in instance.items():
                 child_path = deque(path)
                 child_path.append(key)
 
                 if (
-                    in_payload
-                    and isinstance(key, str)
+                    isinstance(key, str)
                     and key.endswith(".$")
                     and not self._is_jsonpath_or_intrinsic(value)
                 ):
@@ -250,17 +244,68 @@ class StateMachineDefinition(CfnLintJsonSchema):
                     error_path.extend(child_path)
                     yield ValidationError(message, path=error_path, rule=self)
 
-                child_in_payload = in_payload or key in self._payload_template_fields
-                yield from self._validate_reference_paths(
-                    value, k, child_path, child_in_payload
-                )
+                yield from self._validate_payload(value, k, child_path)
         elif isinstance(instance, list):
             for idx, item in enumerate(instance):
                 child_path = deque(path)
                 child_path.append(idx)
-                yield from self._validate_reference_paths(
-                    item, k, child_path, in_payload
-                )
+                yield from self._validate_payload(item, k, child_path)
+
+    def _validate_reference_paths(
+        self,
+        instance: Any,
+        k: str,
+        path: deque | None = None,
+    ) -> ValidationResult:
+        """
+        Per the Amazon States Language specification, inside a payload template
+        a field whose name ends with '.$' must have a value that is a valid
+        JSONPath (beginning with '$') or an intrinsic function call.
+
+        Payload detection is scoped structurally: only the payload template
+        fields that appear as a direct field of a state are validated. This
+        keeps literal data (such as a Pass 'Result') and any state that merely
+        shares a name with a payload field from being flagged.
+
+        Reference: https://states-language.net/spec.html#payload-template
+        """
+        path = deque() if path is None else path
+
+        if not isinstance(instance, dict):
+            return
+
+        states = instance.get("States")
+        if not isinstance(states, dict):
+            return
+
+        for state_name, state in states.items():
+            if not isinstance(state, dict):
+                continue
+
+            state_path = deque(path)
+            state_path.extend(["States", state_name])
+
+            for field in self._payload_template_fields:
+                if field in state:
+                    field_path = deque(state_path)
+                    field_path.append(field)
+                    yield from self._validate_payload(state[field], k, field_path)
+
+            # Recurse into nested state machines so their payload templates are
+            # validated with the same structural scoping.
+            branches = state.get("Branches")
+            if isinstance(branches, list):
+                for idx, branch in enumerate(branches):
+                    branch_path = deque(state_path)
+                    branch_path.extend(["Branches", idx])
+                    yield from self._validate_reference_paths(branch, k, branch_path)
+
+            for nested_key in ("ItemProcessor", "Iterator"):
+                nested = state.get(nested_key)
+                if isinstance(nested, dict):
+                    nested_path = deque(state_path)
+                    nested_path.append(nested_key)
+                    yield from self._validate_reference_paths(nested, k, nested_path)
 
     def _validate_step(
         self,

--- a/src/cfnlint/rules/resources/stepfunctions/StateMachineDefinition.py
+++ b/src/cfnlint/rules/resources/stepfunctions/StateMachineDefinition.py
@@ -184,6 +184,81 @@ class StateMachineDefinition(CfnLintJsonSchema):
                         iterator, k, add_path_to_message, iterator_path
                     )
 
+    # Amazon States Language payload template fields. Inside these, a field
+    # whose name ends with ".$" is evaluated as a JSONPath expression or an
+    # intrinsic function rather than being treated as a literal value.
+    # https://docs.aws.amazon.com/step-functions/latest/dg/amazon-states-language-input-output-processing.html
+    _payload_template_fields = (
+        "Parameters",
+        "ResultSelector",
+        "ItemSelector",
+        "Assign",
+    )
+
+    def _is_jsonpath_or_intrinsic(self, value: Any) -> bool:
+        # Only string values carry the ".$" JSONPath/intrinsic contract. A non
+        # string value (for example a resolved intrinsic function object) is
+        # validated elsewhere, and a substitution placeholder may resolve to a
+        # valid path at deploy time, so neither is flagged here.
+        if not isinstance(value, str):
+            return True
+        stripped = value.strip()
+        if "${" in stripped:
+            return True
+        if stripped.startswith("$"):
+            return True
+        if stripped.startswith("States.") and stripped.endswith(")"):
+            return True
+        return False
+
+    def _validate_reference_paths(
+        self,
+        instance: Any,
+        k: str,
+        path: deque | None = None,
+        in_payload: bool = False,
+    ) -> ValidationResult:
+        """
+        Per the Amazon States Language specification, inside a payload template
+        a field whose name ends with '.$' must have a value that is a valid
+        JSONPath (beginning with '$') or an intrinsic function call.
+
+        Reference: https://states-language.net/spec.html#payload-template
+        """
+        path = deque() if path is None else path
+
+        if isinstance(instance, dict):
+            for key, value in instance.items():
+                child_path = deque(path)
+                child_path.append(key)
+
+                if (
+                    in_payload
+                    and isinstance(key, str)
+                    and key.endswith(".$")
+                    and not self._is_jsonpath_or_intrinsic(value)
+                ):
+                    display_path = "/" + "/".join(str(p) for p in child_path)
+                    message = (
+                        f"{value!r} is not a valid JSONPath string or "
+                        f"intrinsic function for {key!r} at {display_path}"
+                    )
+                    error_path = deque([k])
+                    error_path.extend(child_path)
+                    yield ValidationError(message, path=error_path, rule=self)
+
+                child_in_payload = in_payload or key in self._payload_template_fields
+                yield from self._validate_reference_paths(
+                    value, k, child_path, child_in_payload
+                )
+        elif isinstance(instance, list):
+            for idx, item in enumerate(instance):
+                child_path = deque(path)
+                child_path.append(idx)
+                yield from self._validate_reference_paths(
+                    item, k, child_path, in_payload
+                )
+
     def _validate_step(
         self,
         validator: Validator,
@@ -217,6 +292,10 @@ class StateMachineDefinition(CfnLintJsonSchema):
 
         # Validate StartAt exists
         yield from self._validate_start_at(value, k, add_path_to_message)
+
+        # Validate that ".$" payload template fields reference a JSONPath or
+        # an intrinsic function
+        yield from self._validate_reference_paths(value, k)
 
     def validate(
         self, validator: Validator, keywords: Any, instance: Any, schema: dict[str, Any]

--- a/src/cfnlint/rules/resources/stepfunctions/StateMachineDefinition.py
+++ b/src/cfnlint/rules/resources/stepfunctions/StateMachineDefinition.py
@@ -256,6 +256,7 @@ class StateMachineDefinition(CfnLintJsonSchema):
         instance: Any,
         k: str,
         path: deque | None = None,
+        inherited_query_language: str = "JSONPath",
     ) -> ValidationResult:
         """
         Per the Amazon States Language specification, inside a payload template
@@ -266,6 +267,11 @@ class StateMachineDefinition(CfnLintJsonSchema):
         fields that appear as a direct field of a state are validated. This
         keeps literal data (such as a Pass 'Result') and any state that merely
         shares a name with a payload field from being flagged.
+
+        QueryLanguage is resolved per state: a state may set its own
+        QueryLanguage to adopt JSONata incrementally, and the '.$' convention
+        does not apply to a JSONata state, so those states (and any nested
+        state machines that inherit JSONata) are skipped.
 
         Reference: https://states-language.net/spec.html#payload-template
         """
@@ -285,27 +291,37 @@ class StateMachineDefinition(CfnLintJsonSchema):
             state_path = deque(path)
             state_path.extend(["States", state_name])
 
-            for field in self._payload_template_fields:
-                if field in state:
-                    field_path = deque(state_path)
-                    field_path.append(field)
-                    yield from self._validate_payload(state[field], k, field_path)
+            state_ql = state.get("QueryLanguage")
+            if not isinstance(state_ql, str):
+                state_ql = inherited_query_language
+
+            if state_ql != "JSONata":
+                for field in self._payload_template_fields:
+                    if field in state:
+                        field_path = deque(state_path)
+                        field_path.append(field)
+                        yield from self._validate_payload(state[field], k, field_path)
 
             # Recurse into nested state machines so their payload templates are
-            # validated with the same structural scoping.
+            # validated with the same structural scoping, carrying the resolved
+            # QueryLanguage down as the inherited default.
             branches = state.get("Branches")
             if isinstance(branches, list):
                 for idx, branch in enumerate(branches):
                     branch_path = deque(state_path)
                     branch_path.extend(["Branches", idx])
-                    yield from self._validate_reference_paths(branch, k, branch_path)
+                    yield from self._validate_reference_paths(
+                        branch, k, branch_path, state_ql
+                    )
 
             for nested_key in ("ItemProcessor", "Iterator"):
                 nested = state.get(nested_key)
                 if isinstance(nested, dict):
                     nested_path = deque(state_path)
                     nested_path.append(nested_key)
-                    yield from self._validate_reference_paths(nested, k, nested_path)
+                    yield from self._validate_reference_paths(
+                        nested, k, nested_path, state_ql
+                    )
 
     def _validate_step(
         self,

--- a/src/cfnlint/rules/resources/stepfunctions/StateMachineDefinition.py
+++ b/src/cfnlint/rules/resources/stepfunctions/StateMachineDefinition.py
@@ -109,10 +109,10 @@ class StateMachineDefinition(CfnLintJsonSchema):
             validator, instance, deque(["QueryLanguage"])
         ):
             if ql is None or ql == "JSONPath":
-                yield self.schema, ql_validator
+                yield self.schema, ql_validator, True
 
             if ql == "JSONata":
-                yield self._convert_schema_to_jsonata(), ql_validator
+                yield self._convert_schema_to_jsonata(), ql_validator, False
 
     def _validate_start_at(
         self,
@@ -207,6 +207,9 @@ class StateMachineDefinition(CfnLintJsonSchema):
             return True
         if stripped.startswith("$"):
             return True
+        # Intentionally loose: this accepts a malformed intrinsic such as
+        # "States.Foo bar)" as valid. Erring toward a false negative here is
+        # preferable to falsely flagging a genuine intrinsic function call.
         if stripped.startswith("States.") and stripped.endswith(")"):
             return True
         return False
@@ -266,6 +269,7 @@ class StateMachineDefinition(CfnLintJsonSchema):
         value: Any,
         add_path_to_message: bool,
         k: str,
+        is_jsonpath: bool = True,
     ) -> ValidationResult:
         for err in validator.iter_errors(value):
             if validator.is_type(err.instance, "string"):
@@ -294,8 +298,11 @@ class StateMachineDefinition(CfnLintJsonSchema):
         yield from self._validate_start_at(value, k, add_path_to_message)
 
         # Validate that ".$" payload template fields reference a JSONPath or
-        # an intrinsic function
-        yield from self._validate_reference_paths(value, k)
+        # an intrinsic function. The ".$" convention is specific to JSONPath;
+        # under QueryLanguage: JSONata a literal ".$" field name is legal and
+        # carries no JSONPath semantics, so this check is skipped there.
+        if is_jsonpath:
+            yield from self._validate_reference_paths(value, k)
 
     def validate(
         self, validator: Validator, keywords: Any, instance: Any, schema: dict[str, Any]
@@ -324,7 +331,7 @@ class StateMachineDefinition(CfnLintJsonSchema):
                 try:
                     value = json.loads(value)
                     add_path_to_message = True
-                    for schema, schema_validator in self._clean_schema(
+                    for schema, schema_validator, is_jsonpath in self._clean_schema(
                         validator, value
                     ):
                         resolver = RefResolver.from_schema(schema, store=self.store)
@@ -337,17 +344,29 @@ class StateMachineDefinition(CfnLintJsonSchema):
                         )
 
                         yield from self._validate_step(
-                            step_validator, substitutions, value, add_path_to_message, k
+                            step_validator,
+                            substitutions,
+                            value,
+                            add_path_to_message,
+                            k,
+                            is_jsonpath,
                         )
                 except json.JSONDecodeError:
                     return
             else:
-                for schema, schema_validator in self._clean_schema(validator, value):
+                for schema, schema_validator, is_jsonpath in self._clean_schema(
+                    validator, value
+                ):
                     resolver = RefResolver.from_schema(schema, store=self.store)
                     step_validator = schema_validator.evolve(
                         resolver=resolver,
                         schema=schema,
                     )
                     yield from self._validate_step(
-                        step_validator, substitutions, value, add_path_to_message, k
+                        step_validator,
+                        substitutions,
+                        value,
+                        add_path_to_message,
+                        k,
+                        is_jsonpath,
                     )

--- a/test/unit/rules/resources/stepfunctions/test_state_machine_definition.py
+++ b/test/unit/rules/resources/stepfunctions/test_state_machine_definition.py
@@ -1675,6 +1675,25 @@ def rule():
             },
             [],
         ),
+        (
+            "Literal '.$' in a Pass Result and a state named after a "
+            "payload field are not flagged",
+            {
+                "Definition": {
+                    "StartAt": "Parameters",
+                    "States": {
+                        "Parameters": {
+                            "Type": "Pass",
+                            "Result": {
+                                "literalKey.$": "literal data",
+                            },
+                            "End": True,
+                        },
+                    },
+                }
+            },
+            [],
+        ),
     ],
 )
 def test_validate(

--- a/test/unit/rules/resources/stepfunctions/test_state_machine_definition.py
+++ b/test/unit/rules/resources/stepfunctions/test_state_machine_definition.py
@@ -1694,6 +1694,32 @@ def rule():
             },
             [],
         ),
+        (
+            "Per-state JSONata in a JSONPath machine allows a literal '.$'",
+            {
+                "Definition": {
+                    "StartAt": "JsonPathPass",
+                    "States": {
+                        "JsonPathPass": {
+                            "Type": "Pass",
+                            "Assign": {
+                                "Good.$": "$.input.value",
+                            },
+                            "Next": "JsonataPass",
+                        },
+                        "JsonataPass": {
+                            "Type": "Pass",
+                            "QueryLanguage": "JSONata",
+                            "Assign": {
+                                "foo.$": "plainliteral",
+                            },
+                            "End": True,
+                        },
+                    },
+                }
+            },
+            [],
+        ),
     ],
 )
 def test_validate(

--- a/test/unit/rules/resources/stepfunctions/test_state_machine_definition.py
+++ b/test/unit/rules/resources/stepfunctions/test_state_machine_definition.py
@@ -1656,6 +1656,25 @@ def rule():
                 ),
             ],
         ),
+        (
+            "Literal '.$' field is allowed under QueryLanguage JSONata",
+            {
+                "Definition": {
+                    "QueryLanguage": "JSONata",
+                    "StartAt": "Pass",
+                    "States": {
+                        "Pass": {
+                            "Type": "Pass",
+                            "Assign": {
+                                "foo.$": "plainliteral",
+                            },
+                            "End": True,
+                        },
+                    },
+                }
+            },
+            [],
+        ),
     ],
 )
 def test_validate(

--- a/test/unit/rules/resources/stepfunctions/test_state_machine_definition.py
+++ b/test/unit/rules/resources/stepfunctions/test_state_machine_definition.py
@@ -1560,6 +1560,102 @@ def rule():
             },
             [],
         ),
+        (
+            "Valid JSONPath and intrinsic function reference paths",
+            {
+                "Definition": {
+                    "StartAt": "Pass",
+                    "States": {
+                        "Pass": {
+                            "Type": "Pass",
+                            "Assign": {
+                                "JsonPathVar.$": "$.input.value",
+                                "ContextVar.$": "$$.Execution.Id",
+                                "IntrinsicVar.$": "States.Format('{}', $.name)",
+                                "LiteralVar": "a plain literal is fine",
+                                "Nested": {
+                                    "InnerPath.$": "$.a.b",
+                                },
+                            },
+                            "Parameters": {
+                                "Comment.$": "$.comment",
+                            },
+                            "End": True,
+                        },
+                    },
+                }
+            },
+            [],
+        ),
+        (
+            "Invalid literal value for a reference path field",
+            {
+                "Definition": {
+                    "StartAt": "Pass",
+                    "States": {
+                        "Pass": {
+                            "Type": "Pass",
+                            "Assign": {
+                                "Variable.$": "Test",
+                            },
+                            "Next": "Success",
+                        },
+                        "Success": {
+                            "Type": "Succeed",
+                        },
+                    },
+                }
+            },
+            [
+                ValidationError(
+                    "'Test' is not a valid JSONPath string or intrinsic "
+                    "function for 'Variable.$' at "
+                    "/States/Pass/Assign/Variable.$",
+                    rule=StateMachineDefinition(),
+                    path=deque(
+                        ["Definition", "States", "Pass", "Assign", "Variable.$"]
+                    ),
+                ),
+            ],
+        ),
+        (
+            "Invalid reference path nested inside Parameters",
+            {
+                "Definition": {
+                    "StartAt": "Task",
+                    "States": {
+                        "Task": {
+                            "Type": "Task",
+                            "Resource": "arn:aws:states:::lambda:invoke",
+                            "Parameters": {
+                                "Payload": {
+                                    "Value.$": "not-a-path",
+                                },
+                            },
+                            "End": True,
+                        },
+                    },
+                }
+            },
+            [
+                ValidationError(
+                    "'not-a-path' is not a valid JSONPath string or intrinsic "
+                    "function for 'Value.$' at "
+                    "/States/Task/Parameters/Payload/Value.$",
+                    rule=StateMachineDefinition(),
+                    path=deque(
+                        [
+                            "Definition",
+                            "States",
+                            "Task",
+                            "Parameters",
+                            "Payload",
+                            "Value.$",
+                        ]
+                    ),
+                ),
+            ],
+        ),
     ],
 )
 def test_validate(


### PR DESCRIPTION
*Issue #, if available:* Fixes #4085

*Description of changes:*

Adds validation so that E3601 catches `.$` reference-path fields whose value is not a valid JSONPath or intrinsic function call, before Step Functions rejects the template at deploy time.

In the Amazon States Language, inside a payload template (`Parameters`, `ResultSelector`, `ItemSelector`, and `Assign`) a field whose name ends with `.$` is evaluated as a JSONPath or an intrinsic function rather than as a literal. Using a literal there fails at deploy time with, e.g.:

```
The value for the field 'Variable.$' must be a valid JSONPath or a valid intrinsic function call at /States/Pass/Assign
```

cfn-lint didn't flag this. This change teaches `StateMachineDefinition` (E3601) to walk payload templates recursively and report any `.$` field whose value is a plain string that neither begins with `$` (JSONPath, including `$$` context references) nor looks like an intrinsic function call (`States.*( ... )`).

To avoid false positives it only inspects string values: non-string values (a resolved intrinsic function object, for example) and strings containing a `${...}` substitution placeholder are left alone, since those can resolve to a valid path at deploy time. Nested objects and arrays inside a payload template are treated as payload templates too, matching the ASL semantics.

*Testing:*

- Added unit cases to `test/unit/rules/resources/stepfunctions/test_state_machine_definition.py` covering a valid mix of JSONPath / context / intrinsic / literal values (no error), the literal `Assign` case from the issue, and an invalid path nested inside `Parameters`.
- `pytest test/unit/rules/resources/stepfunctions/` passes (23 tests).
- Ran cfn-lint over every fixture template under `test/fixtures/templates` that declares an `AWS::StepFunctions::StateMachine`; none produce a new E3601, so existing snapshots are unchanged.
- `ruff check`, `ruff format --check`, and `mypy` are clean on the changed files.
