### PR TITLE
fix: resolve every index Fn::Select can take

### DIFF
--- a/src/cfnlint/jsonschema/_resolvers_cfn.py
+++ b/src/cfnlint/jsonschema/_resolvers_cfn.py
@@ -356,19 +356,17 @@ def select(validator: Validator, instance: Any) -> ResolutionResult:
     if not len(instance) == 2:
         return
 
-    # get the values from the list
-    indexes = validator.resolve_value(instance[0])
-    objs = validator.resolve_value(instance[1])
-
-    for i, _, _ in indexes:
-        for obj, obj_v, _ in objs:
-            try:
-                i = int(i)
-            except ValueError:
-                continue
-            if not validator.is_type(obj, "array"):
-                continue
-            if i < 0:
+    # resolve the list with the index's validator so the values the index
+    # resolved from (a Ref to a parameter, for instance) are carried along
+    for i, index_v, _ in validator.resolve_value(instance[0]):
+        try:
+            i = int(i)
+        except (ValueError, TypeError):
+            continue
+        if i < 0:
+            continue
+        for obj, obj_v, _ in index_v.resolve_value(instance[1]):
+            if not obj_v.is_type(obj, "array"):
                 continue
             if len(obj) <= i:
                 continue

--- a/test/unit/module/jsonschema/test_resolvers_cfn.py
+++ b/test/unit/module/jsonschema/test_resolvers_cfn.py
@@ -767,6 +767,119 @@ def test_invalid_functions(name, instance, response):
             {"Fn::Join": ["-", [{"Ref": "Environment"}, {"Ref": "DNE"}]]},
             [],
         ),
+        (
+            "Fn::Select resolves every index a Ref can take",
+            {"Fn::Select": [{"Ref": "Index"}, ["a", "b"]]},
+            [
+                (
+                    "a",
+                    Context(
+                        ref_values={"Index": "0"},
+                        path=Path(
+                            value_path=deque(
+                                ["Parameters", "Index", "AllowedValues", 0]
+                            )
+                        ),
+                    ),
+                    None,
+                ),
+                (
+                    "b",
+                    Context(
+                        ref_values={"Index": "1"},
+                        path=Path(
+                            value_path=deque(
+                                ["Parameters", "Index", "AllowedValues", 1]
+                            )
+                        ),
+                    ),
+                    None,
+                ),
+            ],
+        ),
+        (
+            "Fn::Select uses previous values when doing resolution",
+            {
+                "Fn::Select": [
+                    {"Ref": "Index"},
+                    [{"Ref": "Environment"}, {"Ref": "Environment"}],
+                ]
+            },
+            [
+                (
+                    "dev",
+                    Context(
+                        ref_values={"Index": "0", "Environment": "dev"},
+                        path=Path(
+                            value_path=deque(
+                                ["Parameters", "Environment", "AllowedValues", 0]
+                            )
+                        ),
+                    ),
+                    None,
+                ),
+                (
+                    "test",
+                    Context(
+                        ref_values={"Index": "0", "Environment": "test"},
+                        path=Path(
+                            value_path=deque(
+                                ["Parameters", "Environment", "AllowedValues", 1]
+                            )
+                        ),
+                    ),
+                    None,
+                ),
+                (
+                    "prod",
+                    Context(
+                        ref_values={"Index": "0", "Environment": "prod"},
+                        path=Path(
+                            value_path=deque(
+                                ["Parameters", "Environment", "AllowedValues", 2]
+                            )
+                        ),
+                    ),
+                    None,
+                ),
+                (
+                    "dev",
+                    Context(
+                        ref_values={"Index": "1", "Environment": "dev"},
+                        path=Path(
+                            value_path=deque(
+                                ["Parameters", "Environment", "AllowedValues", 0]
+                            )
+                        ),
+                    ),
+                    None,
+                ),
+                (
+                    "test",
+                    Context(
+                        ref_values={"Index": "1", "Environment": "test"},
+                        path=Path(
+                            value_path=deque(
+                                ["Parameters", "Environment", "AllowedValues", 1]
+                            )
+                        ),
+                    ),
+                    None,
+                ),
+                (
+                    "prod",
+                    Context(
+                        ref_values={"Index": "1", "Environment": "prod"},
+                        path=Path(
+                            value_path=deque(
+                                ["Parameters", "Environment", "AllowedValues", 2]
+                            )
+                        ),
+                    ),
+                    None,
+                ),
+            ],
+        ),
     ],
 )
 def test_valid_functions(name, instance, response):
@@ -781,6 +894,12 @@ def test_valid_functions(name, instance, response):
                 {
                     "Type": "String",
                     "AllowedValues": ["dev", "test", "prod"],
+                }
+            ),
+            "Index": Parameter(
+                {
+                    "Type": "String",
+                    "AllowedValues": ["0", "1"],
                 }
             ),
         },


### PR DESCRIPTION
The Fn::Select resolver only ever checked the first index, so whether a bad
value is reported depends on where it sits in the list.

This template lints clean today:

```yaml
Parameters:
  Idx:
    Type: String
    AllowedValues: ["0", "1"]
Resources:
  T:
    Type: AWS::DynamoDB::Table
    Properties:
      KeySchema:
        - AttributeName: id
          KeyType: HASH
      AttributeDefinitions:
        - AttributeName: id
          AttributeType: S
      BillingMode: !Select [!Ref Idx, ["PAY_PER_REQUEST", "NOT_A_MODE"]]
```

Swap the two list entries and W1035 fires. Same template, same reachable
values, different answer.

Two things caused it, both in `select` in `_resolvers_cfn.py`:

The index and the list were resolved from the same validator up front and then
walked as nested loops. `resolve_value` is a generator, so the list was
exhausted on the first index and every later index resolved to nothing.

The index's validator was also discarded. The value that gets yielded therefore
carried the context of the hardcoded list rather than of the Ref, so
`is_resolved_from_parameters` was false and `BaseFn.resolve` returned at the
first clean value instead of checking the rest.

Fn::Join already threads its delimiter validator into the resolution of its
values, so this does the same for Fn::Select. The index checks move out of the
inner loop since they do not depend on the list. `int()` also catches TypeError
now, which the resolver can raise on a non-scalar index if it is called
directly; through the CLI E1017 rejects that first, so this is defensive only.

Tested: full unit and integration suites pass (2864 passed) on Python 3.12.
Both new resolver cases fail on main, yielding 3 resolutions instead of 6.
The integration snapshots and the good-templates check are unchanged, and lint
output across all 11 fixture templates that use Fn::Select is byte identical
before and after, so nothing new is reported on templates that were clean.
