### PR TITLE
fix: Skip E3700 first-stage check for conditional stage entries

### DIFF
--- a/src/cfnlint/rules/resources/codepipeline/PipelineFirstStageHasSource.py
+++ b/src/cfnlint/rules/resources/codepipeline/PipelineFirstStageHasSource.py
@@ -52,7 +52,7 @@ class PipelineFirstStageHasSource(CfnLintKeyword):
                 # stage lands, so don't make a first-stage determination.
                 if i + 1 < len(path) and path[i + 1] == "Fn::If":
                     return None
-                return path[i] == 0
+                return bool(path[i] == 0)
             i += 1
 
         return None

--- a/src/cfnlint/rules/resources/codepipeline/PipelineFirstStageHasSource.py
+++ b/src/cfnlint/rules/resources/codepipeline/PipelineFirstStageHasSource.py
@@ -45,10 +45,14 @@ class PipelineFirstStageHasSource(CfnLintKeyword):
             if path[i] == "Fn::If":
                 i += 2
                 continue
-            if path[i] == 0:
-                return True
-            elif isinstance(path[i], int):
-                return False
+            if isinstance(path[i], int):
+                # When a stage entry is itself wrapped in an Fn::If it can
+                # resolve to AWS::NoValue, so the list index no longer reflects
+                # the realized order of the stages. We can't tell where this
+                # stage lands, so don't make a first-stage determination.
+                if i + 1 < len(path) and path[i + 1] == "Fn::If":
+                    return None
+                return path[i] == 0
             i += 1
 
         return None

--- a/test/unit/rules/resources/codepipeline/test_pipeline_first_stage_has_source.py
+++ b/test/unit/rules/resources/codepipeline/test_pipeline_first_stage_has_source.py
@@ -151,6 +151,29 @@ def _append_queues(queue1: Iterable, queue2: Iterable) -> deque:
                 )
             ],
         ),
+        (
+            # A stage entry that is itself an Fn::If can resolve to
+            # AWS::NoValue, so the list index no longer reflects the realized
+            # order. A source stage at any such index must not be flagged.
+            "Source",
+            {
+                "path": _append_queues(
+                    _standard_path,
+                    [1, "Fn::If", 1, "Actions", 0, "ActionTypeId", "Category"],
+                ),
+            },
+            [],
+        ),
+        (
+            "Source",
+            {
+                "path": _append_queues(
+                    _standard_path,
+                    [0, "Fn::If", 1, "Actions", 0, "ActionTypeId", "Category"],
+                ),
+            },
+            [],
+        ),
     ],
     indirect=["path"],
 )


### PR DESCRIPTION
Fixes #4672

### Problem
`E3700` treats a stage's index in the `Stages` list as its order. When a `Stages` entry is an `Fn::If` that can resolve to `AWS::NoValue`, index and realized order diverge: once an earlier conditional stage collapses to `NoValue`, a later conditional source stage becomes the first realized stage but still carries a non-zero list index. `_is_first_stage` returned `False` for it and the `Source` category was rejected — a false positive.

The runtime path for a conditional stage entry is `Stages / <index> / Fn::If / <branch> / Actions / ...` (the list index precedes `Fn::If`), so the old loop returned on the index before accounting for the condition.

### Fix
When a stage's list index is immediately followed by `Fn::If` in the path, the entry is conditional and its realized order can't be inferred, so `_is_first_stage` now returns `None` (no determination), per the reporter's suggestion. Plain stages and whole-list `Fn::If` wrappers (`Stages / Fn::If / branch / index`) are unchanged, preserving existing true positives.

### Testing
- Added two unit cases for conditional stage entries at index 0 and index 1.
- Existing E3700 unit tests and the codepipeline suite pass (37 passed).
- Repro template from the issue now lints clean; the existing bad fixture (plain second-stage `Source`) still flags E3700.