### PR TITLE
chore: Remove unused caching path from get_url_retrieve

### DIFF
--- a/src/cfnlint/helpers.py
+++ b/src/cfnlint/helpers.py
@@ -577,26 +577,19 @@ def get_url_metadata(url: str) -> tuple[dict[str, Any], str] | None:
         return metadata, metadata_filename
 
 
-def get_url_retrieve(url: str, caching: bool = False) -> str:
-    """Get the contents of a zip file and returns
-    a string representing the file
+def get_url_retrieve(url: str) -> str:
+    """Download a URL with retries and return the local file path.
 
     Args:
         url (str): The url to retrieve
-        caching (bool): If we can cache the results (default: False)
     Returns:
         str: A string representing the file object that was retrieved
     """
-
-    pending_metadata = get_url_metadata(url) if caching else None
 
     fileobject, _ = _retry_url_operation(
         lambda: urlretrieve(url),
         f"downloading {url}",
     )
-
-    if pending_metadata:
-        save_metadata(*pending_metadata)
 
     return fileobject
 

--- a/test/unit/module/helpers/test_get_url_retrieve.py
+++ b/test/unit/module/helpers/test_get_url_retrieve.py
@@ -3,9 +3,6 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 
-import json
-import tempfile
-from pathlib import Path
 from test.testlib.testcase import BaseTestCase
 from unittest.mock import MagicMock, patch
 from urllib.error import HTTPError, URLError
@@ -27,64 +24,41 @@ class TestGetUrlRetrieve(BaseTestCase):
         mocked_urlretrieve.assert_called_with(url)
         self.assertEqual(result, "file/path")
 
-    @patch("cfnlint.helpers.urlopen")
+    @patch("cfnlint.helpers.get_metadata_filename")
     @patch("cfnlint.helpers.load_metadata")
     @patch("cfnlint.helpers.save_metadata")
-    @patch("cfnlint.helpers.urlretrieve")
-    def test_get_url_retrieve_cached(
-        self, mocked_urlretrieve, mock_save_metadata, mock_load_metadata, mocked_urlopen
-    ):
-        """Test the basics of URL retrieve"""
-        etag = "ETAG_ONE"
-        url = "http://foo.com"
-
-        mock_load_metadata.return_value = {}
-
-        cm = MagicMock()
-        cm.getcode.return_value = 200
-        cm.info.return_value = {"Content-Encoding": "gzip", "ETag": etag}
-        cm.__enter__.return_value = cm
-        mocked_urlopen.return_value = cm
-
-        mocked_urlretrieve.return_value = ("file/path", None)
-
-        result = cfnlint.helpers.get_url_retrieve(url, caching=True)
-        mocked_urlretrieve.assert_called_with(url)
-        mock_load_metadata.assert_called_once()
-        mock_save_metadata.assert_called_once()
-        self.assertEqual(result, "file/path")
-
-    @patch("cfnlint.helpers.get_metadata_filename")
     @patch("cfnlint.helpers.urlopen")
-    @patch("cfnlint.helpers.urlretrieve")
-    def test_failed_cached_download_does_not_advance_etag(
-        self, mocked_urlretrieve, mocked_urlopen, mock_get_metadata_filename
+    def test_get_url_metadata_returns_without_persisting(
+        self,
+        mocked_urlopen,
+        mock_save_metadata,
+        mock_load_metadata,
+        mock_get_metadata_filename,
     ):
-        """A failed download leaves the prior ETag available for the next update"""
-        old_etag = "ETAG_ONE"
-        new_etag = "ETAG_TWO"
+        """get_url_metadata computes updated metadata but does not persist it"""
         url = "http://foo.com"
+        mock_load_metadata.return_value = {}
+        mock_get_metadata_filename.return_value = "metadata.json"
 
         cm = MagicMock()
-        cm.info.return_value = {"ETag": new_etag}
+        cm.info.return_value = {"ETag": "ETAG_ONE"}
         cm.__enter__.return_value = cm
         mocked_urlopen.return_value = cm
-        mocked_urlretrieve.side_effect = HTTPError(
-            url, 403, "Forbidden", hdrs=None, fp=None
-        )
 
-        with tempfile.TemporaryDirectory() as tmpdir:
-            metadata_file = Path(tmpdir) / "metadata.json"
-            metadata_file.write_text(json.dumps({"etag": old_etag}))
-            mock_get_metadata_filename.return_value = str(metadata_file)
+        result = cfnlint.helpers.get_url_metadata(url)
 
-            with self.assertRaises(HTTPError):
-                cfnlint.helpers.get_url_retrieve(url, caching=True)
+        self.assertEqual(result, ({"etag": "ETAG_ONE", "url": url}, "metadata.json"))
+        mock_save_metadata.assert_not_called()
 
-            self.assertEqual(json.loads(metadata_file.read_text()), {"etag": old_etag})
-            self.assertTrue(cfnlint.helpers.url_has_newer_version(url))
+    @patch("cfnlint.helpers.urlopen")
+    def test_get_url_metadata_returns_none_without_etag(self, mocked_urlopen):
+        """get_url_metadata returns None when the response has no ETag"""
+        cm = MagicMock()
+        cm.info.return_value = {}
+        cm.__enter__.return_value = cm
+        mocked_urlopen.return_value = cm
 
-        mocked_urlretrieve.assert_called_once_with(url)
+        self.assertIsNone(cfnlint.helpers.get_url_metadata("http://foo.com"))
 
     @patch("cfnlint.helpers.time.sleep")
     @patch("cfnlint.helpers.urlretrieve")


### PR DESCRIPTION
## Context
Follow-up to #4662. That PR moved schema-cache metadata handling into `cfnlint.schema.manager` (via `get_url_metadata`/`save_metadata`), deferring the ETag write until *after* a successful install. The manager is the only caller of `get_url_retrieve` and no longer passes `caching=True`, so that branch is now dead code.

## Change
- Drop the `caching` parameter and the metadata-save branch from `get_url_retrieve` — it's now just the retry-wrapped download.
- Replace the two obsolete cached-retrieve tests with direct coverage of `get_url_metadata`: it returns updated metadata **without persisting** it, and returns `None` when the response has no ETag.

`get_url_retrieve` itself is retained (the manager still uses it for the retry download); only the unused caching capability is removed.

## Validation
- `test/unit/module/helpers/test_get_url_retrieve.py` + `test/unit/module/schema/test_manager.py`: 48 passed
- ruff check + format, isort: clean
- mypy on `helpers.py` + `manager.py`: no issues