### PR TITLE
fix(E1010): Resolve GetAtt to SAM generated resources

### DIFF
--- a/src/cfnlint/rules/functions/GetAtt.py
+++ b/src/cfnlint/rules/functions/GetAtt.py
@@ -154,6 +154,24 @@ class GetAtt(BaseFn):
         if keyword in rule.keywords or "*" in rule.keywords:  # type: ignore
             yield from rule.validate(validator, s, value, s)  # type: ignore
 
+    def _resolve_sam_getatt(self, value: list[Any], validator: Validator) -> list[Any]:
+        # A GetAtt is split on the first "." into [logical id, attribute],
+        # either by the decoder (``!GetAtt Foo.Bar``) or below (JSON string
+        # form). SAM generated resources (a function's ``Version``/``Alias``,
+        # for example) are modeled as synthetic resources whose logical id
+        # itself contains a "." (``MyFn.Version``). Re-associate the longest
+        # logical-id prefix that matches a known resource so
+        # ``!GetAtt MyFn.Version.FunctionArn`` resolves against the synthetic
+        # ``MyFn.Version`` resource instead of the function itself.
+        if len(value) != 2 or not all(validator.is_type(v, "string") for v in value):
+            return value
+        parts = ".".join(value).split(".")
+        for i in range(len(parts) - 1, 1, -1):
+            name = ".".join(parts[:i])
+            if name in validator.context.resources:
+                return [name, ".".join(parts[i:])]
+        return value
+
     def fn_getatt(
         self, validator: Validator, s: Any, instance: Any, schema: Any
     ) -> ValidationResult:
@@ -164,6 +182,9 @@ class GetAtt(BaseFn):
         if validator.is_type(value, "string"):
             paths = [None, None]
             value = value.split(".", 1)
+
+        if validator.is_type(value, "array"):
+            value = self._resolve_sam_getatt(value, validator)
 
         if errs:
             if any(getattr(e, "unknown", False) for e in errs):

--- a/test/fixtures/templates/good/functions/getatt_serverless_function_version.yaml
+++ b/test/fixtures/templates/good/functions/getatt_serverless_function_version.yaml
@@ -1,0 +1,30 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: 'AWS::Serverless-2016-10-31'
+
+# Regression test for https://github.com/aws-cloudformation/cfn-lint/issues/4644
+# When a SAM function has AutoPublishAlias, SAM generates an
+# ``AWS::Lambda::Version`` resource that is referenceable via
+# ``!GetAtt <Function>.Version.FunctionArn``. The logical id of that synthetic
+# resource contains a ".", so GetAtt resolution must keep it intact instead of
+# splitting on the first ".".
+Resources:
+  Lambda:
+    Type: AWS::Serverless::Function
+    Properties:
+      InlineCode: "exports.handler = async () => {}"
+      Handler: index.handler
+      Runtime: nodejs22.x
+      AutoPublishAlias: live
+
+  CloudFront:
+    Type: AWS::CloudFront::Distribution
+    Properties:
+      DistributionConfig:
+        DefaultCacheBehavior:
+          ViewerProtocolPolicy: redirect-to-https
+          TargetOriginId: Dummy
+          LambdaFunctionAssociations:
+            - EventType: 'origin-request'
+              IncludeBody: false
+              LambdaFunctionARN: !GetAtt Lambda.Version.FunctionArn
+        Enabled: 'true'

--- a/test/integration/test_good_templates.py
+++ b/test/integration/test_good_templates.py
@@ -159,6 +159,14 @@ class TestQuickStartTemplates(BaseCliTestCase):
             "results": [],
             "exit_code": 0,
         },
+        {
+            "filename": (
+                "test/fixtures/templates/good/functions/"
+                "getatt_serverless_function_version.yaml"
+            ),
+            "results": [],
+            "exit_code": 0,
+        },
     ]
 
     def test_templates(self):

--- a/test/unit/rules/functions/test_getatt.py
+++ b/test/unit/rules/functions/test_getatt.py
@@ -276,3 +276,62 @@ def test_validate(name, instance, schema, child_rules, expected, validator, rule
     rule.child_rules = child_rules
     errs = list(rule.fn_getatt(validator, schema, instance, {}))
     assert errs == expected, f"Test {name!r} got {errs!r}"
+
+
+_sam_template = {
+    "Transform": "AWS::Serverless-2016-10-31",
+    "Resources": {
+        "Lambda": {
+            "Type": "AWS::Serverless::Function",
+            "Properties": {"AutoPublishAlias": "live"},
+        },
+    },
+}
+
+
+@pytest.mark.parametrize(
+    "name,template,value,expected",
+    [
+        (
+            "SAM synthetic Version resource keeps the dotted logical id together",
+            _sam_template,
+            ["Lambda", "Version.FunctionArn"],
+            ["Lambda.Version", "FunctionArn"],
+        ),
+        (
+            "SAM synthetic Alias resource keeps the dotted logical id together",
+            _sam_template,
+            ["Lambda", "Alias.Arn"],
+            ["Lambda.Alias", "Arn"],
+        ),
+        (
+            "List form with the dotted logical id already intact is unchanged",
+            _sam_template,
+            ["Lambda.Version", "FunctionArn"],
+            ["Lambda.Version", "FunctionArn"],
+        ),
+        (
+            "A plain attribute on the function itself is unchanged",
+            _sam_template,
+            ["Lambda", "Arn"],
+            ["Lambda", "Arn"],
+        ),
+        (
+            "No matching synthetic resource leaves the split unchanged",
+            _template,
+            ["MyBucket", "Foo.Bar"],
+            ["MyBucket", "Foo.Bar"],
+        ),
+        (
+            "A resolved (non string) resource name is left untouched",
+            _sam_template,
+            [{"Ref": "Lambda"}, "Version.FunctionArn"],
+            [{"Ref": "Lambda"}, "Version.FunctionArn"],
+        ),
+    ],
+    indirect=["template"],
+)
+def test_resolve_sam_getatt(name, value, expected, validator, rule):
+    assert rule._resolve_sam_getatt(value, validator) == expected, (
+        f"Test {name!r} got {rule._resolve_sam_getatt(value, validator)!r}"
+    )


### PR DESCRIPTION
### Issue #, if available

Fixes #4644

### Description of changes

`!GetAtt <Function>.Version.FunctionArn` on an `AWS::Serverless::Function` produced a false positive `E1010` since v1.54.0 (regression from removing the SAM translator in #4491):

```
E1010 'Version.FunctionArn' is not one of ['SnapStartResponse', 'SnapStartResponse.ApplyOn', 'SnapStartResponse.OptimizationStatus', 'Arn']
```

**Root cause:** SAM's generated `Version`/`Alias` resources are modeled as synthetic resources whose logical id contains a `.` (`MyFn.Version`, type `AWS::Lambda::Version`), injected when `AutoPublishAlias`/`DeploymentPreference` is present. A GetAtt shorthand is split on the *first* `.`, so `MyFn.Version.FunctionArn` was validated as attribute `Version.FunctionArn` on the function itself instead of resolving against the synthetic `MyFn.Version` resource.

**Fix:** In `E1010`, re-associate the longest logical-id prefix that matches a known resource before validating the attribute, keeping the dotted synthetic id intact. Ordinary two-segment GetAtts and unresolved (`Ref`/`Sub`) resource names are unaffected.

Verified against the real `aws-sam-translator`:
- **With** `AutoPublishAlias`: SAM emits `AWS::Lambda::Version` and rewrites the GetAtt to it → now passes.
- **Without** it: SAM generates no Version resource and leaves the GetAtt on the plain function, which CloudFormation rejects at deploy → `E1010` still (correctly) fires. The minimal template in the issue falls in this second case.

### Tests

- Unit: cases for the GetAtt prefix re-association in `test/unit/rules/functions/test_getatt.py`.
- Integration: `test/fixtures/templates/good/functions/getatt_serverless_function_version.yaml` reproducing #4644, registered in `test_good_templates.py`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.