### PR TITLE
Allow resource Refs in UpdatePolicy validation

### DIFF
--- a/src/cfnlint/rules/resources/updatepolicy/Configuration.py
+++ b/src/cfnlint/rules/resources/updatepolicy/Configuration.py
@@ -35,7 +35,6 @@ class Configuration(CfnLintJsonSchema):
         validator = validator.evolve(
             context=validator.context.evolve(
                 functions=list(FUNCTIONS),
-                resources={},
                 strict_types=False,
             ),
             schema=self._schema,

--- a/test/unit/rules/resources/updatepolicy/test_configuration.py
+++ b/test/unit/rules/resources/updatepolicy/test_configuration.py
@@ -5,6 +5,7 @@ SPDX-License-Identifier: MIT-0
 
 import pytest
 
+from cfnlint.core import get_rules, run_checks
 from cfnlint.jsonschema import ValidationError
 from cfnlint.rules.resources.updatepolicy.Configuration import Configuration
 
@@ -185,3 +186,54 @@ def rule():
 def test_update_policy_configuration(name, instance, expected, rule, validator):
     errors = list(rule.validate(validator, {}, instance, {}))
     assert errors == expected, f"Test {name!r} got {errors!r}"
+
+
+def test_update_policy_allows_refs_to_template_resources():
+    template = {
+        "Resources": {
+            "MyApp": {
+                "Type": "AWS::CodeDeploy::Application",
+                "Properties": {"ComputePlatform": "Lambda"},
+            },
+            "MyDeploymentGroup": {
+                "Type": "AWS::CodeDeploy::DeploymentGroup",
+                "Properties": {
+                    "ApplicationName": {"Ref": "MyApp"},
+                    "ServiceRoleArn": "arn:aws:iam::123456789012:role/CodeDeployRole",
+                },
+            },
+            "MyFunction": {
+                "Type": "AWS::Lambda::Function",
+                "Properties": {
+                    "Code": {"ZipFile": "def handler(e, c): pass"},
+                    "Handler": "index.handler",
+                    "Role": "arn:aws:iam::123456789012:role/LambdaRole",
+                    "Runtime": "python3.13",
+                },
+            },
+            "MyVersion": {
+                "Type": "AWS::Lambda::Version",
+                "Properties": {"FunctionName": {"Ref": "MyFunction"}},
+            },
+            "MyAlias": {
+                "Type": "AWS::Lambda::Alias",
+                "Properties": {
+                    "FunctionName": {"Ref": "MyFunction"},
+                    "FunctionVersion": {"Fn::GetAtt": ["MyVersion", "Version"]},
+                    "Name": "live",
+                },
+                "UpdatePolicy": {
+                    "CodeDeployLambdaAliasUpdate": {
+                        "ApplicationName": {"Ref": "MyApp"},
+                        "DeploymentGroupName": {"Ref": "MyDeploymentGroup"},
+                    }
+                },
+            },
+        }
+    }
+
+    matches = run_checks(
+        "test.yaml", template, get_rules([], [], ["E1020", "E3016"]), ["us-east-1"]
+    )
+
+    assert matches == []


### PR DESCRIPTION
## What

Fixes #4669 by preserving the template resource map while validating `UpdatePolicy` attribute schemas.

`E3016` still narrows the allowed intrinsic functions and disables strict type checks for the attribute schema, but it no longer evolves the validator context with `resources={}`. That empty resource map caused nested `E1020` checks to reject valid `Ref`s to resources inside `UpdatePolicy.CodeDeployLambdaAliasUpdate`.

## Tests

- `PYTHONPATH=/tmp/cfn-lint-main-x5MuHS/src /Users/jensenzane/Projects/cfn-lint/.venv/bin/python -m pytest /tmp/cfn-lint-main-x5MuHS/test/unit/rules/resources/updatepolicy/test_configuration.py::test_update_policy_allows_refs_to_template_resources /tmp/cfn-lint-main-x5MuHS/test/unit/rules/resources/updatepolicy/test_configuration.py -q`
- `PYTHONPATH=/tmp/cfn-lint-main-x5MuHS/src /Users/jensenzane/Projects/cfn-lint/.venv/bin/cfn-lint -r us-east-1 -- /tmp/cfn-updatepolicy-XXXX.yaml`
- `PYTHONPATH=/tmp/cfn-lint-main-x5MuHS/src /Users/jensenzane/Projects/cfn-lint/.venv/bin/ruff check /tmp/cfn-lint-main-x5MuHS/src/cfnlint/rules/resources/updatepolicy/Configuration.py /tmp/cfn-lint-main-x5MuHS/test/unit/rules/resources/updatepolicy/test_configuration.py`
- `PYTHONPATH=/tmp/cfn-lint-main-x5MuHS/src /Users/jensenzane/Projects/cfn-lint/.venv/bin/ruff format --check /tmp/cfn-lint-main-x5MuHS/src/cfnlint/rules/resources/updatepolicy/Configuration.py /tmp/cfn-lint-main-x5MuHS/test/unit/rules/resources/updatepolicy/test_configuration.py`

Note: local git fetch/push for this checkout hit GitHub HTTPS transport errors, so I validated against a temporary current-main source snapshot and published the branch with the GitHub Git database API from upstream commit `162a611e2c57678bfdc34d8f8015a84ef3f31bf6`.