### PR TITLE
fix: reject Fn::Select lifecycle policies without transform

### DIFF
--- a/src/cfnlint/rules/resources/CreationPolicy.py
+++ b/src/cfnlint/rules/resources/CreationPolicy.py
@@ -7,8 +7,8 @@ from __future__ import annotations
 
 from typing import Any
 
-from cfnlint.helpers import FUNCTIONS
-from cfnlint.jsonschema import Validator
+from cfnlint.helpers import FUNCTIONS, is_function
+from cfnlint.jsonschema import ValidationError, Validator
 from cfnlint.rules.jsonschema.CfnLintJsonSchema import CfnLintJsonSchema
 
 
@@ -82,6 +82,18 @@ class CreationPolicy(CfnLintJsonSchema):
         if not isinstance(resource_name, str):
             return
         resource_type = validator.context.resources[resource_name].type
+
+        function, _ = is_function(instance)
+        if (
+            function == "Fn::Select"
+            and not validator.context.transforms.has_language_extensions_transform()
+        ):
+            yield ValidationError(
+                f"{instance!r} is not of type 'object'",
+                rule=self,
+                validator="type",
+            )
+            return
 
         validator = validator.evolve(
             context=validator.context.evolve(

--- a/src/cfnlint/rules/resources/updatepolicy/Configuration.py
+++ b/src/cfnlint/rules/resources/updatepolicy/Configuration.py
@@ -6,8 +6,8 @@ SPDX-License-Identifier: MIT-0
 from typing import Any
 
 import cfnlint.data.schemas.other.resources
-from cfnlint.helpers import FUNCTIONS
-from cfnlint.jsonschema import Validator
+from cfnlint.helpers import FUNCTIONS, is_function
+from cfnlint.jsonschema import ValidationError, Validator
 from cfnlint.rules.jsonschema.CfnLintJsonSchema import CfnLintJsonSchema, SchemaDetails
 from cfnlint.schema.resolver import RefResolver
 
@@ -32,6 +32,30 @@ class Configuration(CfnLintJsonSchema):
         )
 
     def validate(self, validator: Validator, keywords: Any, instance: Any, schema: Any):
+        update_policy = instance.get("UpdatePolicy")
+        function, _ = is_function(update_policy)
+        if (
+            function == "Fn::Select"
+            and not validator.context.transforms.has_language_extensions_transform()
+        ):
+            yield ValidationError(
+                f"{update_policy!r} is not of type 'object'",
+                path=["UpdatePolicy"],
+                rule=self,
+                instance=update_policy,
+                validator="type",
+                validator_value="object",
+                schema_path=[
+                    "allOf",
+                    0,
+                    "then",
+                    "properties",
+                    "UpdatePolicy",
+                    "type",
+                ],
+            )
+            return
+
         validator = validator.evolve(
             context=validator.context.evolve(
                 functions=list(FUNCTIONS),

--- a/test/unit/rules/resources/test_creationpolicy.py
+++ b/test/unit/rules/resources/test_creationpolicy.py
@@ -7,6 +7,7 @@ from collections import deque
 
 import pytest
 
+from cfnlint.context.context import Transforms
 from cfnlint.jsonschema import ValidationError
 from cfnlint.rules.resources.CreationPolicy import CreationPolicy
 
@@ -137,6 +138,21 @@ def template():
             [],
         ),
         (
+            "Invalid Wait Condition select policy",
+            {"Fn::Select": [0, [{"ResourceSignal": {"Count": 0, "Timeout": "PT1M"}}]]},
+            {
+                "path": deque(["Resources", "MyWaitCondition", "CreationPolicy"]),
+            },
+            [
+                ValidationError(
+                    "{'Fn::Select': [0, [{'ResourceSignal': {'Count': 0, "
+                    "'Timeout': 'PT1M'}}]]} is not of type 'object'",
+                    rule=CreationPolicy(),
+                    validator="type",
+                )
+            ],
+        ),
+        (
             "Invalid Instance",
             {"Foo": {"Bar"}},
             {
@@ -175,3 +191,35 @@ def test_deletion_policy(name, instance, expected, rule, validator):
     )
 
     assert errors == expected, f"{name}: {errors} != {expected}"
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        {
+            "path": deque(["Resources", "MyWaitCondition", "CreationPolicy"]),
+        },
+    ],
+    indirect=["path"],
+)
+def test_creation_policy_allows_select_with_language_extensions(rule, validator):
+    validator = validator.evolve(
+        context=validator.context.evolve(
+            transforms=Transforms(["AWS::LanguageExtensions"]),
+        )
+    )
+    errors = list(
+        rule.validate(
+            validator=validator,
+            dP="creationpolicy",
+            instance={
+                "Fn::Select": [
+                    0,
+                    [{"ResourceSignal": {"Count": 0, "Timeout": "PT1M"}}],
+                ]
+            },
+            schema={},
+        )
+    )
+
+    assert errors == []

--- a/test/unit/rules/resources/updatepolicy/test_configuration.py
+++ b/test/unit/rules/resources/updatepolicy/test_configuration.py
@@ -5,6 +5,7 @@ SPDX-License-Identifier: MIT-0
 
 import pytest
 
+from cfnlint.context.context import Transforms
 from cfnlint.jsonschema import ValidationError
 from cfnlint.rules.resources.updatepolicy.Configuration import Configuration
 
@@ -28,6 +29,42 @@ def rule():
                     path=["UpdatePolicy"],
                     rule=Configuration(),
                     instance=[],
+                    validator="type",
+                    validator_value="object",
+                    schema_path=[
+                        "allOf",
+                        0,
+                        "then",
+                        "properties",
+                        "UpdatePolicy",
+                        "type",
+                    ],
+                )
+            ],
+        ),
+        (
+            "Invalid with autoscaling group select policy",
+            {
+                "Type": "AWS::AutoScaling::AutoScalingGroup",
+                "UpdatePolicy": {
+                    "Fn::Select": [
+                        0,
+                        [{"AutoScalingRollingUpdate": {"MaxBatchSize": 1}}],
+                    ]
+                },
+            },
+            [
+                ValidationError(
+                    "{'Fn::Select': [0, [{'AutoScalingRollingUpdate': "
+                    "{'MaxBatchSize': 1}}]]} is not of type 'object'",
+                    path=["UpdatePolicy"],
+                    rule=Configuration(),
+                    instance={
+                        "Fn::Select": [
+                            0,
+                            [{"AutoScalingRollingUpdate": {"MaxBatchSize": 1}}],
+                        ]
+                    },
                     validator="type",
                     validator_value="object",
                     schema_path=[
@@ -185,3 +222,29 @@ def rule():
 def test_update_policy_configuration(name, instance, expected, rule, validator):
     errors = list(rule.validate(validator, {}, instance, {}))
     assert errors == expected, f"Test {name!r} got {errors!r}"
+
+
+def test_update_policy_allows_select_with_language_extensions(rule, validator):
+    validator = validator.evolve(
+        context=validator.context.evolve(
+            transforms=Transforms(["AWS::LanguageExtensions"]),
+        )
+    )
+    errors = list(
+        rule.validate(
+            validator,
+            {},
+            {
+                "Type": "AWS::AutoScaling::AutoScalingGroup",
+                "UpdatePolicy": {
+                    "Fn::Select": [
+                        0,
+                        [{"AutoScalingRollingUpdate": {"MaxBatchSize": 1}}],
+                    ]
+                },
+            },
+            {},
+        )
+    )
+
+    assert errors == []


### PR DESCRIPTION
### Description

Fixes #4645.

CloudFormation rejects a bare `Fn::Select` when it is used as the entire `CreationPolicy` or `UpdatePolicy` value unless `AWS::LanguageExtensions` resolves it before deployment. cfn-lint currently treats `Fn::Select` as object-compatible everywhere, so these lifecycle-policy shapes pass linting and then fail at deploy time.

This keeps `Fn::Select` unchanged globally, but rejects it at the lifecycle-policy attribute level when the language extension transform is not present. `Fn::If` and ordinary policy objects continue through the existing validators.

### Tests

- `PYTHONPATH=/tmp/cfn-lint-main-4645.nNFaKy/src /Users/jensenzane/Projects/cfn-lint/.venv/bin/python -m pytest test/unit/rules/resources/test_creationpolicy.py test/unit/rules/resources/updatepolicy test/unit/rules/functions/test_select.py test/unit/rules/functions/test_select_language_extension.py -q`
- `/Users/jensenzane/Projects/cfn-lint/.venv/bin/ruff check src/cfnlint/rules/resources/CreationPolicy.py src/cfnlint/rules/resources/updatepolicy/Configuration.py test/unit/rules/resources/test_creationpolicy.py test/unit/rules/resources/updatepolicy/test_configuration.py`
- `/Users/jensenzane/Projects/cfn-lint/.venv/bin/ruff format --check src/cfnlint/rules/resources/CreationPolicy.py src/cfnlint/rules/resources/updatepolicy/Configuration.py test/unit/rules/resources/test_creationpolicy.py test/unit/rules/resources/updatepolicy/test_configuration.py`

A CLI smoke template emitted the new `E3055`; the local schema cache also emitted unrelated `E3006` because enhanced schema refresh failed with local SSL certificate verification.
