### PR TITLE
Allow Fn::GetAZs in Fn::Join values

### DIFF
--- a/src/cfnlint/data/schemas/other/functions/join.json
+++ b/src/cfnlint/data/schemas/other/functions/join.json
@@ -21,6 +21,7 @@
        "Fn::Cidr",
        "Fn::FindInMap",
        "Fn::GetAtt",
+       "Fn::GetAZs",
        "Fn::If",
        "Fn::Split",
        "Ref"

--- a/test/unit/rules/functions/test_join.py
+++ b/test/unit/rules/functions/test_join.py
@@ -128,6 +128,12 @@ def rule():
             [],
         ),
         (
+            "Valid Fn::Join with Fn::GetAZs",
+            {"Fn::Join": [",", {"Fn::GetAZs": ""}]},
+            {"type": "string"},
+            [],
+        ),
+        (
             "Valid Fn::Join with a valid item function",
             {"Fn::Join": ["-", [{"Fn::Sub": "bar"}]]},
             {"type": "string"},


### PR DESCRIPTION
## Summary
- allow `Fn::GetAZs` as the second argument to `Fn::Join`
- add regression coverage for the reported `Fn::Join`/`Fn::GetAZs` false positive

## Rationale
CloudFormation documents `Fn::GetAZs` as supported in the list-of-values argument for `Fn::Join`, and `Fn::Select` already allows the same array-producing function. Without this, cfn-lint reports E1022 for a valid pattern such as joining all AZs into a comma-delimited string.

## Validation
- `.venv/bin/python -m pytest test/unit/rules/functions/test_join.py -q`
- `.venv/bin/python -m pytest test/unit/rules/functions -q`
- `.venv/bin/ruff check test/unit/rules/functions/test_join.py`
- `.venv/bin/ruff format --check test/unit/rules/functions/test_join.py`
- `.venv/bin/python -m json.tool src/cfnlint/data/schemas/other/functions/join.json`
- `.venv/bin/cfn-lint -r us-east-1 -- /tmp/cfn-join-getazs-XXXX.yaml`

Fixes #4674