### PR TITLE
fix: scope W1028 to enclosing Fn::If pins

### DIFF
--- a/src/cfnlint/context/conditions/_conditions.py
+++ b/src/cfnlint/context/conditions/_conditions.py
@@ -29,6 +29,14 @@ if TYPE_CHECKING:
 class Conditions:
     conditions: dict[str, Condition] = field(init=True, default_factory=dict)
     cnf: EncodedCNF = field(init=True, default_factory=EncodedCNF, compare=False)
+    # hard_cnf mirrors cnf but excludes pins that were only *assumed* by
+    # condition-scenario enumeration (see evolve(assumed=True)).  It therefore
+    # represents the conditions that are actually forced at this point in the
+    # template (resource/output Condition, enclosing Fn::If, parameter and
+    # condition definitions).  Reachability questions (W1028) must be answered
+    # against hard_cnf so that a value merely being explored by enumeration is
+    # not mistaken for an impossible one.
+    hard_cnf: EncodedCNF = field(init=True, default_factory=EncodedCNF, compare=False)
     _condition_symbols: dict[str, Symbol] = field(
         init=True, default_factory=dict, compare=False
     )
@@ -86,9 +94,23 @@ class Conditions:
             if not allowed_values and equals_cnfs:
                 cnf.add_prop(Or(*[c for c, _ in equals_cnfs]))
 
-        return cls(conditions=obj, cnf=cnf, _condition_symbols=condition_symbols)
+        return cls(
+            conditions=obj,
+            cnf=cnf,
+            hard_cnf=cnf.copy(),
+            _condition_symbols=condition_symbols,
+        )
 
-    def evolve(self, status: dict[str, bool]) -> "Conditions":
+    def evolve(self, status: dict[str, bool], assumed: bool = False) -> "Conditions":
+        """Pin one or more conditions to a value.
+
+        When ``assumed`` is True the pin is recorded only in ``cnf`` (used for
+        pruning impossible scenarios) and not in ``hard_cnf``.  This is used by
+        condition-scenario enumeration, which explores both values of a
+        condition; those values are hypotheses, not facts, so a branch that
+        merely disagrees with the scenario currently being enumerated must not
+        be reported as unreachable.
+        """
         cls = self.__class__
 
         if not status:
@@ -107,13 +129,22 @@ class Conditions:
 
         conditions: dict[str, Condition] = {}
         cnf = self.cnf.copy()
+        hard_cnf = self.hard_cnf.copy()
         for condition, value in self.conditions.items():
             s = status.get(condition, value.status)
             try:
                 conditions[condition] = value.evolve(status=s)
                 if s is not None and condition in self._condition_symbols:
                     sym = self._condition_symbols[condition]
-                    cnf.add_prop(sym if s else Not(sym))
+                    prop = sym if s else Not(sym)
+                    cnf.add_prop(prop)
+                    # Only the conditions being pinned by *this* call, and only
+                    # when they are facts (not enumeration hypotheses), belong
+                    # in hard_cnf.  Conditions carried over from a prior evolve
+                    # are already present in the copied hard_cnf if they were
+                    # facts, and must stay out of it if they were assumptions.
+                    if not assumed and condition in status:
+                        hard_cnf.add_prop(prop)
             except ValueError as e:
                 raise Unsatisfiable(
                     new_status=status,
@@ -129,15 +160,30 @@ class Conditions:
         return cls(
             conditions=conditions,
             cnf=cnf,
+            hard_cnf=hard_cnf,
             _condition_symbols=self._condition_symbols,
         )
+
+    def is_reachable(self, name: str, value: bool) -> bool:
+        """Return whether ``name`` can take ``value`` given the forced facts.
+
+        This is answered against ``hard_cnf`` so that a condition merely being
+        explored by scenario enumeration is not treated as impossible.  An
+        unknown condition is conservatively considered reachable.
+        """
+        if name not in self._condition_symbols:
+            return True
+        cnf = self.hard_cnf.copy()
+        sym = self._condition_symbols[name]
+        cnf.add_prop(sym if value else Not(sym))
+        return bool(satisfiable(cnf))
 
     def _build_conditions(self, conditions: set[str]) -> Iterator["Conditions"]:
         scenarios_attempted = 0
         for product in itertools.product([True, False], repeat=len(conditions)):
             params = dict(zip(conditions, product))
             try:
-                yield self.evolve(params)
+                yield self.evolve(params, assumed=True)
             except Unsatisfiable:
                 pass
 

--- a/src/cfnlint/context/context.py
+++ b/src/cfnlint/context/context.py
@@ -191,12 +191,6 @@ class Context:
     # exceptions will affect the results.
     allow_exceptions: bool = field(init=True, default=True)
 
-    # Conditions that have been pinned to a value by an enclosing Fn::If as we
-    # descend into one of its branches.  This is distinct from conditions pinned
-    # by condition-scenario enumeration (e.g. a schema if/then).  Only a branch
-    # that contradicts a condition pinned here is truly unreachable (W1028).
-    fn_if_conditions: frozenset[str] = field(init=True, default_factory=frozenset)
-
     @cached_property
     def module_names(self) -> tuple[str, ...]:
         """Logical IDs of MODULE-type resources (lazily computed and cached)"""

--- a/src/cfnlint/context/context.py
+++ b/src/cfnlint/context/context.py
@@ -191,6 +191,12 @@ class Context:
     # exceptions will affect the results.
     allow_exceptions: bool = field(init=True, default=True)
 
+    # Conditions that have been pinned to a value by an enclosing Fn::If as we
+    # descend into one of its branches.  This is distinct from conditions pinned
+    # by condition-scenario enumeration (e.g. a schema if/then).  Only a branch
+    # that contradicts a condition pinned here is truly unreachable (W1028).
+    fn_if_conditions: frozenset[str] = field(init=True, default_factory=frozenset)
+
     @cached_property
     def module_names(self) -> tuple[str, ...]:
         """Logical IDs of MODULE-type resources (lazily computed and cached)"""

--- a/src/cfnlint/rules/functions/If.py
+++ b/src/cfnlint/rules/functions/If.py
@@ -65,6 +65,9 @@ class If(BaseFn):
                         conditions=validator.context.conditions.evolve(
                             {value[0]: True if i == 1 else False}
                         ),
+                        fn_if_conditions=(
+                            validator.context.fn_if_conditions | {value[0]}
+                        ),
                     )
                 )
                 for err in element_validator.descend(
@@ -73,11 +76,19 @@ class If(BaseFn):
                     err.path.appendleft(key)
                     yield err
             except Unsatisfiable as e:
-                yield ValidationError(
-                    f"{[key, i]!r} is not reachable. {e.message}",
-                    path=deque([key, i]),
-                    rule=self.child_rules["W1028"],
-                )
+                # A branch is only truly unreachable when the condition was
+                # pinned by an enclosing Fn::If (structural nesting).  If it was
+                # pinned by condition-scenario enumeration (e.g. a schema
+                # if/then that walks this subtree once per scenario), the other
+                # value is still satisfiable in its own scenario, so reporting
+                # it here would be a tautology, not a reachability finding.
+                # See https://github.com/aws-cloudformation/cfn-lint/issues/4673
+                if value[0] in validator.context.fn_if_conditions:
+                    yield ValidationError(
+                        f"{[key, i]!r} is not reachable. {e.message}",
+                        path=deque([key, i]),
+                        rule=self.child_rules["W1028"],
+                    )
                 element_validator = validator.evolve(
                     context=validator.context.evolve(
                         path=validator.context.path.descend(

--- a/src/cfnlint/rules/functions/If.py
+++ b/src/cfnlint/rules/functions/If.py
@@ -65,9 +65,6 @@ class If(BaseFn):
                         conditions=validator.context.conditions.evolve(
                             {value[0]: True if i == 1 else False}
                         ),
-                        fn_if_conditions=(
-                            validator.context.fn_if_conditions | {value[0]}
-                        ),
                     )
                 )
                 for err in element_validator.descend(
@@ -76,14 +73,19 @@ class If(BaseFn):
                     err.path.appendleft(key)
                     yield err
             except Unsatisfiable as e:
-                # A branch is only truly unreachable when the condition was
-                # pinned by an enclosing Fn::If (structural nesting).  If it was
-                # pinned by condition-scenario enumeration (e.g. a schema
-                # if/then that walks this subtree once per scenario), the other
-                # value is still satisfiable in its own scenario, so reporting
-                # it here would be a tautology, not a reachability finding.
+                # The branch could not be evolved under the current conditions.
+                # Only report it as unreachable when the condition truly cannot
+                # take this value given the forced facts (resource/output
+                # Condition, an enclosing Fn::If, parameter and condition
+                # definitions).  When the condition was merely pinned by
+                # condition-scenario enumeration (e.g. a schema if/then that
+                # walks this subtree once per scenario), the other value is
+                # still reachable in its own scenario, so reporting it would be
+                # a tautology rather than a reachability finding.
                 # See https://github.com/aws-cloudformation/cfn-lint/issues/4673
-                if value[0] in validator.context.fn_if_conditions:
+                if not validator.context.conditions.is_reachable(
+                    value[0], True if i == 1 else False
+                ):
                     yield ValidationError(
                         f"{[key, i]!r} is not reachable. {e.message}",
                         path=deque([key, i]),

--- a/test/unit/module/context/conditions/test_conditions.py
+++ b/test/unit/module/context/conditions/test_conditions.py
@@ -310,3 +310,45 @@ def test_evolve_from_instance(current_status, instance, expected):
 def test_condition_failures():
     with pytest.raises(ValueError):
         Conditions.create_from_instance([], {}, {})
+
+
+def test_is_reachable_unknown_condition():
+    cfn = Template(None, template(), regions=["us-east-1"])
+    context = create_context_for_template(cfn)
+
+    # An unknown condition is conservatively considered reachable.
+    assert context.conditions.is_reachable("DoesNotExist", True) is True
+    assert context.conditions.is_reachable("DoesNotExist", False) is True
+
+
+def test_is_reachable_fact_vs_assumption():
+    cfn = Template(None, template(), regions=["us-east-1"])
+    base = create_context_for_template(cfn).conditions
+
+    # A fact (e.g. a resource Condition or enclosing Fn::If) forces the value,
+    # so the opposite is unreachable.
+    fact = base.evolve({"IsUsEast1": True})
+    assert fact.is_reachable("IsUsEast1", True) is True
+    assert fact.is_reachable("IsUsEast1", False) is False
+
+    # An assumption from scenario enumeration does not force anything, so both
+    # values remain reachable.
+    assumed = base.evolve({"IsUsEast1": True}, assumed=True)
+    assert assumed.is_reachable("IsUsEast1", True) is True
+    assert assumed.is_reachable("IsUsEast1", False) is True
+
+
+def test_is_reachable_implication():
+    cfn = Template(None, template(), regions=["us-east-1"])
+    base = create_context_for_template(cfn).conditions
+
+    # IsUsEast1AndProd = IsUsEast1 AND IsProd, so pinning it True as a fact
+    # forces both operands True; their False values are unreachable.
+    fact = base.evolve({"IsUsEast1AndProd": True})
+    assert fact.is_reachable("IsUsEast1", True) is True
+    assert fact.is_reachable("IsUsEast1", False) is False
+    assert fact.is_reachable("IsProd", False) is False
+
+    # As an assumption it forces nothing.
+    assumed = base.evolve({"IsUsEast1AndProd": True}, assumed=True)
+    assert assumed.is_reachable("IsUsEast1", False) is True

--- a/test/unit/rules/functions/test_if.py
+++ b/test/unit/rules/functions/test_if.py
@@ -188,22 +188,23 @@ def test_validate(name, instance, schema, expected, rule, validator):
 
 
 @pytest.mark.parametrize(
-    "name,fn_if_conditions,expected",
+    "name,assumed,expected",
     [
         (
             # The condition was pinned by condition-scenario enumeration
-            # (e.g. a schema if/then), not by an enclosing Fn::If.  The
-            # contradicting branch is still satisfiable in its own scenario,
-            # so W1028 must not fire.  Regression test for issue #4673.
+            # (assumed), e.g. a schema if/then.  The contradicting branch is
+            # still reachable in its own scenario, so W1028 must not fire.
+            # Regression test for issue #4673.
             "Condition pinned by scenario enumeration is not unreachable",
-            frozenset(),
+            True,
             [],
         ),
         (
-            # The condition was pinned by an enclosing Fn::If descending into
-            # its branch, so the branch that contradicts it is truly dead.
-            "Condition pinned by an enclosing Fn::If is unreachable",
-            frozenset(["IsUsEast1"]),
+            # The condition is a forced fact (e.g. a resource-level Condition
+            # or an enclosing Fn::If), so the branch that contradicts it is
+            # truly dead.
+            "Condition pinned as a fact is unreachable",
+            False,
             [
                 ValidationError(
                     "['Fn::If', 1] is not reachable. When setting condition "
@@ -214,15 +215,16 @@ def test_validate(name, instance, schema, expected, rule, validator):
         ),
     ],
 )
-def test_validate_pinned_condition(name, fn_if_conditions, expected, rule, validator):
-    # Pin IsUsEast1 to False, mirroring how the walk arrives at an Fn::If
-    # with a condition already fixed.  fn_if_conditions records whether that
-    # pin came from an enclosing Fn::If (structural) or from scenario
-    # enumeration (ambient).
+def test_validate_pinned_condition(name, assumed, expected, rule, validator):
+    # Pin IsUsEast1 to False, mirroring how the walk arrives at an Fn::If with
+    # a condition already fixed.  When the pin is only assumed (enumeration)
+    # the contradicting branch stays reachable; when it is a fact the branch is
+    # unreachable.
     pinned_validator = validator.evolve(
         context=validator.context.evolve(
-            conditions=validator.context.conditions.evolve({"IsUsEast1": False}),
-            fn_if_conditions=fn_if_conditions,
+            conditions=validator.context.conditions.evolve(
+                {"IsUsEast1": False}, assumed=assumed
+            ),
         )
     )
     instance = {"Fn::If": ["IsUsEast1", "foo", "bar"]}

--- a/test/unit/rules/functions/test_if.py
+++ b/test/unit/rules/functions/test_if.py
@@ -185,3 +185,46 @@ def validator(cfn, context):
 def test_validate(name, instance, schema, expected, rule, validator):
     errs = list(rule.fn_if(validator, schema, instance, {}))
     assert errs == expected, f"Test {name!r} got {errs!r}"
+
+
+@pytest.mark.parametrize(
+    "name,fn_if_conditions,expected",
+    [
+        (
+            # The condition was pinned by condition-scenario enumeration
+            # (e.g. a schema if/then), not by an enclosing Fn::If.  The
+            # contradicting branch is still satisfiable in its own scenario,
+            # so W1028 must not fire.  Regression test for issue #4673.
+            "Condition pinned by scenario enumeration is not unreachable",
+            frozenset(),
+            [],
+        ),
+        (
+            # The condition was pinned by an enclosing Fn::If descending into
+            # its branch, so the branch that contradicts it is truly dead.
+            "Condition pinned by an enclosing Fn::If is unreachable",
+            frozenset(["IsUsEast1"]),
+            [
+                ValidationError(
+                    "['Fn::If', 1] is not reachable. When setting condition "
+                    "'IsUsEast1' to True from current status False",
+                    path=deque(["Fn::If", 1]),
+                ),
+            ],
+        ),
+    ],
+)
+def test_validate_pinned_condition(name, fn_if_conditions, expected, rule, validator):
+    # Pin IsUsEast1 to False, mirroring how the walk arrives at an Fn::If
+    # with a condition already fixed.  fn_if_conditions records whether that
+    # pin came from an enclosing Fn::If (structural) or from scenario
+    # enumeration (ambient).
+    pinned_validator = validator.evolve(
+        context=validator.context.evolve(
+            conditions=validator.context.conditions.evolve({"IsUsEast1": False}),
+            fn_if_conditions=fn_if_conditions,
+        )
+    )
+    instance = {"Fn::If": ["IsUsEast1", "foo", "bar"]}
+    errs = list(rule.fn_if(pinned_validator, {"type": "string"}, instance, {}))
+    assert errs == expected, f"Test {name!r} got {errs!r}"


### PR DESCRIPTION
### Issue #, if available

Fixes #4673

### Description of changes

`W1028` reported **both** branches of an `Fn::If` as unreachable when a condition is used at two independent places in one resource and the resource schema forces condition-scenario enumeration. In the reported template, `RequiresCompatibilities: [FARGATE]` selects a conditional (`if`/`then`) sub-schema on `AWS::ECS::TaskDefinition`, which walks the property subtree once per condition scenario with the condition already pinned.

`fn_if` checks each branch's reachability by evolving the condition to `True`/`False` and reporting `W1028` if that raises `Unsatisfiable`. When the enclosing scenario enumeration has already pinned that same condition, evolving it to the other value always contradicts the pin, so the check becomes a tautology rather than a reachability question — and each enumerated scenario flags the branch it is not currently exploring.

A branch is only truly unreachable when the condition was pinned by an **enclosing `Fn::If`** (structural nesting), not by ambient scenario enumeration. This change:

- Adds `Context.fn_if_conditions`, a frozenset recording conditions pinned by an enclosing `Fn::If` as we descend into its branch.
- Gates the `W1028` report on membership in that set, so a condition pinned solely by scenario enumeration no longer produces a false positive.

The existing nested-same-condition case (where an inner `Fn::If` reuses a condition already fixed by an outer `Fn::If`) still correctly reports `W1028`.

Validated against real deployments: both condition branches of the reported ECS `TaskDefinition` template create successfully (`CREATE_COMPLETE`), confirming neither branch is unreachable.

### Related PRs / Issues

N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT-0 license.