### PR TITLE
docs: add inspect.software health badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![PyPI downloads](https://pepy.tech/badge/cfn-lint/week)](https://pypistats.org/packages/cfn-lint)
 [![PyPI downloads](https://pepy.tech/badge/cfn-lint/month)](https://pypistats.org/packages/cfn-lint)
 [![codecov](https://codecov.io/gh/aws-cloudformation/cfn-lint/branch/main/graph/badge.svg)](https://codecov.io/gh/aws-cloudformation/cfn-python-lint)
+[![inspect.software](https://raw.githubusercontent.com/inspect-software/badges/main/v1/a/aws-cloudformation/cfn-lint.svg)](https://inspect.software/software/aws-cloudformation/cfn-lint)
 [![Discord Shield](https://img.shields.io/discord/981586120448020580?logo=discord)](https://discord.gg/KENDm6DHCv)
 
 Validate AWS CloudFormation yaml/json templates against the [AWS CloudFormation resource provider schemas](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/resource-type-schemas.html) and additional checks. Includes checking valid values for resource properties and best practices.


### PR DESCRIPTION
This PR adds the [inspect.software](https://inspect.software) health badge to the README.

**Why this PR?**
Your project ranks in the upper rating bands of our open-source health index (which measures maintainability, responsiveness, and security). This badge makes that standing objectively visible to your users. Our index is a free public good, and scores cannot be bought.

**Technical details:**
- **No tracking:** Static SVG served via GitHub's CDN. No JavaScript, no third-party tracking.
- **No maintenance:** The badge updates automatically after every inspection.
- **Transparent:** Links directly to [your full report](https://inspect.software/software/aws-cloudformation/cfn-lint), based on our open [methodology](https://inspect.software/methodology).

If you prefer to keep your README minimal, feel free to close this PR without replying. Your report will remain publicly available and up-to-date either way.
