### PR TITLE
Add AutoScalingInstanceRefresh to the UpdatePolicy schema

### DIFF
--- a/src/cfnlint/data/schemas/other/resources/update_policy.json
+++ b/src/cfnlint/data/schemas/other/resources/update_policy.json
@@ -154,6 +154,9 @@
   "AutoScalingGroupUpdatePolicy": {
    "additionalProperties": false,
    "properties": {
+    "AutoScalingInstanceRefresh": {
+     "$ref": "#/definitions/AutoScalingInstanceRefresh"
+    },
     "AutoScalingReplacingUpdate": {
      "$ref": "#/definitions/AutoScalingReplacingUpdate"
     },
@@ -162,6 +165,96 @@
     },
     "AutoScalingScheduledAction": {
      "$ref": "#/definitions/AutoScalingScheduledAction"
+    }
+   },
+   "type": "object"
+  },
+  "AutoScalingInstanceRefresh": {
+   "additionalProperties": false,
+   "properties": {
+    "Preferences": {
+     "$ref": "#/definitions/AutoScalingInstanceRefreshPreferences"
+    },
+    "Strategy": {
+     "enum": [
+      "ReplaceRootVolume",
+      "Rolling"
+     ],
+     "type": "string"
+    }
+   },
+   "required": [
+    "Strategy"
+   ],
+   "type": "object"
+  },
+  "AutoScalingInstanceRefreshAlarmSpecification": {
+   "additionalProperties": false,
+   "properties": {
+    "Alarms": {
+     "items": {
+      "type": "string"
+     },
+     "maxItems": 10,
+     "type": "array"
+    }
+   },
+   "type": "object"
+  },
+  "AutoScalingInstanceRefreshPreferences": {
+   "additionalProperties": false,
+   "properties": {
+    "AlarmSpecification": {
+     "$ref": "#/definitions/AutoScalingInstanceRefreshAlarmSpecification"
+    },
+    "BakeTime": {
+     "maximum": 172800,
+     "minimum": 0,
+     "type": "integer"
+    },
+    "CheckpointDelay": {
+     "maximum": 172800,
+     "minimum": 0,
+     "type": "integer"
+    },
+    "CheckpointPercentages": {
+     "items": {
+      "type": "integer"
+     },
+     "type": "array"
+    },
+    "InstanceWarmup": {
+     "minimum": 0,
+     "type": "integer"
+    },
+    "MaxHealthyPercentage": {
+     "maximum": 200,
+     "minimum": 100,
+     "type": "integer"
+    },
+    "MinHealthyPercentage": {
+     "maximum": 100,
+     "minimum": 0,
+     "type": "integer"
+    },
+    "ScaleInProtectedInstances": {
+     "enum": [
+      "Ignore",
+      "Refresh",
+      "Wait"
+     ],
+     "type": "string"
+    },
+    "SkipMatching": {
+     "type": "boolean"
+    },
+    "StandbyInstances": {
+     "enum": [
+      "Ignore",
+      "Terminate",
+      "Wait"
+     ],
+     "type": "string"
     }
    },
    "type": "object"

--- a/test/unit/rules/resources/updatepolicy/test_configuration.py
+++ b/test/unit/rules/resources/updatepolicy/test_configuration.py
@@ -90,6 +90,30 @@ def rule():
             [],
         ),
         (
+            "Valid with autoscaling group instance refresh",
+            {
+                "Type": "AWS::AutoScaling::AutoScalingGroup",
+                "UpdatePolicy": {
+                    "AutoScalingInstanceRefresh": {
+                        "Strategy": "Rolling",
+                        "Preferences": {
+                            "AlarmSpecification": {"Alarms": ["my-alarm"]},
+                            "BakeTime": 600,
+                            "CheckpointDelay": 300,
+                            "CheckpointPercentages": [50, 100],
+                            "InstanceWarmup": 300,
+                            "MaxHealthyPercentage": 200,
+                            "MinHealthyPercentage": 100,
+                            "ScaleInProtectedInstances": "Ignore",
+                            "SkipMatching": True,
+                            "StandbyInstances": "Terminate",
+                        },
+                    },
+                },
+            },
+            [],
+        ),
+        (
             "Valid with lambda function",
             {
                 "Type": "AWS::Lambda::Alias",


### PR DESCRIPTION
*Issue #, if available:* None found (searched open/closed issues and PRs for `AutoScalingInstanceRefresh` — no hits)

*Description of changes:*

`E3016` reports an error on templates that use the documented `AutoScalingInstanceRefresh` update policy:

```yaml
Resources:
  Asg:
    Type: AWS::AutoScaling::AutoScalingGroup
    UpdatePolicy:
      AutoScalingInstanceRefresh:
        Strategy: Rolling
        Preferences:
          MinHealthyPercentage: 0
          InstanceWarmup: 300
          SkipMatching: true
    Properties:
      AutoScalingGroupName: dummy-asg
      MinSize: 1
      MaxSize: 1
      DesiredCapacity: 1
      LaunchTemplate:
        LaunchTemplateId: lt-0123456789abcdef0
        Version: '1'
      VPCZoneIdentifier:
        - subnet-0123456789abcdef0
```

```
$ cfn-lint -t min-refresh.yaml
E3016 Additional properties are not allowed ('AutoScalingInstanceRefresh' was unexpected)
min-refresh.yaml:7:7
$ echo $?
2
```

The template is valid. `AutoScalingInstanceRefresh` is documented as an `UpdatePolicy` attribute for
`AWS::AutoScaling::AutoScalingGroup`, and `aws cloudformation validate-template` accepts the template
(exit 0).

The cause is that `AutoScalingGroupUpdatePolicy` in
`src/cfnlint/data/schemas/other/resources/update_policy.json` sets `additionalProperties: false` and
enumerates only `AutoScalingReplacingUpdate`, `AutoScalingRollingUpdate` and
`AutoScalingScheduledAction`, so the newer policy falls through to the "unknown key" branch.
`UpdatePolicy` is a template attribute rather than a resource property, so it is not supplied by the
CloudFormation provider schemas (`AutoScalingInstanceRefresh` and `AutoScalingRollingUpdate` both
appear 0 times under `data/schemas/providers/`) — this file is hand-maintained, and the key was
simply never added.

This change adds `AutoScalingInstanceRefresh` to `AutoScalingGroupUpdatePolicy` plus three new
definitions (`AutoScalingInstanceRefresh`, `AutoScalingInstanceRefreshPreferences`,
`AutoScalingInstanceRefreshAlarmSpecification`), transcribed from the `AutoScalingInstanceRefresh
policy` section of the `UpdatePolicy` attribute reference:

- `Strategy` — required, `Rolling` | `ReplaceRootVolume`
- `Preferences.BakeTime` / `CheckpointDelay` — integer, 0–172800
- `Preferences.CheckpointPercentages` — array of integers
- `Preferences.InstanceWarmup` — integer
- `Preferences.MaxHealthyPercentage` — integer, 100–200
- `Preferences.MinHealthyPercentage` — integer, 0–100
- `Preferences.ScaleInProtectedInstances` / `StandbyInstances` — `Refresh`/`Terminate` | `Ignore` | `Wait`
- `Preferences.SkipMatching` — boolean
- `Preferences.AlarmSpecification.Alarms` — array of strings, up to 10 items

Docs: https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-attribute-updatepolicy.html

**Validation**

Ran the schema through `CfnTemplateValidator` the same way `rules/resources/updatepolicy/Configuration.py`
does (`strict_types=False`, `FUNCTIONS` in context):

Accepted — the repro above, both examples from the docs page (launch-before-terminate, and
alarm-based rollback with checkpoints and bake time), and `Strategy: ReplaceRootVolume`.

Still rejected — missing `Strategy`; `Strategy: Bogus`; a misspelled preference
(`MinHealtyPercentage`, which usefully reports `Did you mean 'MaxHealthyPercentage'?`);
`MinHealthyPercentage: 101`; `MaxHealthyPercentage: 99`; and `AutoScalingInstanceRefresh` on a
non-Auto-Scaling resource.

No regression — the existing "Valid with autoscaling group" combination still passes and
`UpdatePolicy: {Foo: Bar}` is still rejected.

A positive case covering the full `Preferences` surface is added to
`test/unit/rules/resources/updatepolicy/test_configuration.py`.

**Deliberately not included**

The docs state that `AutoScalingInstanceRefresh` and `AutoScalingRollingUpdate` cannot both be
specified on the same Auto Scaling group. That could be expressed as a `not`/`required` pair, but I
left it out to keep this change to the missing definitions. Happy to add it here or in a follow-up
if you would prefer it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Generated with [Claude Code](https://claude.com/claude-code)
