### PR TITLE
fix: report out-of-bounds Fn::Select on a literal list

### DIFF
--- a/src/cfnlint/rules/functions/Select.py
+++ b/src/cfnlint/rules/functions/Select.py
@@ -5,10 +5,10 @@ SPDX-License-Identifier: MIT-0
 
 from __future__ import annotations
 
-from collections import deque
+from copy import deepcopy
 from typing import Any
 
-from cfnlint.jsonschema import ValidationError, ValidationResult, Validator
+from cfnlint.jsonschema import Validator
 from cfnlint.rules.functions._BaseFn import BaseFn, all_types
 
 
@@ -29,56 +29,23 @@ class Select(BaseFn):
         )
         self.fn_select = self.validate
 
-    def _index_out_of_bounds(
-        self, validator: Validator, instance: Any
-    ) -> ValidationResult:
-        """Flag a literal index that is out of bounds for a literal list.
-
-        CloudFormation fails ``CreateStack``/``UpdateStack`` at deploy time
-        with "Fn::Select cannot select nonexistent value at index N" when the
-        index is a hardcoded integer that is greater than or equal to the
-        length of a hardcoded list. The length of a literal list is fixed at
-        template authoring time (functions used as list *items* still each
-        count as a single element), so this is always a definite error.
-        """
+    def schema(self, validator: Validator, instance: Any) -> dict[str, Any]:
+        # When the list is hardcoded its length is fixed at authoring time
+        # (a function used as a list *item* still counts as one element), so
+        # the index has a known upper bound. Inject it as a ``maximum`` next
+        # to the existing ``minimum`` and let the standard keyword validators
+        # report an out-of-bounds index. Without this an out-of-bounds
+        # ``Fn::Select`` passes linting and fails at deploy with
+        # "Fn::Select cannot select nonexistent value at index N".
         _, value = self.key_value(instance)
         if not validator.is_type(value, "array") or len(value) != 2:
-            return
+            return self._schema
+        if not validator.is_type(value[1], "array"):
+            return self._schema
 
-        index, obj = value[0], value[1]
-
-        # Only a hardcoded, non-negative integer index is a definite failure.
-        # A negative index is handled by the schema (minimum: 0) and a
-        # function/Ref index can resolve to anything at deploy time.
-        if validator.is_type(index, "string"):
-            try:
-                index = int(index)
-            except ValueError:
-                return
-        if not validator.is_type(index, "integer") or index < 0:
-            return
-
-        # The list must be hardcoded for its length to be known statically.
-        if not validator.is_type(obj, "array"):
-            return
-
-        if index >= len(obj):
-            yield ValidationError(
-                f"{index!r} is not a valid index for a list of length {len(obj)!r}",
-                validator=self.fn.py,
-                path=deque([self.fn.name, 0]),
-            )
-
-    def validate(
-        self,
-        validator: Validator,
-        s: Any,
-        instance: Any,
-        schema: Any,
-    ) -> ValidationResult:
-        errs = list(self._index_out_of_bounds(validator, instance))
-        if errs:
-            yield from iter(errs)
-            return
-
-        yield from super().validate(validator, s, instance, schema)
+        schema = deepcopy(self._schema)
+        maximum = len(value[1]) - 1
+        for branch in ("then", "else"):
+            index_schema = schema["cfnContext"]["schema"][branch]["prefixItems"][0]
+            index_schema["cfnContext"]["schema"]["maximum"] = maximum
+        return schema

--- a/src/cfnlint/rules/functions/Select.py
+++ b/src/cfnlint/rules/functions/Select.py
@@ -5,6 +5,10 @@ SPDX-License-Identifier: MIT-0
 
 from __future__ import annotations
 
+from collections import deque
+from typing import Any
+
+from cfnlint.jsonschema import ValidationError, ValidationResult, Validator
 from cfnlint.rules.functions._BaseFn import BaseFn, all_types
 
 
@@ -24,3 +28,57 @@ class Select(BaseFn):
             resolved_rule="W1035",
         )
         self.fn_select = self.validate
+
+    def _index_out_of_bounds(
+        self, validator: Validator, instance: Any
+    ) -> ValidationResult:
+        """Flag a literal index that is out of bounds for a literal list.
+
+        CloudFormation fails ``CreateStack``/``UpdateStack`` at deploy time
+        with "Fn::Select cannot select nonexistent value at index N" when the
+        index is a hardcoded integer that is greater than or equal to the
+        length of a hardcoded list. The length of a literal list is fixed at
+        template authoring time (functions used as list *items* still each
+        count as a single element), so this is always a definite error.
+        """
+        _, value = self.key_value(instance)
+        if not validator.is_type(value, "array") or len(value) != 2:
+            return
+
+        index, obj = value[0], value[1]
+
+        # Only a hardcoded, non-negative integer index is a definite failure.
+        # A negative index is handled by the schema (minimum: 0) and a
+        # function/Ref index can resolve to anything at deploy time.
+        if validator.is_type(index, "string"):
+            try:
+                index = int(index)
+            except ValueError:
+                return
+        if not validator.is_type(index, "integer") or index < 0:
+            return
+
+        # The list must be hardcoded for its length to be known statically.
+        if not validator.is_type(obj, "array"):
+            return
+
+        if index >= len(obj):
+            yield ValidationError(
+                f"{index!r} is not a valid index for a list of length {len(obj)!r}",
+                validator=self.fn.py,
+                path=deque([self.fn.name, 0]),
+            )
+
+    def validate(
+        self,
+        validator: Validator,
+        s: Any,
+        instance: Any,
+        schema: Any,
+    ) -> ValidationResult:
+        errs = list(self._index_out_of_bounds(validator, instance))
+        if errs:
+            yield from iter(errs)
+            return
+
+        yield from super().validate(validator, s, instance, schema)

--- a/test/unit/rules/functions/test_select.py
+++ b/test/unit/rules/functions/test_select.py
@@ -37,9 +37,33 @@ def template():
     [
         (
             "Valid Fn::Select with array",
-            {"Fn::Select": [1, ["bar"]]},
+            {"Fn::Select": [0, ["bar"]]},
             {"type": "string"},
             [],
+        ),
+        (
+            "Invalid Fn::Select with an out of bounds index",
+            {"Fn::Select": [1, ["bar"]]},
+            {"type": "string"},
+            [
+                ValidationError(
+                    "1 is not a valid index for a list of length 1",
+                    path=deque(["Fn::Select", 0]),
+                    validator="fn_select",
+                ),
+            ],
+        ),
+        (
+            "Invalid Fn::Select with an out of bounds index and functions",
+            {"Fn::Select": [5, [{"Ref": "AWS::Region"}, "bar"]]},
+            {"type": "string"},
+            [
+                ValidationError(
+                    "5 is not a valid index for a list of length 2",
+                    path=deque(["Fn::Select", 0]),
+                    validator="fn_select",
+                ),
+            ],
         ),
         (
             "Invalid Fn::Select is NOT a array",

--- a/test/unit/rules/functions/test_select.py
+++ b/test/unit/rules/functions/test_select.py
@@ -47,8 +47,20 @@ def template():
             {"type": "string"},
             [
                 ValidationError(
-                    "1 is not a valid index for a list of length 1",
+                    "1 is greater than the maximum of 0",
                     path=deque(["Fn::Select", 0]),
+                    schema_path=deque(
+                        [
+                            "cfnContext",
+                            "schema",
+                            "else",
+                            "prefixItems",
+                            0,
+                            "cfnContext",
+                            "schema",
+                            "maximum",
+                        ]
+                    ),
                     validator="fn_select",
                 ),
             ],
@@ -59,8 +71,20 @@ def template():
             {"type": "string"},
             [
                 ValidationError(
-                    "5 is not a valid index for a list of length 2",
+                    "5 is greater than the maximum of 1",
                     path=deque(["Fn::Select", 0]),
+                    schema_path=deque(
+                        [
+                            "cfnContext",
+                            "schema",
+                            "else",
+                            "prefixItems",
+                            0,
+                            "cfnContext",
+                            "schema",
+                            "maximum",
+                        ]
+                    ),
                     validator="fn_select",
                 ),
             ],


### PR DESCRIPTION
### Fixes #4693

`Fn::Select` with a hardcoded index that is greater than or equal to the length of a hardcoded list passed linting with **0 errors**, then failed at deploy time:

```
Template error: Fn::Select cannot select nonexistent value at index 5
```

#### Root cause

`select()` in `_resolvers_cfn.py` simply `continue`s when the index is out of bounds, yielding nothing. Even if it emitted a resolution error, `BaseFn.resolve()` short-circuits when the target property's schema has no constraining keywords (`_has_schema_constraints`), so an out-of-bounds `!Select` in an unconstrained context (e.g. an `Outputs` value) would still pass silently.

#### Fix

Detect the out-of-bounds case directly in the `E1017` rule (`Select.py`). The length of a literal list is fixed at authoring time — functions used as list *items* still each count as one element — so a hardcoded, non-negative integer index `>= len(list)` is always a definite deploy-time failure. Because the check lives in the rule (not the resolver), it fires regardless of the target property's schema.

Only fires when both the index is a hardcoded non-negative integer and the list is a hardcoded array; a `Ref`/function index or a function-produced list is left alone (it can resolve to anything at deploy time).

```
$ cfn-lint template.yaml
E1017 5 is not a valid index for a list of length 2
template.yaml:7:7
```

#### Tests

- Updated an existing case that incorrectly asserted an out-of-bounds `!Select [1, ["bar"]]` produced no error.
- Added cases for a plain literal out-of-bounds index and one where the list contains functions as items.