### PR TITLE
fix: Require ProvisionedThroughput when DynamoDB BillingMode is omitted

### DIFF
--- a/src/cfnlint/data/schemas/extensions/aws_dynamodb_table/billingmode_provisioned_dependent.json
+++ b/src/cfnlint/data/schemas/extensions/aws_dynamodb_table/billingmode_provisioned_dependent.json
@@ -1,13 +1,13 @@
 {
+ "description": "When 'BillingMode' is 'PROVISIONED' or omitted (the default) 'ProvisionedThroughput' is required",
  "if": {
   "properties": {
    "BillingMode": {
-    "const": "PROVISIONED"
+    "not": {
+     "const": "PAY_PER_REQUEST"
+    }
    }
-  },
-  "required": [
-   "BillingMode"
-  ]
+  }
  },
  "then": {
   "properties": {

--- a/test/fixtures/templates/good/resources/dynamodb/attributes_transform.yaml
+++ b/test/fixtures/templates/good/resources/dynamodb/attributes_transform.yaml
@@ -7,6 +7,7 @@ Resources:
   DDBTableTransformAttributeDefinitions:
     Type: AWS::DynamoDB::Table
     Properties:
+      BillingMode: PAY_PER_REQUEST
       AttributeDefinitions:
         Fn::Transform:
           - Name: AWS::Include
@@ -18,6 +19,7 @@ Resources:
   DDBTableTransformKeySchema:
     Type: AWS::DynamoDB::Table
     Properties:
+      BillingMode: PAY_PER_REQUEST
       AttributeDefinitions:
         - AttributeName: "pk"
           AttributeType: "S"
@@ -29,6 +31,7 @@ Resources:
   DDBTableTransformBoth:
     Type: AWS::DynamoDB::Table
     Properties:
+      BillingMode: PAY_PER_REQUEST
       AttributeDefinitions:
         Fn::Transform:
           - Name: AWS::Include

--- a/test/unit/rules/resources/dynamodb/test_table_billingmode_provisioned.py
+++ b/test/unit/rules/resources/dynamodb/test_table_billingmode_provisioned.py
@@ -56,6 +56,30 @@ def rule():
                 )
             ],
         ),
+        (
+            # BillingMode omitted defaults to PROVISIONED
+            {
+                "TableName": "foo",
+            },
+            [
+                ValidationError(
+                    "'ProvisionedThroughput' is a required property",
+                    rule=TableBillingModeProvisioned(),
+                    path=deque([]),
+                    validator="required",
+                    schema_path=deque(["then", "required"]),
+                )
+            ],
+        ),
+        (
+            {
+                "ProvisionedThroughput": {
+                    "WriteCapacityUnits": 5,
+                    "ReadCapacityUnits": 5,
+                },
+            },
+            [],
+        ),
     ],
 )
 def test_validate(instance, expected, rule, validator):


### PR DESCRIPTION
Fixes #4651

### Problem
A `AWS::DynamoDB::Table` with neither `BillingMode` nor `ProvisionedThroughput` fails to deploy with `Property ProvisionedThroughput cannot be empty`, because the default `BillingMode` is `PROVISIONED` (which requires `ProvisionedThroughput`). cfn-lint reported nothing.

E3639's `billingmode_provisioned_dependent` extension only required `ProvisionedThroughput` when `BillingMode` was **explicitly** `PROVISIONED` (`if` required `BillingMode` present + `const: PROVISIONED`), so the omitted-default case slipped through.

### Fix
Change the `if` to match when `BillingMode` is anything other than `PAY_PER_REQUEST` (`not const PAY_PER_REQUEST`). This matches both an explicit `PROVISIONED` and an omitted `BillingMode`, so `ProvisionedThroughput` is now required in both. `PAY_PER_REQUEST` is unaffected (and the separate `billingmode_exclusive` extension still enforces RCU/WCU 0 there).

### Behavior after fix
| BillingMode | ProvisionedThroughput | Result |
|---|---|---|
| omitted | missing | **E3639** (new) |
| PROVISIONED | missing | E3639 |
| omitted / PROVISIONED | present | clean |
| PAY_PER_REQUEST | missing | clean |

### Testing
- Added unit cases for omitted `BillingMode` (with and without `ProvisionedThroughput`).
- Updated `good/resources/dynamodb/attributes_transform.yaml` (three tables that had neither field — actually invalid) to `PAY_PER_REQUEST`.
- Repro template from the issue now reports E3639; full unit rule suite passes; no other fixtures newly flagged.