### PR TITLE
Avoid maxProperties warnings for single-property schemas

### DIFF
--- a/src/cfnlint/rules/jsonschema/MaxProperties.py
+++ b/src/cfnlint/rules/jsonschema/MaxProperties.py
@@ -34,6 +34,8 @@ class MaxProperties(CloudFormationLintRule):
                 f"has more than {mP!r} properties"
             )
             return
+        if mP <= 1:
+            return
         if percent > self.config["threshold"]:
             rule = self.child_rules.get(self.approaching_limit_rule)
             if not rule:

--- a/test/unit/rules/jsonschema/test_max_properties.py
+++ b/test/unit/rules/jsonschema/test_max_properties.py
@@ -42,6 +42,27 @@ class TestMaxProperties(BaseRuleTestCase):
         self.assertIsNone(errs[0].rule)
 
         errs = list(self.rule.maxProperties(validator, 1, {"foo": True}, {}))
+        self.assertEqual(len(errs), 0)
+
+        errs = list(
+            self.rule.maxProperties(
+                validator,
+                10,
+                {
+                    "foo0": True,
+                    "foo1": True,
+                    "foo2": True,
+                    "foo3": True,
+                    "foo4": True,
+                    "foo5": True,
+                    "foo6": True,
+                    "foo7": True,
+                    "foo8": True,
+                    "foo9": True,
+                },
+                {},
+            )
+        )
         self.assertEqual(len(errs), 1)
         self.assertEqual(errs[0].rule.id, "ChildMaxProperties")
 
@@ -71,7 +92,25 @@ class TestMaxPropertiesWithFunction(BaseRuleTestCase):
     def test_property_names(self):
         validator = CfnTemplateValidator({})
 
-        errs = list(self.rule.maxProperties(validator, 1, {"foo": True}, {}))
+        errs = list(
+            self.rule.maxProperties(
+                validator,
+                10,
+                {
+                    "foo0": True,
+                    "foo1": True,
+                    "foo2": True,
+                    "foo3": True,
+                    "foo4": True,
+                    "foo5": True,
+                    "foo6": True,
+                    "foo7": True,
+                    "foo8": True,
+                    "foo9": True,
+                },
+                {},
+            )
+        )
         self.assertEqual(len(errs), 2)
         self.assertEqual(errs[0].rule.id, "ChildMaxPropertiesWithFunction")
 


### PR DESCRIPTION
## What

Suppress the `I3010` approaching-limit child rule when a schema has `maxProperties: 1`.

## Why

A schema with a one-property maximum has no useful "approaching the limit" state: any valid one-property object is already at 100% of the limit. That causes noisy `I3010` matches for one-of style schemas such as `AWS::Logs::Transformer` processors, where each processor object intentionally has exactly one key.

The real `E3010` overflow behavior is unchanged: objects with more than the allowed number of properties still fail before this guard.

Fixes #4684.

## Validation

- `.venv/bin/python -m pytest test/unit/rules/jsonschema/test_max_properties.py -q`
- `.venv/bin/python -m pytest test/unit/rules/jsonschema -q`
- `.venv/bin/ruff check src/cfnlint/rules/jsonschema/MaxProperties.py test/unit/rules/jsonschema/test_max_properties.py`
- `.venv/bin/ruff format --check src/cfnlint/rules/jsonschema/MaxProperties.py test/unit/rules/jsonschema/test_max_properties.py`
- `git diff --check`

Note: I attempted a CLI smoke test with the issue's `AWS::Logs::Transformer` template, but my local schema cache did not include that resource and enhanced schema refresh failed on local SSL certificate verification. The focused jsonschema tests cover the rule path directly.
