### PR TITLE
fix: Escape hyphen in SSM dynamic reference pattern

### DIFF
--- a/src/cfnlint/rules/functions/DynamicReference.py
+++ b/src/cfnlint/rules/functions/DynamicReference.py
@@ -22,7 +22,7 @@ _ssm = {
     "prefixItems": [
         {"type": "string", "const": "resolve"},
         {"type": "string", "enum": ["ssm", "ssm-secure"]},
-        {"type": "string", "pattern": "[a-zA-Z0-9_.-/]+"},
+        {"type": "string", "pattern": "[a-zA-Z0-9_.\\-/]+"},
         {"type": "string", "pattern": "\\d+"},
     ],
     "maxItems": 4,

--- a/test/unit/rules/functions/test_dynamic_reference.py
+++ b/test/unit/rules/functions/test_dynamic_reference.py
@@ -96,6 +96,17 @@ def context(cfn):
             [],
         ),
         (
+            "Valid SSM Parameter name with only a hyphen",
+            "{{resolve:ssm:-:1}}",
+            {"type": "test"},
+            {
+                "E1051": _TestRule(),
+                "E1027": _TestRule(),
+                "W1051": _TestRule(),
+            },
+            [],
+        ),
+        (
             "Valid when item isn't a string",
             {},
             {"type": "test"},


### PR DESCRIPTION
Fixes #4692

The `_ssm` pattern `[a-zA-Z0-9_.-/]+` treated `.-/` as an ASCII range (46-47) rather than a literal hyphen, so an SSM parameter segment composed solely of hyphens would fail E1050 validation. Escaping the hyphen matches the intent and aligns with the already-correct `REGEX_DYN_REF_SSM` in `helpers.py`.

Note: because cfn-lint's `pattern` keyword uses `re.search`, the exact template in the issue lints clean today (any alphanumeric char in the path satisfies the search). This fixes the latent correctness bug and adds a regression test for the minimal failing case (`{{resolve:ssm:-:1}}`).

Added test: `test/unit/rules/functions/test_dynamic_reference.py`.