### PR TITLE
fix: Allow intrinsics in SAM Globals properties

### DIFF
--- a/src/cfnlint/rules/resources/GlobalsTransform.py
+++ b/src/cfnlint/rules/resources/GlobalsTransform.py
@@ -9,8 +9,9 @@ from typing import Any
 
 import cfnlint.data.schemas.other.sam
 from cfnlint._typing import RuleMatches
-from cfnlint.helpers import TRANSFORM_SAM, is_function
+from cfnlint.helpers import FUNCTIONS, TRANSFORM_SAM, is_function
 from cfnlint.jsonschema import ValidationError, ValidationResult, Validator
+from cfnlint.jsonschema._keywords_cfn import cfn_type
 from cfnlint.rules import RuleMatch
 from cfnlint.rules.jsonschema.CfnLintJsonSchema import CfnLintJsonSchema, SchemaDetails
 from cfnlint.template import Template
@@ -66,11 +67,27 @@ class GlobalsTransform(CfnLintJsonSchema):
             )
             return
 
-        # Validate the Globals section structure against the schema
+        # Validate the Globals section structure against the schema.
+        # Globals values accept the same intrinsic functions as the
+        # underlying resource properties (Ref, Fn::ImportValue, Fn::Sub,
+        # ...). Enable functions and intrinsic-aware type checking so a
+        # type-constrained global (e.g. Function.PermissionsBoundary) is
+        # not rejected for holding an intrinsic that CloudFormation
+        # accepts.
         cfn_validator = self.extend_validator(
-            validator=validator,
+            validator=validator.evolve(
+                function_filter=validator.function_filter.evolve(
+                    validate_dynamic_references=False,
+                    add_cfn_lint_keyword=False,
+                )
+            ),
             schema=self._schema,
-            context=validator.context.evolve(),
+            context=validator.context.evolve(
+                functions=list(FUNCTIONS),
+                strict_types=False,
+                unresolvable_function_mode=True,
+            ),
+            validators={"type": cfn_type},
         )
         yield from self._iter_errors(cfn_validator, instance)
 

--- a/test/unit/rules/resources/test_globals_transform.py
+++ b/test/unit/rules/resources/test_globals_transform.py
@@ -49,6 +49,34 @@ def rule():
             {"cfn_path": deque(["Globals"])},
             1,
         ),
+        (
+            # https://github.com/aws-cloudformation/cfn-lint/issues/4680
+            "Intrinsic in a type-constrained global (PermissionsBoundary)",
+            {
+                "Function": {
+                    "PermissionsBoundary": {
+                        "Fn::ImportValue": {"Fn::Sub": "my-boundary-arn"}
+                    }
+                }
+            },
+            {"Transform": ["AWS::Serverless-2016-10-31"]},
+            {"cfn_path": deque(["Globals"])},
+            0,
+        ),
+        (
+            "Intrinsic Ref in a type-constrained global (Runtime)",
+            {"Function": {"Runtime": {"Ref": "AWS::Region"}}},
+            {"Transform": ["AWS::Serverless-2016-10-31"]},
+            {"cfn_path": deque(["Globals"])},
+            0,
+        ),
+        (
+            "Non-intrinsic object still rejected for a string global",
+            {"Function": {"PermissionsBoundary": {"Foo": "bar"}}},
+            {"Transform": ["AWS::Serverless-2016-10-31"]},
+            {"cfn_path": deque(["Globals"])},
+            1,
+        ),
     ],
     indirect=["template", "path"],
 )


### PR DESCRIPTION
### Issue #, if available

Fixes #4680

### Description of changes

Since #4491 the `Globals` section is validated against `globals.json` by `E3724` (`GlobalsTransform`). That rule validated the section **without** enabling intrinsic functions or intrinsic-aware type checking, so any `type`-constrained Globals property rejected `Ref`/`Fn::ImportValue`/`Fn::Sub`:

```
E3724 {'Fn::ImportValue': {'Fn::Sub': 'my-iam-${Environment}-lambda-boundary-arn'}} is not of type 'string'
```

The reporter flagged `Function.PermissionsBoundary`, but it's broader — e.g. `Function.Runtime: !Ref X` failed the same way. The same intrinsic on the resource's own `Properties` was already accepted, so only the Globals path was affected.

Fix: when validating the Globals section, enable `functions` and use the intrinsic-aware `cfn_type`, mirroring how resource properties and `Outputs` values are validated. Malformed literals are still flagged (`E3724`/`E3012`), and the merged resource-level validation remains a second layer.

Validated against the real SAM translator (`sam validate`, aws-sam-translator 1.165.0): it accepts the intrinsic in `Globals.Function.PermissionsBoundary` and in `Globals.Function.Runtime`; a non-intrinsic object literal is still rejected by cfn-lint's schema type check.

### Testing

- Added regression cases to `test/unit/rules/resources/test_globals_transform.py` (intrinsic in `PermissionsBoundary`/`Runtime` → no error; non-intrinsic object → still errors).
- `ruff`, `ruff format`, `isort`, `mypy` clean.
- `test/unit/rules/resources` + `test/unit/rules/functions` (1482) and serverless integration tests pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.