### PR TITLE
fix: report clean error for Fn::GetAtt string form without an attribute

### DIFF
--- a/src/cfnlint/data/schemas/other/functions/getatt.json
+++ b/src/cfnlint/data/schemas/other/functions/getatt.json
@@ -35,6 +35,7 @@
    },
    "maxItems": 2,
    "minItems": 2,
+   "pattern": "^[a-zA-Z0-9]+\\..+$",
    "then": {
     "prefixItems": [
      {

--- a/src/cfnlint/rules/functions/GetAtt.py
+++ b/src/cfnlint/rules/functions/GetAtt.py
@@ -186,6 +186,21 @@ class GetAtt(BaseFn):
         if validator.is_type(value, "array"):
             value = self._resolve_sam_getatt(value, validator)
 
+            # The string form (``{"Fn::GetAtt": "MyResource"}``) is split on
+            # the first ".". The schema's ``minItems``/``maxItems`` and the
+            # string ``pattern`` reject a missing attribute, but resolve it
+            # cleanly here too so a malformed value can never reach the
+            # ``value[1]`` indexing in ``_resolve_getatt`` and crash with an
+            # IndexError.
+            if len(value) < 2:
+                yield ValidationError(
+                    f"{instance!r} is not a valid GetAtt. It must specify a "
+                    "resource and an attribute name",
+                    validator=self.fn.py,
+                    path=deque([self.fn.name]),
+                )
+                return
+
         if errs:
             if any(getattr(e, "unknown", False) for e in errs):
                 format_errs = list(self._run_format_rule(validator, s, value))
@@ -196,19 +211,6 @@ class GetAtt(BaseFn):
                         yield e
             else:
                 yield from iter(errs)
-            return
-
-        # The string form (``{"Fn::GetAtt": "MyResource"}``) is split on the
-        # first ".". ``minItems``/``maxItems`` in the schema only constrain the
-        # array form, so a dotless string slips through with no attribute name
-        # and later indexing (``value[1]``) would crash. Report it cleanly.
-        if len(value) < 2:
-            yield ValidationError(
-                f"{instance!r} is not a valid GetAtt. It must specify a "
-                "resource and an attribute name",
-                validator=self.fn.py,
-                path=deque([self.fn.name]),
-            )
             return
 
         errs = list(

--- a/src/cfnlint/rules/functions/GetAtt.py
+++ b/src/cfnlint/rules/functions/GetAtt.py
@@ -198,6 +198,19 @@ class GetAtt(BaseFn):
                 yield from iter(errs)
             return
 
+        # The string form (``{"Fn::GetAtt": "MyResource"}``) is split on the
+        # first ".". ``minItems``/``maxItems`` in the schema only constrain the
+        # array form, so a dotless string slips through with no attribute name
+        # and later indexing (``value[1]``) would crash. Report it cleanly.
+        if len(value) < 2:
+            yield ValidationError(
+                f"{instance!r} is not a valid GetAtt. It must specify a "
+                "resource and an attribute name",
+                validator=self.fn.py,
+                path=deque([self.fn.name]),
+            )
+            return
+
         errs = list(
             self._resolve_getatt(
                 self.validator(validator, schema), key, value, instance, s, paths

--- a/test/unit/rules/functions/test_getatt.py
+++ b/test/unit/rules/functions/test_getatt.py
@@ -127,6 +127,21 @@ class _Fail(CfnLintKeyword):
             ],
         ),
         (
+            "Invalid GetAtt string form without an attribute",
+            {"Fn::GetAtt": "MyBucket"},
+            {"type": "string"},
+            _template,
+            {},
+            [
+                ValidationError(
+                    "{'Fn::GetAtt': 'MyBucket'} is not a valid GetAtt. "
+                    "It must specify a resource and an attribute name",
+                    path=deque(["Fn::GetAtt"]),
+                    validator="fn_getatt",
+                ),
+            ],
+        ),
+        (
             "Invalid GetAtt with a bad response type",
             {"Fn::GetAtt": "MyBucket.Arn"},
             {"type": "array"},

--- a/test/unit/rules/functions/test_getatt.py
+++ b/test/unit/rules/functions/test_getatt.py
@@ -34,6 +34,15 @@ _template = {
 _template_with_transform = _template.copy()
 _template_with_transform["Transform"] = "AWS::LanguageExtensions"
 
+_custom_template = {
+    "Resources": {
+        "MyCustomResource": {
+            "Type": "Custom::Thing",
+            "Properties": {"ServiceToken": "arn:aws:lambda:us-east-1:1:function:f"},
+        },
+    },
+}
+
 
 class _Pass(CfnLintKeyword):
     id = "AAAAA"
@@ -140,6 +149,14 @@ class _Fail(CfnLintKeyword):
                     validator="fn_getatt",
                 ),
             ],
+        ),
+        (
+            "Valid GetAtt to a custom resource attribute with non-alphanumerics",
+            {"Fn::GetAtt": "MyCustomResource.My_Attribute-1"},
+            {"type": "string"},
+            _custom_template,
+            {},
+            [],
         ),
         (
             "Invalid GetAtt with a bad response type",


### PR DESCRIPTION
## Summary

`{"Fn::GetAtt": "MyResource"}` (JSON string form without a `.`) crashed cfn-lint with an unhandled `IndexError: list index out of range`, surfaced as `E1010 Exception 'list index out of range' raised while validating 'fn_getatt'`.

The string form is split on the first "." into `[resource, attribute]`. The schema's `minItems`/`maxItems` only constrain the **array** form (they are ignored for strings), so a dotless string produced a single-element list that passed validation, and `_resolve_getatt` then indexed `value[1]` and crashed.

This fixes it in two complementary ways:

1. **Schema** (`getatt.json`): add a `pattern` so the string form must contain a resource and an attribute separated by a dot. The resource segment is a CloudFormation logical id (`[a-zA-Z0-9]+`); the attribute is left unconstrained (`.+`) so custom-resource attribute names (underscores, hyphens) and nested attributes (`.Outputs.X`) are still accepted. The real per-resource attribute validation continues to happen in `_resolve_getatt`.
2. **Rule** (`GetAtt.py`): a guard emits a clear message and returns before the crashing `value[1]` index, so a malformed value can never crash even if the schema is bypassed.

The array form (`{"Fn::GetAtt": ["MyResource"]}`) and the YAML shorthand (`!GetAtt MyResource`) were already handled by `minItems: 2`.

Fixes #4694

## Behavior

Before:
```
E1010 Exception 'list index out of range' raised while validating 'fn_getatt'
```
After:
```
E1010 {'Fn::GetAtt': 'MyBucket'} is not a valid GetAtt. It must specify a resource and an attribute name
```

Custom-resource attributes with non-alphanumerics (e.g. `MyCustom.my_attr-1`) remain valid — verified against `main`.

## Testing
- Added unit cases in `test/unit/rules/functions/test_getatt.py`: dotless string (clean error) and a custom-resource attribute with underscores/hyphens (valid, guards against an over-strict pattern).
- `pytest test/unit/rules/functions/` — 279 pass.
- `ruff check`, `ruff format --check`, `isort`, `mypy` — all clean.