### PR TITLE
fix: resolved Fn::FindInMap should not share identity (W1101 false positive)

### DIFF
--- a/src/cfnlint/template/transforms/_language_extensions.py
+++ b/src/cfnlint/template/transforms/_language_extensions.py
@@ -164,7 +164,15 @@ class _Transform:
                         map_value = mapping.value(cfn, params, True, False)
                         # if we can resolve it we will return it
                         if isinstance(map_value, tuple([list]) + _SCALAR_TYPES):
-                            return map_value
+                            # Return an independent copy of the resolved value.
+                            # ``mapping.value`` hands back the object stored in
+                            # the ``Mappings`` section, so returning it directly
+                            # makes every location that resolves to the same
+                            # mapping entry share one object. That shared
+                            # identity looks like a YAML alias to W1101 (false
+                            # positive, issue #4697) and lets a later mutation of
+                            # one location bleed into the mapping definition.
+                            return deepcopy(map_value)
                     except Exception as e:  # pylint: disable=broad-exception-caught
                         # We couldn't resolve the FindInMap so we are going to
                         # leave it as it is

--- a/src/cfnlint/template/transforms/_language_extensions.py
+++ b/src/cfnlint/template/transforms/_language_extensions.py
@@ -183,12 +183,15 @@ class _Transform:
                 elif k == "Ref":
                     if isinstance(v, str):
                         if v in params:
-                            return params[v]
+                            # Copy so two Refs to the same parameter do not
+                            # share one object (see the Fn::FindInMap note
+                            # above / issue #4697).
+                            return deepcopy(params[v])
                     elif isinstance(v, dict):
                         r = self._walk(v, params, cfn)
                         if isinstance(r, str):
                             if r in params:
-                                return params[r]
+                                return deepcopy(params[r])
                         obj[k] = r
                 elif k == "Fn::If":
                     if isinstance(v, list) and len(v) == 3:

--- a/test/unit/module/template/transforms/test_language_extensions.py
+++ b/test/unit/module/template/transforms/test_language_extensions.py
@@ -1510,3 +1510,55 @@ class TestTransformFindInMapDistinctObjects(TestCase):
             metadata["A"],
             template["Mappings"]["FooMap"]["TopKey"]["SecondKey"],
         )
+
+
+class TestTransformRefDistinctObjects(TestCase):
+    """Regression test for the Fn::ForEach Ref variant of issue #4697.
+
+    Two Refs to the same loop parameter that resolves to a dict/list must not
+    share object identity in the transformed template, or W1101 reports a
+    YAML-alias false positive.
+    """
+
+    def setUp(self) -> None:
+        self.template_obj = convert_dict(
+            {
+                "Transform": ["AWS::LanguageExtensions"],
+                "Parameters": {
+                    "Names": {"Type": "CommaDelimitedList"},
+                },
+                "Resources": {
+                    "Fn::ForEach::Loop": [
+                        "Name",
+                        {"Ref": "Names"},
+                        {
+                            "Bucket${Name}": {
+                                "Type": "AWS::S3::Bucket",
+                                "Properties": {
+                                    "Tags": [
+                                        {"Key": "a", "Value": {"Ref": "Name"}},
+                                        {"Key": "b", "Value": {"Ref": "Name"}},
+                                    ]
+                                },
+                            }
+                        },
+                    ]
+                },
+            }
+        )
+        return super().setUp()
+
+    def test_transform(self):
+        cfn = Template(filename="", template=self.template_obj, regions=["us-east-1"])
+        matches, template = language_extension(cfn)
+        self.assertListEqual(matches, [])
+        buckets = [
+            r for r in template["Resources"].values() if r["Type"] == "AWS::S3::Bucket"
+        ]
+        self.assertTrue(buckets, "expected the ForEach to expand into buckets")
+        for bucket in buckets:
+            tags = bucket["Properties"]["Tags"]
+            # Both Values resolve to the same parameter ...
+            self.assertEqual(tags[0]["Value"], tags[1]["Value"])
+            # ... but must be independent objects, not a shared reference.
+            self.assertIsNot(tags[0]["Value"], tags[1]["Value"])

--- a/test/unit/module/template/transforms/test_language_extensions.py
+++ b/test/unit/module/template/transforms/test_language_extensions.py
@@ -1562,3 +1562,48 @@ class TestTransformRefDistinctObjects(TestCase):
             self.assertEqual(tags[0]["Value"], tags[1]["Value"])
             # ... but must be independent objects, not a shared reference.
             self.assertIsNot(tags[0]["Value"], tags[1]["Value"])
+
+
+class TestTransformNestedRefResolvesParameter(TestCase):
+    """Cover the dict-form Ref path where a Ref value resolves to a parameter.
+
+    ``{"Ref": {"Ref": "Ptr"}}`` walks the inner Ref to a string that is itself
+    a loop parameter name, so the outer Ref resolves to that parameter's value.
+    """
+
+    def setUp(self) -> None:
+        self.template_obj = convert_dict(
+            {
+                "Transform": ["AWS::LanguageExtensions"],
+                "Resources": {
+                    "Fn::ForEach::Outer": [
+                        "Ptr",
+                        ["Name"],
+                        {
+                            "Fn::ForEach::Inner": [
+                                "Name",
+                                ["hello"],
+                                {
+                                    "Res${Name}": {
+                                        "Type": "AWS::SNS::Topic",
+                                        "Properties": {
+                                            "TopicName": {"Ref": {"Ref": "Ptr"}}
+                                        },
+                                    }
+                                },
+                            ]
+                        },
+                    ]
+                },
+            }
+        )
+        return super().setUp()
+
+    def test_transform(self):
+        cfn = Template(filename="", template=self.template_obj, regions=["us-east-1"])
+        matches, template = language_extension(cfn)
+        self.assertListEqual(matches, [])
+        self.assertEqual(
+            template["Resources"]["Reshello"]["Properties"]["TopicName"],
+            "hello",
+        )

--- a/test/unit/module/template/transforms/test_language_extensions.py
+++ b/test/unit/module/template/transforms/test_language_extensions.py
@@ -1461,3 +1461,52 @@ class TestTransformSubWithUnderscoreVariable(TestCase):
         self.assertIn("Fn::Sub", bucket_name)
         self.assertEqual(bucket_name["Fn::Sub"][0], "${Bucket_Arn}/*")
         self.assertIn("Bucket_Arn", bucket_name["Fn::Sub"][1])
+
+
+class TestTransformFindInMapDistinctObjects(TestCase):
+    """Regression test for issue #4697 (W1101 false positive).
+
+    Two Fn::FindInMap calls that resolve to the same mapping entry must not
+    share object identity in the transformed template. Shared identity looks
+    like a YAML alias to rule W1101 and produces a false positive.
+    """
+
+    def setUp(self) -> None:
+        self.template_obj = convert_dict(
+            {
+                "Transform": ["AWS::LanguageExtensions"],
+                "Mappings": {
+                    "FooMap": {
+                        "TopKey": {
+                            "SecondKey": [0],
+                        },
+                    },
+                },
+                "Resources": {
+                    "NoOp": {
+                        "Type": "AWS::CloudFormation::WaitConditionHandle",
+                        "Metadata": {
+                            "A": {"Fn::FindInMap": ["FooMap", "TopKey", "SecondKey"]},
+                            "B": {"Fn::FindInMap": ["FooMap", "TopKey", "SecondKey"]},
+                        },
+                    },
+                },
+            }
+        )
+        return super().setUp()
+
+    def test_transform(self):
+        cfn = Template(filename="", template=self.template_obj, regions=["us-east-1"])
+        matches, template = language_extension(cfn)
+        self.assertListEqual(matches, [])
+        metadata = template["Resources"]["NoOp"]["Metadata"]
+        # Both resolve to the mapping value [0] ...
+        self.assertEqual(metadata["A"], [0])
+        self.assertEqual(metadata["B"], [0])
+        # ... but must be independent objects, not a shared reference (which
+        # would trip W1101 and let a mutation of one bleed into the other).
+        self.assertIsNot(metadata["A"], metadata["B"])
+        self.assertIsNot(
+            metadata["A"],
+            template["Mappings"]["FooMap"]["TopKey"]["SecondKey"],
+        )


### PR DESCRIPTION
Fixes #4697

### Problem

`W1101` (uses YAML alias) fired on templates that contain no YAML aliases when `AWS::LanguageExtensions` was enabled:

```yaml
Transform: AWS::LanguageExtensions
Mappings:
  FooMap:
    TopKey:
      SecondKey: [0]
Resources:
  NoOp:
    Type: AWS::CloudFormation::WaitConditionHandle
    Metadata:
      A: !FindInMap [FooMap, TopKey, SecondKey]
      B: !FindInMap [FooMap, TopKey, SecondKey]
```

### Root cause

`W1101` detects YAML aliases by object identity: any dict/list reachable from more than one place in the template is treated as an alias target. The `AWS::LanguageExtensions` transform resolved `Fn::FindInMap` by returning the value object stored in the `Mappings` section **directly**, so both `A` and `B` (and the mapping entry itself) became one shared object. That shared identity looked like an alias, and also let a later mutation of one location bleed into the mapping definition.

### Fix

Return a `deepcopy` of the resolved `Fn::FindInMap` value so each resolution is an independent object.

### Testing

- New regression test `TestTransformFindInMapDistinctObjects` asserting the two resolutions are equal in value but distinct objects, and distinct from the `Mappings` entry.
- Verified the reported template lints clean and a genuine YAML alias still warns `W1101`.
- Full `test/unit/rules/` suite (1837 tests) and the transform test suite pass.