### PR TITLE
Allow GetAtt outputs on SAM applications

### DIFF
--- a/src/cfnlint/rules/functions/GetAttFormat.py
+++ b/src/cfnlint/rules/functions/GetAttFormat.py
@@ -32,6 +32,7 @@ class GetAttFormat(CfnLintKeyword):
         self._resource_type_exceptions = [
             "AWS::CloudFormation::CustomResource",
             "AWS::CloudFormation::Stack",
+            "AWS::Serverless::Application",
             "AWS::ServiceCatalog::CloudFormationProvisionedProduct",
         ]
 

--- a/src/cfnlint/schema/_getatts.py
+++ b/src/cfnlint/schema/_getatts.py
@@ -258,7 +258,10 @@ class GetAtts:
                     f"/properties/{name}"
                 )
 
-        if schema.type_name == "AWS::CloudFormation::Stack":
+        if schema.type_name in [
+            "AWS::CloudFormation::Stack",
+            "AWS::Serverless::Application",
+        ]:
             self._attrs["Outputs\\..*"] = "/properties/CfnLintStringType"
             return
 

--- a/test/unit/rules/functions/test_getatt.py
+++ b/test/unit/rules/functions/test_getatt.py
@@ -23,6 +23,7 @@ _template = {
         "MyBucket": {"Type": "AWS::S3::Bucket"},
         "MyCodePipeline": {"Type": "AWS::CodePipeline::Pipeline"},
         "DocDBCluster": {"Type": "AWS::DocDB::DBCluster"},
+        "MyServerlessApplication": {"Type": "AWS::Serverless::Application"},
     },
     "Parameters": {
         "MyResourceParameter": {"Type": "String", "Default": "MyBucket"},
@@ -102,7 +103,8 @@ class _Fail(CfnLintKeyword):
             [
                 ValidationError(
                     "'Foo' is not one of ['MyBucket', "
-                    "'MyCodePipeline', 'DocDBCluster']",
+                    "'MyCodePipeline', 'DocDBCluster', "
+                    "'MyServerlessApplication']",
                     path=deque(["Fn::GetAtt", 0]),
                     schema_path=deque(["enum"]),
                     validator="fn_getatt",
@@ -199,6 +201,14 @@ class _Fail(CfnLintKeyword):
             [],
         ),
         (
+            "Valid GetAtt to a serverless application output",
+            {"Fn::GetAtt": "MyServerlessApplication.Outputs.TopicArn"},
+            {"type": "string"},
+            _template,
+            {},
+            [],
+        ),
+        (
             "Valid Ref in GetAtt for resource",
             {"Fn::GetAtt": [{"Ref": "MyResourceParameter"}, "Arn"]},
             {"type": "string"},
@@ -249,7 +259,8 @@ class _Fail(CfnLintKeyword):
             [
                 ValidationError(
                     "'Arn' is not one of ['MyBucket', "
-                    "'MyCodePipeline', 'DocDBCluster'] when "
+                    "'MyCodePipeline', 'DocDBCluster', "
+                    "'MyServerlessApplication'] when "
                     "{'Ref': 'MyAttributeParameter'} is resolved",
                     path=deque(["Fn::GetAtt", 0]),
                     schema_path=deque(["enum"]),

--- a/test/unit/rules/functions/test_getatt_format.py
+++ b/test/unit/rules/functions/test_getatt_format.py
@@ -28,6 +28,7 @@ def template():
             "MyProvisionedProduct": {
                 "Type": "AWS::ServiceCatalog::CloudFormationProvisionedProduct"
             },
+            "MyServerlessApplication": {"Type": "AWS::Serverless::Application"},
             "MySSMParameter": {"Type": "AWS::SSM::Parameter"},
         },
     }
@@ -58,6 +59,12 @@ def template():
             "Valid GetAtt to a provisioned product ",
             ["MyProvisionedProduct", "Outputs.VpcId"],
             {"format": "AWS::EC2::VPC.Id"},
+            [],
+        ),
+        (
+            "Valid GetAtt to a serverless application output",
+            ["MyServerlessApplication", "Outputs.TopicArn"],
+            {"format": "AWS::SNS::Topic.TopicArn"},
             [],
         ),
         (


### PR DESCRIPTION
Fixes #4659.

## What changed
- Treat `AWS::Serverless::Application` like nested stacks for `Fn::GetAtt` output attributes, allowing `Outputs.*`.
- Add the same resource-type exception to the GetAtt format child rule.
- Add regression coverage for `E1010` and `E1040` paths.

## Why
SAM applications are transformed into nested CloudFormation stacks, and their outputs are documented as accessible through `!GetAtt Application.Outputs.Name`. After the SAM translator removal, the resource schema only exposed `StackId`, so `Outputs.*` was rejected as an unknown attribute.

## Validation
- `.venv/bin/python -m pytest test/unit/rules/functions/test_getatt.py test/unit/rules/functions/test_getatt_format.py -q`
- `.venv/bin/python -m pytest test/unit/rules/functions -q`
- `.venv/bin/python -m pytest test/unit/module/schema -q`
- `.venv/bin/ruff check src/cfnlint/schema/_getatts.py src/cfnlint/rules/functions/GetAttFormat.py test/unit/rules/functions/test_getatt.py test/unit/rules/functions/test_getatt_format.py`
- `.venv/bin/ruff format --check src/cfnlint/schema/_getatts.py src/cfnlint/rules/functions/GetAttFormat.py test/unit/rules/functions/test_getatt.py test/unit/rules/functions/test_getatt_format.py`
- `git diff --check`
- CLI smoke with the issue template in `us-east-1`