### PR TITLE
fix(E3016): Reject AutoScalingInstanceRefresh with AutoScalingRollingUpdate

### DIFF
--- a/src/cfnlint/data/schemas/other/resources/update_policy.json
+++ b/src/cfnlint/data/schemas/other/resources/update_policy.json
@@ -153,6 +153,11 @@
   },
   "AutoScalingGroupUpdatePolicy": {
    "additionalProperties": false,
+   "dependentExcluded": {
+    "AutoScalingInstanceRefresh": [
+     "AutoScalingRollingUpdate"
+    ]
+   },
    "properties": {
     "AutoScalingInstanceRefresh": {
      "$ref": "#/definitions/AutoScalingInstanceRefresh"

--- a/test/unit/rules/resources/updatepolicy/test_configuration.py
+++ b/test/unit/rules/resources/updatepolicy/test_configuration.py
@@ -114,6 +114,40 @@ def rule():
             [],
         ),
         (
+            "Invalid with both instance refresh and rolling update",
+            {
+                "Type": "AWS::AutoScaling::AutoScalingGroup",
+                "UpdatePolicy": {
+                    "AutoScalingInstanceRefresh": {"Strategy": "Rolling"},
+                    "AutoScalingRollingUpdate": {"MaxBatchSize": 1},
+                },
+            },
+            [
+                ValidationError(
+                    "'AutoScalingRollingUpdate' should not be included with "
+                    "'AutoScalingInstanceRefresh'",
+                    path=["UpdatePolicy", "AutoScalingRollingUpdate"],
+                    rule=Configuration(),
+                    instance={
+                        "AutoScalingInstanceRefresh": {"Strategy": "Rolling"},
+                        "AutoScalingRollingUpdate": {"MaxBatchSize": 1},
+                    },
+                    validator="dependentExcluded",
+                    validator_value={
+                        "AutoScalingInstanceRefresh": ["AutoScalingRollingUpdate"]
+                    },
+                    schema_path=[
+                        "allOf",
+                        0,
+                        "then",
+                        "properties",
+                        "UpdatePolicy",
+                        "dependentExcluded",
+                    ],
+                )
+            ],
+        ),
+        (
             "Valid with lambda function",
             {
                 "Type": "AWS::Lambda::Alias",


### PR DESCRIPTION
## Problem
CloudFormation fails an Auto Scaling group stack update when both the `AutoScalingInstanceRefresh` and `AutoScalingRollingUpdate` update policies are specified. cfn-lint currently allows the combination, so the error only surfaces at deploy time.

## Change
Add a `dependentExcluded` constraint to the `AutoScalingGroupUpdatePolicy` schema so E3016 flags the two policies being used together at lint time. Follows up on #4656, which added the `AutoScalingInstanceRefresh` property.

## Validation
Verified via a live deploy in a test account: an ASG stack update that specifies **both** policies fails with:

```
Resource handler returned message: "AutoScalingInstanceRefresh and AutoScalingRollingUpdate cannot be used together. Remove one of the update policies from your template and try again."
```

After this change, `cfn-lint` reports at lint time:

```
E3016 'AutoScalingRollingUpdate' should not be included with 'AutoScalingInstanceRefresh'
```

Docs: https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-attribute-updatepolicy.html ("You can't specify both `AutoScalingInstanceRefresh` and `AutoScalingRollingUpdate` on the same Auto Scaling group.")

Tests: added an invalid case to `test/unit/rules/resources/updatepolicy/test_configuration.py`; unit tests, ruff check/format, and isort pass.