### PR TITLE
fix: Defer schema metadata updates until install succeeds

### DIFF
--- a/src/cfnlint/helpers.py
+++ b/src/cfnlint/helpers.py
@@ -562,6 +562,21 @@ def get_url_content(url, caching=False):
     return content
 
 
+def get_url_metadata(url: str) -> tuple[dict[str, Any], str] | None:
+    """Get updated cache metadata for a URL without persisting it."""
+    req = Request(url, method="HEAD")
+    with urlopen(req) as res:
+        etag = res.info().get("ETag")
+        if not etag:
+            return None
+
+        metadata_filename = get_metadata_filename(url)
+        metadata = load_metadata(metadata_filename)
+        metadata["etag"] = etag
+        metadata["url"] = url
+        return metadata, metadata_filename
+
+
 def get_url_retrieve(url: str, caching: bool = False) -> str:
     """Get the contents of a zip file and returns
     a string representing the file
@@ -573,21 +588,15 @@ def get_url_retrieve(url: str, caching: bool = False) -> str:
         str: A string representing the file object that was retrieved
     """
 
-    if caching:
-        req = Request(url, method="HEAD")
-        with urlopen(req) as res:
-            if res.info().get("ETag"):
-                metadata_filename = get_metadata_filename(url)
-                # Load in all existing values
-                metadata = load_metadata(metadata_filename)
-                metadata["etag"] = res.info().get("ETag")
-                metadata["url"] = url  # To make it obvious which url the Tag relates to
-                save_metadata(metadata, metadata_filename)
+    pending_metadata = get_url_metadata(url) if caching else None
 
     fileobject, _ = _retry_url_operation(
         lambda: urlretrieve(url),
         f"downloading {url}",
     )
+
+    if pending_metadata:
+        save_metadata(*pending_metadata)
 
     return fileobject
 

--- a/src/cfnlint/schema/manager.py
+++ b/src/cfnlint/schema/manager.py
@@ -21,7 +21,9 @@ from cfnlint.helpers import (
     REGIONS,
     get_cache_dir,
     get_url_content,
+    get_url_metadata,
     get_url_retrieve,
+    save_metadata,
     url_has_newer_version,
 )
 from cfnlint.schema._exceptions import ResourceNotFoundError
@@ -366,9 +368,13 @@ class ProviderSchemaManager:
             return 2
 
         try:
-            filehandle = get_url_retrieve(_ENHANCED_SCHEMAS_URL, caching=True)
+            pending_metadata = get_url_metadata(_ENHANCED_SCHEMAS_URL)
+            filehandle = get_url_retrieve(_ENHANCED_SCHEMAS_URL)
         except Exception as e:
-            LOGGER.error("Failed to download enhanced schemas: %s", e)
+            LOGGER.error(
+                "Failed to download enhanced schemas; metadata was not updated: %s",
+                e,
+            )
             return 2
 
         providers_dir = cache_dir / "providers"
@@ -402,8 +408,24 @@ class ProviderSchemaManager:
                 self._atomic_replace_dir(tmp_providers, providers_dir)
                 self._atomic_replace_dir(tmp_resources, resources_dir)
         except (OSError, zipfile.BadZipFile) as e:
-            LOGGER.error("Failed to extract and install schema cache: %s", e)
+            LOGGER.error(
+                "Failed to extract and install schemas; metadata was not updated: %s",
+                e,
+            )
             return 2
+
+        if pending_metadata:
+            try:
+                save_metadata(*pending_metadata)
+                LOGGER.debug("Schema cache metadata updated after installation")
+            except OSError as e:
+                LOGGER.error(
+                    "Schemas installed but failed to update schema cache metadata: %s",
+                    e,
+                )
+                return 2
+        else:
+            LOGGER.debug("No schema ETag returned; cache metadata was not updated")
 
         try:
             version_content = get_url_content(_VERSION_URL)

--- a/test/unit/module/helpers/test_get_url_retrieve.py
+++ b/test/unit/module/helpers/test_get_url_retrieve.py
@@ -3,6 +3,9 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 
+import json
+import tempfile
+from pathlib import Path
 from test.testlib.testcase import BaseTestCase
 from unittest.mock import MagicMock, patch
 from urllib.error import HTTPError, URLError
@@ -50,6 +53,38 @@ class TestGetUrlRetrieve(BaseTestCase):
         mock_load_metadata.assert_called_once()
         mock_save_metadata.assert_called_once()
         self.assertEqual(result, "file/path")
+
+    @patch("cfnlint.helpers.get_metadata_filename")
+    @patch("cfnlint.helpers.urlopen")
+    @patch("cfnlint.helpers.urlretrieve")
+    def test_failed_cached_download_does_not_advance_etag(
+        self, mocked_urlretrieve, mocked_urlopen, mock_get_metadata_filename
+    ):
+        """A failed download leaves the prior ETag available for the next update"""
+        old_etag = "ETAG_ONE"
+        new_etag = "ETAG_TWO"
+        url = "http://foo.com"
+
+        cm = MagicMock()
+        cm.info.return_value = {"ETag": new_etag}
+        cm.__enter__.return_value = cm
+        mocked_urlopen.return_value = cm
+        mocked_urlretrieve.side_effect = HTTPError(
+            url, 403, "Forbidden", hdrs=None, fp=None
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            metadata_file = Path(tmpdir) / "metadata.json"
+            metadata_file.write_text(json.dumps({"etag": old_etag}))
+            mock_get_metadata_filename.return_value = str(metadata_file)
+
+            with self.assertRaises(HTTPError):
+                cfnlint.helpers.get_url_retrieve(url, caching=True)
+
+            self.assertEqual(json.loads(metadata_file.read_text()), {"etag": old_etag})
+            self.assertTrue(cfnlint.helpers.url_has_newer_version(url))
+
+        mocked_urlretrieve.assert_called_once_with(url)
 
     @patch("cfnlint.helpers.time.sleep")
     @patch("cfnlint.helpers.urlretrieve")

--- a/test/unit/module/schema/test_manager.py
+++ b/test/unit/module/schema/test_manager.py
@@ -73,15 +73,28 @@ class TestUpdateResourceSchemas(BaseTestCase):
         result = self.manager.update(force=False)
         self.assertEqual(result, 0)
 
+    @patch("cfnlint.schema.manager.LOGGER")
+    @patch("cfnlint.schema.manager.save_metadata")
+    @patch("cfnlint.schema.manager.get_url_metadata")
     @patch("cfnlint.schema.manager.url_has_newer_version")
     @patch("cfnlint.schema.manager.get_url_retrieve")
     @patch("cfnlint.schema.manager.get_cache_dir")
-    def test_update_force(self, mock_cache_dir, mock_get_url, mock_url_newer):
+    def test_update_force(
+        self,
+        mock_cache_dir,
+        mock_get_url,
+        mock_url_newer,
+        mock_get_metadata,
+        mock_save_metadata,
+        mock_logger,
+    ):
         """Force download even if cached"""
         import tempfile
         from pathlib import Path
 
         mock_url_newer.return_value = False
+        pending_metadata = ({"etag": "ETAG_TWO"}, "metadata.json")
+        mock_get_metadata.return_value = pending_metadata
 
         zip_buffer = io.BytesIO()
         with zipfile.ZipFile(zip_buffer, "w") as zf:
@@ -109,16 +122,90 @@ class TestUpdateResourceSchemas(BaseTestCase):
             mock_get_url.assert_called_once()
             self.assertTrue((Path(tmpdir) / "providers" / "us-east-1.json").exists())
             self.assertTrue((Path(tmpdir) / "resources" / "abc123.json").exists())
+            mock_save_metadata.assert_called_once_with(*pending_metadata)
+            mock_logger.debug.assert_called_with(
+                "Schema cache metadata updated after installation"
+            )
 
+    @patch("cfnlint.schema.manager.save_metadata")
+    @patch("cfnlint.schema.manager.get_url_metadata")
+    @patch("cfnlint.schema.manager.LOGGER")
     @patch("cfnlint.schema.manager.url_has_newer_version")
     @patch("cfnlint.schema.manager.get_url_retrieve")
-    def test_update_download_failure(self, mock_get_url, mock_url_newer):
+    @patch("cfnlint.schema.manager.get_cache_dir")
+    def test_update_download_failure(
+        self,
+        mock_cache_dir,
+        mock_get_url,
+        mock_url_newer,
+        mock_logger,
+        mock_get_metadata,
+        mock_save_metadata,
+    ):
         """Returns 2 on download failure"""
+        import tempfile
+
         mock_url_newer.return_value = True
+        mock_get_metadata.return_value = ({"etag": "ETAG_TWO"}, "metadata.json")
         mock_get_url.side_effect = Exception("Network error")
 
-        result = self.manager.update(force=False)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            mock_cache_dir.return_value = tmpdir
+            result = self.manager.update(force=False)
+
         self.assertEqual(result, 2)
+        mock_save_metadata.assert_not_called()
+        logged = " ".join(str(c) for c in mock_logger.error.call_args_list)
+        self.assertIn("metadata was not updated", logged)
+
+    @patch("cfnlint.schema.manager.LOGGER")
+    @patch("cfnlint.schema.manager.save_metadata")
+    @patch("cfnlint.schema.manager.get_url_metadata")
+    @patch("cfnlint.schema.manager.url_has_newer_version")
+    @patch("cfnlint.schema.manager.get_url_retrieve")
+    @patch("cfnlint.schema.manager.get_cache_dir")
+    def test_update_metadata_failure_after_install(
+        self,
+        mock_cache_dir,
+        mock_get_url,
+        mock_url_newer,
+        mock_get_metadata,
+        mock_save_metadata,
+        mock_logger,
+    ):
+        """Metadata write failures are reported after schemas are installed"""
+        import tempfile
+        from pathlib import Path
+
+        mock_url_newer.return_value = True
+        mock_get_metadata.return_value = ({"etag": "ETAG_TWO"}, "metadata.json")
+        mock_save_metadata.side_effect = OSError("Disk full")
+
+        zip_buffer = io.BytesIO()
+        with zipfile.ZipFile(zip_buffer, "w") as zf:
+            zf.writestr(
+                "providers/us-east-1.json",
+                json.dumps({"AWS::S3::Bucket": "abc123"}),
+            )
+            zf.writestr(
+                "resources/abc123.json",
+                json.dumps({"typeName": "AWS::S3::Bucket", "properties": {}}),
+            )
+        zip_buffer.seek(0)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            mock_cache_dir.return_value = tmpdir
+            with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as tmp:
+                tmp.write(zip_buffer.getvalue())
+                tmp.flush()
+                mock_get_url.return_value = tmp.name
+                result = self.manager.update(force=True)
+
+            self.assertTrue((Path(tmpdir) / "providers" / "us-east-1.json").exists())
+
+        self.assertEqual(result, 2)
+        logged = " ".join(str(c) for c in mock_logger.error.call_args_list)
+        self.assertIn("Schemas installed but failed to update", logged)
 
 
 class TestSamModuleLoading(BaseTestCase):
@@ -179,6 +266,7 @@ class TestSamModuleLoading(BaseTestCase):
             self.assertEqual(result["AWS::S3::Bucket"], "abc123")
             self.assertEqual(result["AWS::Serverless::Function"], "sam123")
 
+    @patch("cfnlint.schema.manager.get_url_metadata", lambda _: None)
     @patch("cfnlint.schema.manager.url_has_newer_version")
     @patch("cfnlint.schema.manager.get_url_retrieve")
     @patch("cfnlint.schema.manager.get_cache_dir")
@@ -510,6 +598,7 @@ class TestUpdateDownloadsVersionJson(BaseTestCase):
         super().setUp()
         self.manager = _make_manager()
 
+    @patch("cfnlint.schema.manager.get_url_metadata", lambda _: None)
     @patch("cfnlint.schema.manager.get_url_content")
     @patch("cfnlint.schema.manager.url_has_newer_version")
     @patch("cfnlint.schema.manager.get_url_retrieve")
@@ -553,6 +642,7 @@ class TestUpdateDownloadsVersionJson(BaseTestCase):
                 data = json.load(f)
             self.assertEqual(data["schema_date"], "2026-07-07T14:23:15Z")
 
+    @patch("cfnlint.schema.manager.get_url_metadata", lambda _: None)
     @patch("cfnlint.schema.manager.get_url_content")
     @patch("cfnlint.schema.manager.url_has_newer_version")
     @patch("cfnlint.schema.manager.get_url_retrieve")
@@ -806,18 +896,27 @@ class TestUpdateWithLocking(BaseTestCase):
         logged = " ".join(str(c) for c in mock_logger.error.call_args_list)
         self.assertIn("Failed to acquire schema cache lock", logged)
 
+    @patch("cfnlint.schema.manager.save_metadata")
+    @patch("cfnlint.schema.manager.get_url_metadata")
     @patch("cfnlint.schema.manager.LOGGER")
     @patch("cfnlint.schema.manager.url_has_newer_version")
     @patch("cfnlint.schema.manager.get_url_retrieve")
     @patch("cfnlint.schema.manager.get_cache_dir")
     def test_update_extract_failure_not_labeled_as_lock_error(
-        self, mock_cache_dir, mock_get_url, mock_url_newer, mock_logger
+        self,
+        mock_cache_dir,
+        mock_get_url,
+        mock_url_newer,
+        mock_logger,
+        mock_get_metadata,
+        mock_save_metadata,
     ):
         """A corrupt download (BadZipFile) logs an extraction error, not a lock error"""
         import tempfile
         from pathlib import Path
 
         mock_url_newer.return_value = True
+        mock_get_metadata.return_value = ({"etag": "ETAG_TWO"}, "metadata.json")
 
         with tempfile.TemporaryDirectory() as tmpdir:
             mock_cache_dir.return_value = tmpdir
@@ -834,19 +933,31 @@ class TestUpdateWithLocking(BaseTestCase):
         # Must NOT be mislabeled as a lock failure
         self.assertNotIn("lock", logged.lower())
         self.assertIn("extract and install", logged)
+        self.assertIn("metadata was not updated", logged)
+        mock_save_metadata.assert_not_called()
 
+    @patch("cfnlint.schema.manager.save_metadata")
+    @patch("cfnlint.schema.manager.get_url_metadata")
     @patch("cfnlint.schema.manager.LOGGER")
     @patch("cfnlint.schema.manager.ProviderSchemaManager._atomic_replace_dir")
     @patch("cfnlint.schema.manager.url_has_newer_version")
     @patch("cfnlint.schema.manager.get_url_retrieve")
     @patch("cfnlint.schema.manager.get_cache_dir")
     def test_update_atomic_replace_failure_not_labeled_as_lock_error(
-        self, mock_cache_dir, mock_get_url, mock_url_newer, mock_replace, mock_logger
+        self,
+        mock_cache_dir,
+        mock_get_url,
+        mock_url_newer,
+        mock_replace,
+        mock_logger,
+        mock_get_metadata,
+        mock_save_metadata,
     ):
         """An OSError during atomic replace logs an install error, not a lock error"""
         import tempfile
 
         mock_url_newer.return_value = True
+        mock_get_metadata.return_value = ({"etag": "ETAG_TWO"}, "metadata.json")
         mock_replace.side_effect = OSError("Disk full")
 
         zip_buffer = io.BytesIO()
@@ -871,7 +982,10 @@ class TestUpdateWithLocking(BaseTestCase):
         logged = " ".join(str(c) for c in mock_logger.error.call_args_list)
         self.assertNotIn("lock", logged.lower())
         self.assertIn("extract and install", logged)
+        self.assertIn("metadata was not updated", logged)
+        mock_save_metadata.assert_not_called()
 
+    @patch("cfnlint.schema.manager.get_url_metadata", lambda _: None)
     @patch("cfnlint.schema.manager.get_url_content")
     @patch("cfnlint.schema.manager.url_has_newer_version")
     @patch("cfnlint.schema.manager.get_url_retrieve")
@@ -914,6 +1028,7 @@ class TestUpdateWithLocking(BaseTestCase):
         self.assertNotIn("lock", logged.lower())
         self.assertIn("Failed to check schema version", logged)
 
+    @patch("cfnlint.schema.manager.get_url_metadata", lambda _: None)
     @patch("cfnlint.schema.manager.get_url_content")
     @patch("cfnlint.schema.manager.url_has_newer_version")
     @patch("cfnlint.schema.manager.get_url_retrieve")
@@ -981,6 +1096,7 @@ class TestUpdateWithLocking(BaseTestCase):
 class TestConcurrentUpdate(BaseTestCase):
     """Test concurrent update() calls don't corrupt the cache"""
 
+    @patch("cfnlint.schema.manager.get_url_metadata", lambda _: None)
     @patch("cfnlint.schema.manager.get_url_content")
     @patch("cfnlint.schema.manager.url_has_newer_version")
     @patch("cfnlint.schema.manager.get_url_retrieve")
@@ -1051,6 +1167,7 @@ class TestConcurrentUpdate(BaseTestCase):
             self.assertTrue((providers_dir / "us-east-1.json").exists())
             self.assertTrue((resources_dir / "abc123.json").exists())
 
+    @patch("cfnlint.schema.manager.get_url_metadata", lambda _: None)
     @patch("cfnlint.schema.manager.get_url_content")
     @patch("cfnlint.schema.manager.url_has_newer_version")
     @patch("cfnlint.schema.manager.get_url_retrieve")


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

The enhanced schema updater previously persisted the ETag obtained by its HEAD request before the schema archive was downloaded and installed. If the download, extraction, or installation failed, the existing schemas could be paired with the new ETag, causing subsequent update checks to incorrectly report that the cache was current.

This change:

- Retains candidate metadata in memory until the schema archive is installed successfully.
- Preserves existing metadata when downloading, extracting, or replacing schema files fails.
- Keeps the cached retrieval helper behavior compatible while deferring its metadata write until retrieval succeeds.
- Reports whether metadata was preserved, committed, or could not be committed.
- Adds regression coverage for HTTP 403 responses, corrupt archives, atomic replacement failures, metadata write failures, and successful installation.

Validation:

- tox -e py313: 2814 passed, 4 deselected
- pre-commit run --all-files: all hooks passed

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.