### PR TITLE
fix: Type-check resource Refs in UpdatePolicy/CreationPolicy

### DIFF
--- a/src/cfnlint/rules/functions/Ref.py
+++ b/src/cfnlint/rules/functions/Ref.py
@@ -96,6 +96,25 @@ class Ref(BaseFn):
                     yield ValidationError(f"{instance!r} is not of type {reprs}")
                     return
 
+        elif value in validator.context.resources:
+            # A Ref to a resource always resolves to a string (the resource's
+            # physical id/name), so it can satisfy a scalar slot but never an
+            # object or array slot. Validate that against the schema the same
+            # way we do for named and pseudo parameters. This catches a bare
+            # Ref to a resource standing in for a whole object (e.g. an
+            # UpdatePolicy/CreationPolicy value) without blanking the resource
+            # map, which would break legitimate leaf Refs to resources.
+            schema_types = self.resolve_type(validator, subschema)
+            if not schema_types:
+                return
+            reprs = ", ".join(repr(type) for type in schema_types)
+            if all(
+                st not in ["string", "boolean", "integer", "number"]
+                for st in schema_types
+            ):
+                yield ValidationError(f"{instance!r} is not of type {reprs}")
+                return
+
         for rule_id in self._all_refs:
             rule = self.child_rules.get(rule_id)
             if rule:

--- a/src/cfnlint/rules/resources/CreationPolicy.py
+++ b/src/cfnlint/rules/resources/CreationPolicy.py
@@ -86,7 +86,6 @@ class CreationPolicy(CfnLintJsonSchema):
         validator = validator.evolve(
             context=validator.context.evolve(
                 functions=list(FUNCTIONS),
-                resources={},
                 strict_types=False,
             ),
             schema=self._get_schema(resource_type),

--- a/src/cfnlint/rules/resources/updatepolicy/Configuration.py
+++ b/src/cfnlint/rules/resources/updatepolicy/Configuration.py
@@ -35,7 +35,6 @@ class Configuration(CfnLintJsonSchema):
         validator = validator.evolve(
             context=validator.context.evolve(
                 functions=list(FUNCTIONS),
-                resources={},
                 strict_types=False,
             ),
             schema=self._schema,

--- a/test/fixtures/results/integration/creationpolicy_yaml.json
+++ b/test/fixtures/results/integration/creationpolicy_yaml.json
@@ -29,7 +29,7 @@
     },
     {
         "Filename": "test/fixtures/templates/integration/creationpolicy.yaml",
-        "Id": "3f4508fa-3fdd-6bec-6e01-d63493f18c72",
+        "Id": "eff0a384-0ff9-6a4f-cc21-4d9c8242857f",
         "Level": "Error",
         "Location": {
             "End": {
@@ -39,15 +39,14 @@
             "Path": [
                 "Resources",
                 "BareRefResource",
-                "CreationPolicy",
-                "Ref"
+                "CreationPolicy"
             ],
             "Start": {
                 "ColumnNumber": 5,
                 "LineNumber": 34
             }
         },
-        "Message": "'ValidObject' is not one of ['P', 'SignalCount', 'AWS::AccountId', 'AWS::NoValue', 'AWS::NotificationARNs', 'AWS::Partition', 'AWS::Region', 'AWS::StackId', 'AWS::StackName', 'AWS::URLSuffix']",
+        "Message": "{'Ref': 'ValidObject'} is not of type 'object'",
         "ParentId": null,
         "Rule": {
             "Description": "Making sure the Ref has a String value (no other functions are supported)",

--- a/test/unit/rules/functions/test_ref.py
+++ b/test/unit/rules/functions/test_ref.py
@@ -188,6 +188,35 @@ def context(cfn):
             {},
             [],
         ),
+        (
+            "Resource ref (string) is not an object",
+            {"Ref": "MyVolume"},
+            {"type": "object"},
+            {},
+            [
+                ValidationError(
+                    "{'Ref': 'MyVolume'} is not of type 'object'",
+                ),
+            ],
+        ),
+        (
+            "Resource ref (string) does not satisfy an array schema",
+            {"Ref": "MyVolume"},
+            {"type": "array"},
+            {},
+            [
+                ValidationError(
+                    "{'Ref': 'MyVolume'} is not of type 'array'",
+                ),
+            ],
+        ),
+        (
+            "Resource ref (string) satisfies a string schema",
+            {"Ref": "MyInstance"},
+            {"type": "string"},
+            {},
+            [],
+        ),
     ],
 )
 def test_validate(name, instance, schema, context_evolve, expected, rule, context, cfn):


### PR DESCRIPTION
## What

Fixes #4669: since 1.56.0, a valid `Ref` to a template **resource** at a leaf property inside `UpdatePolicy`/`CreationPolicy` (e.g. `CodeDeployLambdaAliasUpdate.ApplicationName: !Ref MyApp`) was reported as `E1020`.

#4641 added `resources={}` to the `E3016`/`E3055` validator context to reject a bare intrinsic standing in for the whole policy object. Blanking the resource map worked for the object slot but also blanked it for **nested leaf properties**, rejecting legitimate resource `Ref`s.

## Fix

A `Ref` to a resource always resolves to a **string**. Model that in `E1020` type checking, mirroring the existing named-parameter and pseudo-parameter cases. Then:

- a bare `Ref` to a resource as a whole policy object is caught **by type** (`is not of type 'object'`), with no blanked map;
- a `Ref` to a resource at a scalar leaf validates against the **real** resource map and passes.

`resources={}` is removed from both rules. #4641's `allOf` change and pseudo-parameter handling are kept.

## Validated against live CloudFormation (real stacks, us-east-1)

- `CodeDeployLambdaAliasUpdate.ApplicationName/DeploymentGroupName: !Ref <resource>` (no transform): stack creates; on update CFN resolves the refs and runs a real CodeDeploy deployment. ✅ now clean in lint
- `AutoScalingRollingUpdate.MaxBatchSize: !Ref <resource>`: `CREATE_COMPLETE`. ✅ now clean in lint
- bare `UpdatePolicy/CreationPolicy: !Ref X` / `!Sub`: CFN rejects (`Expected an object`). ✅ still flagged

## Tests

Updated the `BareRefResource` integration assertion (now a clean type error instead of the empty-map artifact); added `Ref` unit cases for resource-at-object/array/scalar slots. Full unit suite + integration pass; `ruff` clean.

Supersedes #4675 (which reverted #4641 in full and reintroduced the object-slot false negatives).